### PR TITLE
step template revision

### DIFF
--- a/_step_template/bitrise.yml
+++ b/_step_template/bitrise.yml
@@ -1,24 +1,20 @@
-format_version: 1.0.0
+format_version: 1.1.0
 default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
 
 workflows:
   test:
     steps:
-    - script:
-        title: Switch working dir to test/_tmp dir
+    - change-workdir:
+        title: Switch working dir to test / _tmp dir
         description: |-
           To prevent step testing issues, like referencing relative
-          files with just './some-file', which would work for local tests
-          but not if the step is included in another bitrise.yml!
+          files with just './some-file' in the step's code, which would
+          work for testing the step from this directory directly
+          but would break if the step is included in another `bitrise.yml`.
+        run_if: true
         inputs:
-        - content: |-
-            #!/bin/bash
-            set -e
-            test_workdir_pth="$(pwd)/_tmp"
-            echo " * test_workdir_pth: ${test_workdir_pth}"
-            set -v
-            mkdir -p "${test_workdir_pth}"
-            envman add --key BITRISE_SOURCE_DIR --value "${test_workdir_pth}"
+        - path: ./_tmp
+        - is_create_path: true
     - path::./:
         title: Step Test
         description: |-
@@ -28,3 +24,48 @@ workflows:
           file if you would not specify another value.
         inputs:
         - example_step_input: Example Step Input's value
+
+
+  # ----------------------------------------------------------------
+  # --- workflows to Share this step into a Step Library
+  share-this-step:
+    envs:
+      # if you want to share this step into a StepLib
+      - MY_STEPLIB_REPO_FORK_GIT_URL:
+      - STEP_ID_IN_STEPLIB:
+      - STEP_GIT_VERION_TAG_TO_SHARE:
+      - STEP_GIT_CLONE_URL:
+    description: |-
+      If this is the first time you try to share a Step you should
+      first call: $ bitrise share
+
+      This will print you a guide, and information about how Step sharing
+      works. Please read it at least once!
+
+      As noted in the Step sharing guide you'll have to fork the
+      StepLib you want to share this step into. Once you're done with forking
+      the repository you should set your own fork's git clone URL
+      in the `.bitrise.secrets.yml` file, or here in the `envs` section,
+      as the value of the `MY_STEPLIB_REPO_FORK_GIT_URL` environment.
+
+      You're now ready to share this Step, just make sure that
+      the `STEP_ID_IN_STEPLIB` and `STEP_GIT_VERION_TAG_TO_SHARE`
+      environments are set to the desired values!
+
+      To share this Step into a StepLib you can just run: $ bitrise run share-this-step
+
+      Once it finishes the only thing left is to actually create a Pull Request,
+      the way described in the guide printed at the end of the process.
+    steps:
+    - script:
+        inputs:
+        - content: |-
+            #!/bin/bash
+            set -e
+            set -x
+
+            bitrise share start -c ${MY_STEPLIB_REPO_FORK_GIT_URL}
+
+            bitrise share create --stepid ${STEP_ID_IN_STEPLIB} --tag ${STEP_GIT_VERION_TAG_TO_SHARE} --git ${STEP_GIT_CLONE_URL}
+
+            bitrise share finish


### PR DESCRIPTION
generic format update, using `change-workdir` instead of a custom script, and added a `share-this-step` workflow for quick & easy step sharing