### PR TITLE
set Stdin for bitrise tools commands

### DIFF
--- a/cli/tools.go
+++ b/cli/tools.go
@@ -1,6 +1,8 @@
 package cli
 
 import (
+	"os"
+
 	log "github.com/Sirupsen/logrus"
 	"github.com/bitrise-io/go-utils/command"
 	"github.com/urfave/cli"
@@ -32,6 +34,6 @@ var envmanCommand = cli.Command{
 
 func runCommandWith(toolName string, c *cli.Context) error {
 	args := c.Args()
-	cmd := command.NewWithStandardOuts(toolName, args...)
+	cmd := command.NewWithStandardOuts(toolName, args...).SetStdin(os.Stdin)
 	return cmd.Run()
 }


### PR DESCRIPTION
without this bitrise tools ( envman, stepman ) when invoked through the CLI - e.g. `bitrise envman run ...` - will
not get an interactive input. Meaning: if you run e.g. Bash through envman, bash will exit if there are no parameters specified
and stdin is not interactive.

Example: `bitrise envman run bash`

If stdin is passed through / passed to the tool command (envman run in this case) then
youll get into an interactive bash shell this way, the same if youd run `envman run bash`.

But if you dont pass through Stdin to envman then bash will simply exit right away,
as theres no parameter for it (nothing to do) and no stdin either so it cant
ask for parameters.

This PR fixes this issue and makes `bitrise envman` and `bitrise stepman`
to behave the same as `envman ...` and `stepman ...` direct command calls.