### PR TITLE
Update step-development-guideline.md

### DIFF
--- a/_docs/step-development-guideline.md
+++ b/_docs/step-development-guideline.md
@@ -155,7 +155,6 @@ Available `project_type_tags`:
 - cordova
 - ionic
 - flutter
-- fastlane
 - web
 
 _If step is available for all project types, do not specify project_type_tags, otherwise specify every project types, with which the step can work._


### PR DESCRIPTION
Remove `fastlane` project type as previous fastlane projects are either ios or android projects, we have only one step for this project type. In general, Fastlane is treated as an automation tool since the [1.8.0](https://github.com/bitrise-core/bitrise-init/releases/tag/1.8.0) version of the scanner.