### PR TITLE
Go version bump: 1.9.1 -> 19.2

### DIFF
--- a/toolkits/golang.go
+++ b/toolkits/golang.go
@@ -25,7 +25,7 @@ import (
 )
 
 const (
-	minGoVersionForToolkit = "1.9.1"
+	minGoVersionForToolkit = "1.9.2"
 )
 
 // === Base Toolkit struct ===


### PR DESCRIPTION
FIX commit when merging: it's 1.9.2 not 19.2 ;)