### PR TITLE
Update minimum required Go version for Golang toolkit

### DIFF
--- a/toolkits/golang.go
+++ b/toolkits/golang.go
@@ -25,7 +25,7 @@ import (
 )
 
 const (
-	minGoVersionForToolkit = "1.10.2"
+	minGoVersionForToolkit = "1.11"
 )
 
 // === Base Toolkit struct ===


### PR DESCRIPTION
Updated based on the requirement of errcheck: https://github.com/kisielk/errcheck/blob/e14f8d59a22d460d56c5ee92507cd94c78fbf274/README.md#cgo

Build slug that proves it is working with go 1.11: 0f3178099c8258dd
Build slug that proves it is not working with go version less than 1.11: 068a46286691918c