### PR TITLE
Dependencies: fix xcode-select argument

### DIFF
--- a/bitrise/dependencies.go
+++ b/bitrise/dependencies.go
@@ -84,7 +84,7 @@ func CheckIsXcodeCLTInstalled() error {
 		log.Warn("Once the installation is finished you should call the bitrise setup again.")
 		return err
 	}
-	xcodeSelectPth, err := cmdex.RunCommandAndReturnStdout("xcode-select", "-p")
+	xcodeSelectPth, err := cmdex.RunCommandAndReturnStdout("xcode-select", "-print-path")
 	if err != nil {
 		log.Infoln("")
 		return errors.New("Failed to get Xcode path")


### PR DESCRIPTION
The `-p` shorthand argument to xcode-select was added in OS X 10.9; the long-form argument, `-print-path`, works in older versions of OS X.

See the discussion in Homebrew/homebrew#42862; bitrise fails on launch on 10.8 and older without this, as it thinks that Xcode/CLT aren't installed.