### PR TITLE
Added version naming convention advice to step development guideline

### DIFF
--- a/_docs/step-development-guideline.md
+++ b/_docs/step-development-guideline.md
@@ -70,3 +70,7 @@ Use all-upper-case [snake case](https://en.wikipedia.org/wiki/Snake_case) style 
 ### List of values in outputs
 
 You should postfix the output ID with `_LIST` (e.g. `OUTPUT_PATH_LIST`), and provide the values as a pipe separated list (e.g. `first value|second value`). This is not a hard requirement, but a strong suggestion. This means that you should prefer this solution unless you really need to use another character for separating values. Based on our experience the pipe character (`|`) works really well as a universal separator character, as it's quite rare in output values (compared to `,`, `;`, `=` or other more common separator characters).
+
+## Version naming convention
+
+You should use [semantic versioning](http://semver.org/) (MAJOR.MINOR.PATCH) for your step. For example: `1.2.3`.


### PR DESCRIPTION
To avoid potential issues like https://github.com/bitrise-io/bitrise-steplib/pull/965#issuecomment-297743757 or https://github.com/bitrise-io/bitrise-steplib/pull/356