### PR TITLE
bitrise run now prints the workflow it was started with

### DIFF
--- a/bitrise/print.go
+++ b/bitrise/print.go
@@ -532,7 +532,7 @@ func PrintRunningStepFooter(stepRunResult models.StepRunResultsModel, isLastStep
 // PrintRunningWorkflow ...
 func PrintRunningWorkflow(title string) {
 	fmt.Println()
-	log.Info(colorstring.Bluef("Running workflow (%s)", title))
+	log.Infoln(colorstring.Blue("Switching to workflow:"), title)
 	fmt.Println()
 }
 

--- a/cli/run.go
+++ b/cli/run.go
@@ -202,6 +202,8 @@ func run(c *cli.Context) error {
 		log.Fatalf("Failed to register  CI mode, error: %s", err)
 	}
 
+	log.Infoln(colorstring.Green("Running workflow:"), runParams.WorkflowToRunID)
+
 	runAndExit(bitriseConfig, inventoryEnvironments, runParams.WorkflowToRunID)
 	//
 


### PR DESCRIPTION
and the previous "running workflow", which was printed for every "before" and "after" workflow, was changed to "switching to workflow"