### PR TITLE
configs.InitPaths should be unnecessary here

### DIFF
--- a/cli/run_util.go
+++ b/cli/run_util.go
@@ -797,10 +797,6 @@ func runWorkflowWithConfiguration(
 	bitriseConfig models.BitriseDataModel,
 	secretEnvironments []envmanModels.EnvironmentItemModel) (models.BuildRunResultsModel, error) {
 
-	if err := configs.InitPaths(); err != nil {
-		return models.BuildRunResultsModel{}, fmt.Errorf("Failed to initialize required paths: %s", err)
-	}
-
 	workflowToRun, exist := bitriseConfig.Workflows[workflowToRunID]
 	if !exist {
 		return models.BuildRunResultsModel{}, fmt.Errorf("Specified Workflow (%s) does not exist!", workflowToRunID)


### PR DESCRIPTION
it's already performed in cli/cli before (https://github.com/bitrise-io/bitrise/blob/master/cli/cli.go#L76)

but the tests do fail - I wonder if this is actually required.. and if yes, why.