### PR TITLE
Update syntax of secrets example

### DIFF
--- a/_examples/tutorials/inputs-outputs-envs/.bitrise.secrets.yml
+++ b/_examples/tutorials/inputs-outputs-envs/.bitrise.secrets.yml
@@ -1,3 +1,4 @@
 envs:
 - BITRISE_SECRET_TEST1: Bitrise secret test value 1
-  is_expand: no
+  opts:
+    is_expand: no


### PR DESCRIPTION
The example, as is, results in an error when used

`Failed to create inventory, error: Invalid inventory format: more than 2 keys specified: [BITRISE_SECRET_TEST1 is_expand opts]`