### PR TITLE
Tool 1347 log new step version info

### DIFF
--- a/bitrise/print.go
+++ b/bitrise/print.go
@@ -363,14 +363,12 @@ func getDeprecateNotesRows(notes string) string {
 
 // evaluatedVersion introduced for testing purposes, until StepInfoModel is updated to have the same property
 func buildUpdateRow(stepInfo stepmanModels.StepInfoModel, width int, evaluatedVersion string) string {
-	updateRow := ""
-
 	vstr := fmt.Sprintf("%s -> %s", stepInfo.Version, stepInfo.LatestVersion)
 	if stepInfo.Version != evaluatedVersion {
 		vstr = fmt.Sprintf("%s (%s) -> %s", stepInfo.Version, evaluatedVersion, stepInfo.LatestVersion)
 	}
 
-	updateRow = fmt.Sprintf("| Update available: %s |", vstr)
+	updateRow := fmt.Sprintf("| Update available: %s |", vstr)
 	charDiff := len(updateRow) - width
 
 	if charDiff == 0 {
@@ -386,7 +384,6 @@ func buildUpdateRow(stepInfo stepmanModels.StepInfoModel, width int, evaluatedVe
 		if charDiff > 6 {
 			updateRow = fmt.Sprintf("| Update available!%s |", strings.Repeat(" ", -len("| Update available! |")-width))
 		}
-
 	}
 
 	return updateRow

--- a/bitrise/print.go
+++ b/bitrise/print.go
@@ -2,7 +2,6 @@ package bitrise
 
 import (
 	"fmt"
-	"regexp"
 	"strings"
 	"time"
 	"unicode/utf8"
@@ -12,9 +11,7 @@ import (
 	"github.com/bitrise-io/go-utils/colorstring"
 	log "github.com/bitrise-io/go-utils/log"
 	"github.com/bitrise-io/go-utils/stringutil"
-	"github.com/bitrise-io/go-utils/versions"
 	stepmanModels "github.com/bitrise-io/stepman/models"
-	ver "github.com/hashicorp/go-version"
 )
 
 const (
@@ -25,35 +22,6 @@ const (
 //------------------------------
 // Util methods
 //------------------------------
-
-func isUpdateAvailable(stepInfo stepmanModels.StepInfoModel) bool {
-	if stepInfo.LatestVersion == "" {
-		return false
-	}
-
-	if stepInfo.Version != stepInfo.EvaluatedVersion {
-		re := regexp.MustCompile(`\d+`)
-		components := re.FindAllString(stepInfo.Version, -1)
-		normalized := strings.Join(components, ".")
-		locked, _ := ver.NewSemver(normalized)
-		latest, _ := ver.NewSemver(stepInfo.LatestVersion)
-
-		switch len(components) {
-		case 1:
-			return locked.Segments()[0] < latest.Segments()[0]
-		case 2:
-			return locked.Segments()[0] < latest.Segments()[0] || locked.Segments()[1] < latest.Segments()[1]
-
-		}
-	}
-
-	res, err := versions.CompareVersions(stepInfo.Version, stepInfo.LatestVersion)
-	if err != nil {
-		log.Errorf("Failed to compare versions, err: %s", err)
-	}
-
-	return (res == 1)
-}
 
 func getTrimmedStepName(stepRunResult models.StepRunResultsModel) string {
 	iconBoxWidth := len("   ")

--- a/bitrise/print.go
+++ b/bitrise/print.go
@@ -352,11 +352,10 @@ func getRow(str string) string {
 	return fmt.Sprintf("| %s |", str+strings.Repeat(" ", stepRunSummaryBoxWidthInChars-len(str)-4))
 }
 
-// evaluatedVersion introduced for testing purposes, until StepInfoModel is updated to have the same property
-func buildUpdateRow(stepInfo stepmanModels.StepInfoModel, width int, evaluatedVersion string) string {
+func buildUpdateRow(stepInfo stepmanModels.StepInfoModel, width int) string {
 	vstr := fmt.Sprintf("%s -> %s", stepInfo.Version, stepInfo.LatestVersion)
-	if stepInfo.Version != evaluatedVersion {
-		vstr = fmt.Sprintf("%s (%s) -> %s", stepInfo.Version, evaluatedVersion, stepInfo.LatestVersion)
+	if stepInfo.Version != stepInfo.EvaluatedVersion {
+		vstr = fmt.Sprintf("%s (%s) -> %s", stepInfo.Version, stepInfo.EvaluatedVersion, stepInfo.LatestVersion)
 	}
 
 	updateRow := fmt.Sprintf("| Update available: %s |", vstr)
@@ -404,7 +403,7 @@ func getRunningStepFooterSubSection(stepRunResult models.StepRunResultsModel) st
 	isUpdateAvailable := isUpdateAvailable(stepRunResult.StepInfo)
 	updateRow := ""
 	if isUpdateAvailable {
-		updateRow = buildUpdateRow(stepInfo, stepRunSummaryBoxWidthInChars, stepInfo.EvaluatedVersion)
+		updateRow = buildUpdateRow(stepInfo, stepRunSummaryBoxWidthInChars)
 	}
 
 	issueRow := ""

--- a/bitrise/print.go
+++ b/bitrise/print.go
@@ -361,6 +361,26 @@ func getDeprecateNotesRows(notes string) string {
 	return formattedNote
 }
 
+func buildUpdateRow(stepInfo stepmanModels.StepInfoModel, width int) string {
+	updateRow := ""
+
+	updateRow = fmt.Sprintf("| Update available: %s -> %s |", stepInfo.Version, stepInfo.LatestVersion)
+	charDiff := len(updateRow) - width
+	if charDiff < 0 {
+		// shorter than desired - fill with space
+		updateRow = fmt.Sprintf("| Update available: %s -> %s%s |", stepInfo.Version, stepInfo.LatestVersion, strings.Repeat(" ", -charDiff))
+	} else if charDiff > 0 {
+		// longer than desired - trim title
+		if charDiff > 6 {
+			updateRow = fmt.Sprintf("| Update available!%s |", strings.Repeat(" ", -len("| Update available! |")-width))
+		} else {
+			updateRow = fmt.Sprintf("| Update available: -> %s%s |", stepInfo.LatestVersion, strings.Repeat(" ", -len("| Update available: -> %s |")-width))
+		}
+	}
+
+	return updateRow
+}
+
 func getRunningStepFooterSubSection(stepRunResult models.StepRunResultsModel) string {
 	stepInfo := stepRunResult.StepInfo
 
@@ -385,19 +405,7 @@ func getRunningStepFooterSubSection(stepRunResult models.StepRunResultsModel) st
 	isUpdateAvailable := isUpdateAvailable(stepRunResult.StepInfo)
 	updateRow := ""
 	if isUpdateAvailable {
-		updateRow = fmt.Sprintf("| Update available: %s -> %s |", stepInfo.Version, stepInfo.LatestVersion)
-		charDiff := len(updateRow) - stepRunSummaryBoxWidthInChars
-		if charDiff < 0 {
-			// shorter than desired - fill with space
-			updateRow = fmt.Sprintf("| Update available: %s -> %s%s |", stepInfo.Version, stepInfo.LatestVersion, strings.Repeat(" ", -charDiff))
-		} else if charDiff > 0 {
-			// longer than desired - trim title
-			if charDiff > 6 {
-				updateRow = fmt.Sprintf("| Update available!%s |", strings.Repeat(" ", -len("| Update available! |")-stepRunSummaryBoxWidthInChars))
-			} else {
-				updateRow = fmt.Sprintf("| Update available: -> %s%s |", stepInfo.LatestVersion, strings.Repeat(" ", -len("| Update available: -> %s |")-stepRunSummaryBoxWidthInChars))
-			}
-		}
+		updateRow = buildUpdateRow(stepInfo, stepRunSummaryBoxWidthInChars)
 	}
 
 	issueRow := ""

--- a/bitrise/print.go
+++ b/bitrise/print.go
@@ -352,7 +352,7 @@ func getRow(str string) string {
 	return fmt.Sprintf("| %s |", str+strings.Repeat(" ", stepRunSummaryBoxWidthInChars-len(str)-4))
 }
 
-func buildUpdateRow(stepInfo stepmanModels.StepInfoModel, width int) string {
+func getUpdateRow(stepInfo stepmanModels.StepInfoModel, width int) string {
 	vstr := fmt.Sprintf("%s -> %s", stepInfo.Version, stepInfo.LatestVersion)
 	if stepInfo.Version != stepInfo.EvaluatedVersion {
 		vstr = fmt.Sprintf("%s (%s) -> %s", stepInfo.Version, stepInfo.EvaluatedVersion, stepInfo.LatestVersion)
@@ -403,7 +403,7 @@ func getRunningStepFooterSubSection(stepRunResult models.StepRunResultsModel) st
 	isUpdateAvailable := isUpdateAvailable(stepRunResult.StepInfo)
 	updateRow := ""
 	if isUpdateAvailable {
-		updateRow = buildUpdateRow(stepInfo, stepRunSummaryBoxWidthInChars)
+		updateRow = getUpdateRow(stepInfo, stepRunSummaryBoxWidthInChars)
 	}
 
 	issueRow := ""

--- a/bitrise/print.go
+++ b/bitrise/print.go
@@ -26,16 +26,12 @@ const (
 // Util methods
 //------------------------------
 
-// evaluatedVersion ...string introduced for testing purposes until StepInfoModel is updated
-func isUpdateAvailable(stepInfo stepmanModels.StepInfoModel, evaluatedVersion ...string) bool {
+func isUpdateAvailable(stepInfo stepmanModels.StepInfoModel) bool {
 	if stepInfo.LatestVersion == "" {
 		return false
 	}
 
-	if len(evaluatedVersion) == 0 { // conditional introduced for test purposes to avoid update isUpdateAvailable everywhere
-		evaluatedVersion = append(evaluatedVersion, stepInfo.Version)
-	}
-	if stepInfo.Version != evaluatedVersion[0] { // evaluatedVersion is a slice only to be able to use optional arg pattern in the signature
+	if stepInfo.Version != stepInfo.EvaluatedVersion {
 		re := regexp.MustCompile(`\d+`)
 		components := re.FindAllString(stepInfo.Version, -1)
 		normalized := strings.Join(components, ".")
@@ -437,10 +433,10 @@ func getRunningStepFooterSubSection(stepRunResult models.StepRunResultsModel) st
 		}
 	}
 
-	isUpdateAvailable := isUpdateAvailable(stepRunResult.StepInfo, "1.0.1") // 1.0.1 introduced for test purposes until StepInfoModel is updated
+	isUpdateAvailable := isUpdateAvailable(stepRunResult.StepInfo)
 	updateRow := ""
 	if isUpdateAvailable {
-		updateRow = buildUpdateRow(stepInfo, stepRunSummaryBoxWidthInChars, "1.0.1")
+		updateRow = buildUpdateRow(stepInfo, stepRunSummaryBoxWidthInChars, stepInfo.EvaluatedVersion)
 	}
 
 	issueRow := ""

--- a/bitrise/print.go
+++ b/bitrise/print.go
@@ -361,14 +361,19 @@ func getDeprecateNotesRows(notes string) string {
 	return formattedNote
 }
 
-func buildUpdateRow(stepInfo stepmanModels.StepInfoModel, width int) string {
+// evaluatedVersion introduced for testing purposes, until StepInfoModel is updated to have the same property
+func buildUpdateRow(stepInfo stepmanModels.StepInfoModel, width int, evaluatedVersion string) string {
 	updateRow := ""
 
 	updateRow = fmt.Sprintf("| Update available: %s -> %s |", stepInfo.Version, stepInfo.LatestVersion)
 	charDiff := len(updateRow) - width
 	if charDiff < 0 {
 		// shorter than desired - fill with space
-		updateRow = fmt.Sprintf("| Update available: %s -> %s%s |", stepInfo.Version, stepInfo.LatestVersion, strings.Repeat(" ", -charDiff))
+		if stepInfo.Version != evaluatedVersion {
+			updateRow = fmt.Sprintf("| Update available: %s (%s) -> %s%s |", stepInfo.Version, evaluatedVersion, stepInfo.LatestVersion, strings.Repeat(" ", -charDiff))
+		} else {
+			updateRow = fmt.Sprintf("| Update available: %s -> %s%s |", stepInfo.Version, stepInfo.LatestVersion, strings.Repeat(" ", -charDiff))
+		}
 	} else if charDiff > 0 {
 		// longer than desired - trim title
 		if charDiff > 6 {
@@ -405,7 +410,7 @@ func getRunningStepFooterSubSection(stepRunResult models.StepRunResultsModel) st
 	isUpdateAvailable := isUpdateAvailable(stepRunResult.StepInfo)
 	updateRow := ""
 	if isUpdateAvailable {
-		updateRow = buildUpdateRow(stepInfo, stepRunSummaryBoxWidthInChars)
+		updateRow = buildUpdateRow(stepInfo, stepRunSummaryBoxWidthInChars, stepInfo.Version)
 	}
 
 	issueRow := ""

--- a/bitrise/print.go
+++ b/bitrise/print.go
@@ -361,6 +361,11 @@ func getDeprecateNotesRows(notes string) string {
 	return formattedNote
 }
 
+func getRow(str string) string {
+	str = stringutil.MaxLastCharsWithDots(str, stepRunSummaryBoxWidthInChars-4)
+	return fmt.Sprintf("| %s |", str+strings.Repeat(" ", stepRunSummaryBoxWidthInChars-len(str)-4))
+}
+
 // evaluatedVersion introduced for testing purposes, until StepInfoModel is updated to have the same property
 func buildUpdateRow(stepInfo stepmanModels.StepInfoModel, width int, evaluatedVersion string) string {
 	vstr := fmt.Sprintf("%s -> %s", stepInfo.Version, stepInfo.LatestVersion)
@@ -492,6 +497,10 @@ func getRunningStepFooterSubSection(stepRunResult models.StepRunResultsModel) st
 	content := ""
 	if isUpdateAvailable {
 		content = fmt.Sprintf("%s", updateRow)
+		if stepInfo.Step.SourceCodeURL != nil && *stepInfo.Step.SourceCodeURL != "" {
+			releasesURL := *stepInfo.Step.SourceCodeURL + "/releases"
+			content = fmt.Sprintf("%s\n%s\n%s", content, getRow("Release notes are available on GitHub"), getRow(releasesURL))
+		}
 	}
 
 	// Support URL

--- a/bitrise/print.go
+++ b/bitrise/print.go
@@ -498,8 +498,10 @@ func getRunningStepFooterSubSection(stepRunResult models.StepRunResultsModel) st
 	if isUpdateAvailable {
 		content = fmt.Sprintf("%s", updateRow)
 		if stepInfo.Step.SourceCodeURL != nil && *stepInfo.Step.SourceCodeURL != "" {
+			content = fmt.Sprintf("%s\n%s", content, getRow(""))
 			releasesURL := *stepInfo.Step.SourceCodeURL + "/releases"
-			content = fmt.Sprintf("%s\n%s\n%s", content, getRow("Release notes are available on GitHub"), getRow(releasesURL))
+			content = fmt.Sprintf("%s\n%s", content, getRow("Release notes are available on GitHub"))
+			content = fmt.Sprintf("%s\n%s", content, getRow(releasesURL))
 		}
 	}
 

--- a/bitrise/print.go
+++ b/bitrise/print.go
@@ -365,7 +365,12 @@ func getDeprecateNotesRows(notes string) string {
 func buildUpdateRow(stepInfo stepmanModels.StepInfoModel, width int, evaluatedVersion string) string {
 	updateRow := ""
 
-	updateRow = fmt.Sprintf("| Update available: %s -> %s |", stepInfo.Version, stepInfo.LatestVersion)
+	vstr := fmt.Sprintf("%s -> %s", stepInfo.Version, stepInfo.LatestVersion)
+	if stepInfo.Version != evaluatedVersion {
+		vstr = fmt.Sprintf("%s (%s) -> %s", stepInfo.Version, evaluatedVersion, stepInfo.LatestVersion)
+	}
+
+	updateRow = fmt.Sprintf("| Update available: %s |", vstr)
 	charDiff := len(updateRow) - width
 
 	if charDiff == 0 {
@@ -373,10 +378,7 @@ func buildUpdateRow(stepInfo stepmanModels.StepInfoModel, width int, evaluatedVe
 	}
 
 	// shorter than desired - fill with space
-	updateRow = fmt.Sprintf("| Update available: %s -> %s%s |", stepInfo.Version, stepInfo.LatestVersion, strings.Repeat(" ", -charDiff))
-	if stepInfo.Version != evaluatedVersion {
-		updateRow = fmt.Sprintf("| Update available: %s (%s) -> %s%s |", stepInfo.Version, evaluatedVersion, stepInfo.LatestVersion, strings.Repeat(" ", -charDiff))
-	}
+	updateRow = fmt.Sprintf("| Update available: %s%s |", vstr, strings.Repeat(" ", -charDiff))
 
 	if charDiff > 0 {
 		// longer than desired - trim title
@@ -414,7 +416,7 @@ func getRunningStepFooterSubSection(stepRunResult models.StepRunResultsModel) st
 	isUpdateAvailable := isUpdateAvailable(stepRunResult.StepInfo)
 	updateRow := ""
 	if isUpdateAvailable {
-		updateRow = buildUpdateRow(stepInfo, stepRunSummaryBoxWidthInChars, stepInfo.Version)
+		updateRow = buildUpdateRow(stepInfo, stepRunSummaryBoxWidthInChars, "1.0.1")
 	}
 
 	issueRow := ""

--- a/bitrise/print.go
+++ b/bitrise/print.go
@@ -514,12 +514,12 @@ func getRunningStepFooterSubSection(stepRunResult models.StepRunResultsModel) st
 	// Update available
 	content := ""
 	if isUpdateAvailable {
-		content = fmt.Sprintf("%s", updateRow)
+		content = updateRow
 		if stepInfo.Step.SourceCodeURL != nil && *stepInfo.Step.SourceCodeURL != "" {
-			content = fmt.Sprintf("%s\n%s", content, getRow(""))
+			content += "\n" + getRow("")
 			releasesURL := *stepInfo.Step.SourceCodeURL + "/releases"
-			content = fmt.Sprintf("%s\n%s", content, getRow("Release notes are available on GitHub"))
-			content = fmt.Sprintf("%s\n%s", content, getRow(releasesURL))
+			content += "\n" + getRow("Release notes are available on GitHub")
+			content += "\n" + getRow(releasesURL)
 		}
 	}
 

--- a/bitrise/print.go
+++ b/bitrise/print.go
@@ -369,18 +369,17 @@ func buildUpdateRow(stepInfo stepmanModels.StepInfoModel, width int, evaluatedVe
 	charDiff := len(updateRow) - width
 	if charDiff < 0 {
 		// shorter than desired - fill with space
+		updateRow = fmt.Sprintf("| Update available: %s -> %s%s |", stepInfo.Version, stepInfo.LatestVersion, strings.Repeat(" ", -charDiff))
 		if stepInfo.Version != evaluatedVersion {
 			updateRow = fmt.Sprintf("| Update available: %s (%s) -> %s%s |", stepInfo.Version, evaluatedVersion, stepInfo.LatestVersion, strings.Repeat(" ", -charDiff))
-		} else {
-			updateRow = fmt.Sprintf("| Update available: %s -> %s%s |", stepInfo.Version, stepInfo.LatestVersion, strings.Repeat(" ", -charDiff))
 		}
 	} else if charDiff > 0 {
 		// longer than desired - trim title
+		updateRow = fmt.Sprintf("| Update available: -> %s%s |", stepInfo.LatestVersion, strings.Repeat(" ", -len("| Update available: -> %s |")-width))
 		if charDiff > 6 {
 			updateRow = fmt.Sprintf("| Update available!%s |", strings.Repeat(" ", -len("| Update available! |")-width))
-		} else {
-			updateRow = fmt.Sprintf("| Update available: -> %s%s |", stepInfo.LatestVersion, strings.Repeat(" ", -len("| Update available: -> %s |")-width))
 		}
+
 	}
 
 	return updateRow

--- a/bitrise/print.go
+++ b/bitrise/print.go
@@ -367,13 +367,18 @@ func buildUpdateRow(stepInfo stepmanModels.StepInfoModel, width int, evaluatedVe
 
 	updateRow = fmt.Sprintf("| Update available: %s -> %s |", stepInfo.Version, stepInfo.LatestVersion)
 	charDiff := len(updateRow) - width
-	if charDiff < 0 {
-		// shorter than desired - fill with space
-		updateRow = fmt.Sprintf("| Update available: %s -> %s%s |", stepInfo.Version, stepInfo.LatestVersion, strings.Repeat(" ", -charDiff))
-		if stepInfo.Version != evaluatedVersion {
-			updateRow = fmt.Sprintf("| Update available: %s (%s) -> %s%s |", stepInfo.Version, evaluatedVersion, stepInfo.LatestVersion, strings.Repeat(" ", -charDiff))
-		}
-	} else if charDiff > 0 {
+
+	if charDiff == 0 {
+		return updateRow
+	}
+
+	// shorter than desired - fill with space
+	updateRow = fmt.Sprintf("| Update available: %s -> %s%s |", stepInfo.Version, stepInfo.LatestVersion, strings.Repeat(" ", -charDiff))
+	if stepInfo.Version != evaluatedVersion {
+		updateRow = fmt.Sprintf("| Update available: %s (%s) -> %s%s |", stepInfo.Version, evaluatedVersion, stepInfo.LatestVersion, strings.Repeat(" ", -charDiff))
+	}
+
+	if charDiff > 0 {
 		// longer than desired - trim title
 		updateRow = fmt.Sprintf("| Update available: -> %s%s |", stepInfo.LatestVersion, strings.Repeat(" ", -len("| Update available: -> %s |")-width))
 		if charDiff > 6 {

--- a/bitrise/print_test.go
+++ b/bitrise/print_test.go
@@ -285,9 +285,25 @@ func TestGetRunningStepFooterSubSection(t *testing.T) {
 			"| ...-organization/very-long-test-repository-name-exceeding-max-width/releases |"
 		require.Equal(t, expected, actual)
 
+		result.StepInfo.Version = "1.x.x"
+		actual = getRunningStepFooterSubSection(result)
+		expected = "| Update available: 1.x.x (1.0.1) -> 2.1.0                                     |" + "\n" +
+			"|                                                                              |" + "\n" +
+			"| Release notes are available on GitHub                                        |" + "\n" +
+			"| ...-organization/very-long-test-repository-name-exceeding-max-width/releases |"
+		require.Equal(t, expected, actual)
+
 		result.StepInfo.Version = "1.0"
 		actual = getRunningStepFooterSubSection(result)
 		expected = "| Update available: 1.0 (1.0.1) -> 2.1.0                                       |" + "\n" +
+			"|                                                                              |" + "\n" +
+			"| Release notes are available on GitHub                                        |" + "\n" +
+			"| ...-organization/very-long-test-repository-name-exceeding-max-width/releases |"
+		require.Equal(t, expected, actual)
+
+		result.StepInfo.Version = "1.0.x"
+		actual = getRunningStepFooterSubSection(result)
+		expected = "| Update available: 1.0.x (1.0.1) -> 2.1.0                                     |" + "\n" +
 			"|                                                                              |" + "\n" +
 			"| Release notes are available on GitHub                                        |" + "\n" +
 			"| ...-organization/very-long-test-repository-name-exceeding-max-width/releases |"
@@ -321,9 +337,25 @@ func TestGetRunningStepFooterSubSection(t *testing.T) {
 			"| https://github.com/bitrise-steplib/steps-script/releases                     |"
 		require.Equal(t, expected, actual)
 
+		result.StepInfo.Version = "1.x.x"
+		actual = getRunningStepFooterSubSection(result)
+		expected = "| Update available: 1.x.x (1.0.1) -> 2.1.0                                     |" + "\n" +
+			"|                                                                              |" + "\n" +
+			"| Release notes are available on GitHub                                        |" + "\n" +
+			"| https://github.com/bitrise-steplib/steps-script/releases                     |"
+		require.Equal(t, expected, actual)
+
 		result.StepInfo.Version = "1.0"
 		actual = getRunningStepFooterSubSection(result)
 		expected = "| Update available: 1.0 (1.0.1) -> 2.1.0                                       |" + "\n" +
+			"|                                                                              |" + "\n" +
+			"| Release notes are available on GitHub                                        |" + "\n" +
+			"| https://github.com/bitrise-steplib/steps-script/releases                     |"
+		require.Equal(t, expected, actual)
+
+		result.StepInfo.Version = "1.0.x"
+		actual = getRunningStepFooterSubSection(result)
+		expected = "| Update available: 1.0.x (1.0.1) -> 2.1.0                                     |" + "\n" +
 			"|                                                                              |" + "\n" +
 			"| Release notes are available on GitHub                                        |" + "\n" +
 			"| https://github.com/bitrise-steplib/steps-script/releases                     |"

--- a/bitrise/print_test.go
+++ b/bitrise/print_test.go
@@ -258,41 +258,12 @@ func TestGetRunningStepFooterSubSection(t *testing.T) {
 		require.Equal(t, expected, actual)
 	}
 
-	t.Log("Update available, no support_url, no source_code_url, locked on latest minor")
+	t.Log("Update available, major/minor lock")
 	{
 		stepInfo := stepmanModels.StepInfoModel{
 			Step: stepmanModels.StepModel{
 				Title:         pointers.NewStringPtr(longStr),
 				SourceCodeURL: pointers.NewStringPtr("https://github.com/bitrise-steplib/steps-script"),
-			},
-			Version:       "1.0",
-			LatestVersion: "1.1.0",
-		}
-
-		result := models.StepRunResultsModel{
-			StepInfo: stepInfo,
-			Status:   models.StepRunStatusCodeSuccess,
-			Idx:      0,
-			RunTime:  10000000,
-			ErrorStr: longStr,
-			ExitCode: 1,
-		}
-
-		actual := getRunningStepFooterSubSection(result)
-		expected := "| Update available: 1.0 (1.0.1) -> 1.1.0                                       |" + "\n" +
-			"| Release notes are available on GitHub                                        |" + "\n" +
-			"| https://github.com/bitrise-steplib/steps-script/releases                     |" + "\n" +
-			"| Issue tracker: \x1b[33;1mNot provided\x1b[0m                                                  |" + "\n" +
-			"| Source: https://github.com/bitrise-steplib/steps-script                      |"
-		require.Equal(t, expected, actual)
-	}
-
-	t.Log("Update available, no support_url, no source_code_url, locked on latest major")
-	{
-		stepInfo := stepmanModels.StepInfoModel{
-			Step: stepmanModels.StepModel{
-				Title:         pointers.NewStringPtr(longStr),
-				SourceCodeURL: pointers.NewStringPtr("https://github.com/orgname/a-very-long-repository-name-exceeding-the-maximum-box-width"),
 			},
 			Version:       "1",
 			LatestVersion: "1.1.0",
@@ -310,10 +281,20 @@ func TestGetRunningStepFooterSubSection(t *testing.T) {
 		actual := getRunningStepFooterSubSection(result)
 		expected := "| Update available: 1 (1.0.1) -> 1.1.0                                         |" + "\n" +
 			"| Release notes are available on GitHub                                        |" + "\n" +
-			"| ...name/a-very-long-repository-name-exceeding-the-maximum-box-width/releases |" + "\n" +
+			"| https://github.com/bitrise-steplib/steps-script/releases                     |" + "\n" +
 			"| Issue tracker: \x1b[33;1mNot provided\x1b[0m                                                  |" + "\n" +
-			"| Source: ...gname/a-very-long-repository-name-exceeding-the-maximum-box-width |"
+			"| Source: https://github.com/bitrise-steplib/steps-script                      |"
 		require.Equal(t, expected, actual)
+
+		result.StepInfo.Version = "1.0"
+		actual = getRunningStepFooterSubSection(result)
+		expected = "| Update available: 1.0 (1.0.1) -> 1.1.0                                       |" + "\n" +
+			"| Release notes are available on GitHub                                        |" + "\n" +
+			"| https://github.com/bitrise-steplib/steps-script/releases                     |" + "\n" +
+			"| Issue tracker: \x1b[33;1mNot provided\x1b[0m                                                  |" + "\n" +
+			"| Source: https://github.com/bitrise-steplib/steps-script                      |"
+		require.Equal(t, expected, actual)
+
 	}
 
 	t.Log("support url row length's chardiff = 0")

--- a/bitrise/print_test.go
+++ b/bitrise/print_test.go
@@ -295,7 +295,7 @@ func TestGetRunningStepFooterSubSection(t *testing.T) {
 
 	}
 
-	t.Log("Update available, major/minor lock")
+	t.Log("Update available, major/minor lock, without changelog URL cropping")
 	{
 		stepInfo := stepmanModels.StepInfoModel{
 			Step: stepmanModels.StepModel{

--- a/bitrise/print_test.go
+++ b/bitrise/print_test.go
@@ -238,8 +238,9 @@ func TestGetRunningStepFooterSubSection(t *testing.T) {
 			Step: stepmanModels.StepModel{
 				Title: pointers.NewStringPtr(longStr),
 			},
-			Version:       "1.0.1", // NOTE: changed for test purposes until StepInfoModel is updated to contain EvaluatedVersion property
-			LatestVersion: "1.1.0",
+			Version:          "1.0.0",
+			LatestVersion:    "1.1.0",
+			EvaluatedVersion: "1.0.0",
 		}
 
 		result := models.StepRunResultsModel{
@@ -252,7 +253,7 @@ func TestGetRunningStepFooterSubSection(t *testing.T) {
 		}
 
 		actual := getRunningStepFooterSubSection(result)
-		expected := "| Update available: 1.0.1 -> 1.1.0                                             |" + "\n" +
+		expected := "| Update available: 1.0.0 -> 1.1.0                                             |" + "\n" +
 			"| Issue tracker: \x1b[33;1mNot provided\x1b[0m                                                  |" + "\n" +
 			"| Source: \x1b[33;1mNot provided\x1b[0m                                                         |"
 		require.Equal(t, expected, actual)
@@ -265,8 +266,9 @@ func TestGetRunningStepFooterSubSection(t *testing.T) {
 				Title:         pointers.NewStringPtr(longStr),
 				SourceCodeURL: pointers.NewStringPtr("https://github.com/test-organization/very-long-test-repository-name-exceeding-max-width"),
 			},
-			Version:       "1",
-			LatestVersion: "2.1.0",
+			Version:          "1",
+			LatestVersion:    "2.1.0",
+			EvaluatedVersion: "1.0.1",
 		}
 
 		result := models.StepRunResultsModel{
@@ -306,8 +308,9 @@ func TestGetRunningStepFooterSubSection(t *testing.T) {
 				Title:         pointers.NewStringPtr(longStr),
 				SourceCodeURL: pointers.NewStringPtr("https://github.com/bitrise-steplib/steps-script"),
 			},
-			Version:       "1",
-			LatestVersion: "2.1.0",
+			Version:          "1",
+			LatestVersion:    "2.1.0",
+			EvaluatedVersion: "1.0.1",
 		}
 
 		result := models.StepRunResultsModel{
@@ -347,8 +350,9 @@ func TestGetRunningStepFooterSubSection(t *testing.T) {
 				Title:         pointers.NewStringPtr(longStr),
 				SourceCodeURL: pointers.NewStringPtr("https://github.com/bitrise-steplib/steps-script"),
 			},
-			Version:       "1",
-			LatestVersion: "1.0.1",
+			Version:          "1",
+			LatestVersion:    "1.0.1",
+			EvaluatedVersion: "1.0.1",
 		}
 
 		result := models.StepRunResultsModel{

--- a/bitrise/print_test.go
+++ b/bitrise/print_test.go
@@ -258,6 +258,45 @@ func TestGetRunningStepFooterSubSection(t *testing.T) {
 		require.Equal(t, expected, actual)
 	}
 
+	t.Log("Update available, major/minor lock, with changelog URL cropping")
+	{
+		stepInfo := stepmanModels.StepInfoModel{
+			Step: stepmanModels.StepModel{
+				Title:         pointers.NewStringPtr(longStr),
+				SourceCodeURL: pointers.NewStringPtr("https://github.com/test-organization/very-long-test-repository-name-exceeding-max-width"),
+			},
+			Version:       "1",
+			LatestVersion: "1.1.0",
+		}
+
+		result := models.StepRunResultsModel{
+			StepInfo: stepInfo,
+			Status:   models.StepRunStatusCodeSuccess,
+			Idx:      0,
+			RunTime:  10000000,
+			ErrorStr: longStr,
+			ExitCode: 1,
+		}
+
+		actual := getRunningStepFooterSubSection(result)
+		expected := "| Update available: 1 (1.0.1) -> 1.1.0                                         |" + "\n" +
+			"| Release notes are available on GitHub                                        |" + "\n" +
+			"| ...-organization/very-long-test-repository-name-exceeding-max-width/releases |" + "\n" +
+			"| Issue tracker: \x1b[33;1mNot provided\x1b[0m                                                  |" + "\n" +
+			"| Source: ...t-organization/very-long-test-repository-name-exceeding-max-width |"
+		require.Equal(t, expected, actual)
+
+		result.StepInfo.Version = "1.0"
+		actual = getRunningStepFooterSubSection(result)
+		expected = "| Update available: 1.0 (1.0.1) -> 1.1.0                                       |" + "\n" +
+			"| Release notes are available on GitHub                                        |" + "\n" +
+			"| ...-organization/very-long-test-repository-name-exceeding-max-width/releases |" + "\n" +
+			"| Issue tracker: \x1b[33;1mNot provided\x1b[0m                                                  |" + "\n" +
+			"| Source: ...t-organization/very-long-test-repository-name-exceeding-max-width |"
+		require.Equal(t, expected, actual)
+
+	}
+
 	t.Log("Update available, major/minor lock")
 	{
 		stepInfo := stepmanModels.StepInfoModel{

--- a/bitrise/print_test.go
+++ b/bitrise/print_test.go
@@ -266,7 +266,7 @@ func TestGetRunningStepFooterSubSection(t *testing.T) {
 				SourceCodeURL: pointers.NewStringPtr("https://github.com/test-organization/very-long-test-repository-name-exceeding-max-width"),
 			},
 			Version:       "1",
-			LatestVersion: "1.1.0",
+			LatestVersion: "2.1.0",
 		}
 
 		result := models.StepRunResultsModel{
@@ -279,7 +279,7 @@ func TestGetRunningStepFooterSubSection(t *testing.T) {
 		}
 
 		actual := getRunningStepFooterSubSection(result)
-		expected := "| Update available: 1 (1.0.1) -> 1.1.0                                         |" + "\n" +
+		expected := "| Update available: 1 (1.0.1) -> 2.1.0                                         |" + "\n" +
 			"|                                                                              |" + "\n" +
 			"| Release notes are available on GitHub                                        |" + "\n" +
 			"| ...-organization/very-long-test-repository-name-exceeding-max-width/releases |" + "\n" +
@@ -289,7 +289,7 @@ func TestGetRunningStepFooterSubSection(t *testing.T) {
 
 		result.StepInfo.Version = "1.0"
 		actual = getRunningStepFooterSubSection(result)
-		expected = "| Update available: 1.0 (1.0.1) -> 1.1.0                                       |" + "\n" +
+		expected = "| Update available: 1.0 (1.0.1) -> 2.1.0                                       |" + "\n" +
 			"|                                                                              |" + "\n" +
 			"| Release notes are available on GitHub                                        |" + "\n" +
 			"| ...-organization/very-long-test-repository-name-exceeding-max-width/releases |" + "\n" +
@@ -307,7 +307,7 @@ func TestGetRunningStepFooterSubSection(t *testing.T) {
 				SourceCodeURL: pointers.NewStringPtr("https://github.com/bitrise-steplib/steps-script"),
 			},
 			Version:       "1",
-			LatestVersion: "1.1.0",
+			LatestVersion: "2.1.0",
 		}
 
 		result := models.StepRunResultsModel{
@@ -320,7 +320,7 @@ func TestGetRunningStepFooterSubSection(t *testing.T) {
 		}
 
 		actual := getRunningStepFooterSubSection(result)
-		expected := "| Update available: 1 (1.0.1) -> 1.1.0                                         |" + "\n" +
+		expected := "| Update available: 1 (1.0.1) -> 2.1.0                                         |" + "\n" +
 			"|                                                                              |" + "\n" +
 			"| Release notes are available on GitHub                                        |" + "\n" +
 			"| https://github.com/bitrise-steplib/steps-script/releases                     |" + "\n" +
@@ -330,11 +330,44 @@ func TestGetRunningStepFooterSubSection(t *testing.T) {
 
 		result.StepInfo.Version = "1.0"
 		actual = getRunningStepFooterSubSection(result)
-		expected = "| Update available: 1.0 (1.0.1) -> 1.1.0                                       |" + "\n" +
+		expected = "| Update available: 1.0 (1.0.1) -> 2.1.0                                       |" + "\n" +
 			"|                                                                              |" + "\n" +
 			"| Release notes are available on GitHub                                        |" + "\n" +
 			"| https://github.com/bitrise-steplib/steps-script/releases                     |" + "\n" +
 			"| Issue tracker: \x1b[33;1mNot provided\x1b[0m                                                  |" + "\n" +
+			"| Source: https://github.com/bitrise-steplib/steps-script                      |"
+		require.Equal(t, expected, actual)
+
+	}
+
+	t.Log("Update available, nothing is printed if latest version is within major/minor lock range")
+	{
+		stepInfo := stepmanModels.StepInfoModel{
+			Step: stepmanModels.StepModel{
+				Title:         pointers.NewStringPtr(longStr),
+				SourceCodeURL: pointers.NewStringPtr("https://github.com/bitrise-steplib/steps-script"),
+			},
+			Version:       "1",
+			LatestVersion: "1.0.1",
+		}
+
+		result := models.StepRunResultsModel{
+			StepInfo: stepInfo,
+			Status:   models.StepRunStatusCodeSuccess,
+			Idx:      0,
+			RunTime:  10000000,
+			ErrorStr: longStr,
+			ExitCode: 1,
+		}
+
+		actual := getRunningStepFooterSubSection(result)
+		expected := "| Issue tracker: \x1b[33;1mNot provided\x1b[0m                                                  |" + "\n" +
+			"| Source: https://github.com/bitrise-steplib/steps-script                      |"
+		require.Equal(t, expected, actual)
+
+		result.StepInfo.Version = "1.0"
+		actual = getRunningStepFooterSubSection(result)
+		expected = "| Issue tracker: \x1b[33;1mNot provided\x1b[0m                                                  |" + "\n" +
 			"| Source: https://github.com/bitrise-steplib/steps-script                      |"
 		require.Equal(t, expected, actual)
 

--- a/bitrise/print_test.go
+++ b/bitrise/print_test.go
@@ -238,7 +238,7 @@ func TestGetRunningStepFooterSubSection(t *testing.T) {
 			Step: stepmanModels.StepModel{
 				Title: pointers.NewStringPtr(longStr),
 			},
-			Version:       "1.0.0",
+			Version:       "1.0.1", // NOTE: changed for test purposes until StepInfoModel is updated to contain EvaluatedVersion property
 			LatestVersion: "1.1.0",
 		}
 
@@ -252,7 +252,59 @@ func TestGetRunningStepFooterSubSection(t *testing.T) {
 		}
 
 		actual := getRunningStepFooterSubSection(result)
-		expected := "| Update available: 1.0.0 -> 1.1.0                                             |" + "\n" +
+		expected := "| Update available: 1.0.1 -> 1.1.0                                             |" + "\n" +
+			"| Issue tracker: \x1b[33;1mNot provided\x1b[0m                                                  |" + "\n" +
+			"| Source: \x1b[33;1mNot provided\x1b[0m                                                         |"
+		require.Equal(t, expected, actual)
+	}
+
+	t.Log("Update available, no support_url, no source_code_url, locked on latest minor")
+	{
+		stepInfo := stepmanModels.StepInfoModel{
+			Step: stepmanModels.StepModel{
+				Title: pointers.NewStringPtr(longStr),
+			},
+			Version:       "1.0",
+			LatestVersion: "1.1.0",
+		}
+
+		result := models.StepRunResultsModel{
+			StepInfo: stepInfo,
+			Status:   models.StepRunStatusCodeSuccess,
+			Idx:      0,
+			RunTime:  10000000,
+			ErrorStr: longStr,
+			ExitCode: 1,
+		}
+
+		actual := getRunningStepFooterSubSection(result)
+		expected := "| Update available: 1.0 (1.0.1) -> 1.1.0                                       |" + "\n" +
+			"| Issue tracker: \x1b[33;1mNot provided\x1b[0m                                                  |" + "\n" +
+			"| Source: \x1b[33;1mNot provided\x1b[0m                                                         |"
+		require.Equal(t, expected, actual)
+	}
+
+	t.Log("Update available, no support_url, no source_code_url, locked on latest major")
+	{
+		stepInfo := stepmanModels.StepInfoModel{
+			Step: stepmanModels.StepModel{
+				Title: pointers.NewStringPtr(longStr),
+			},
+			Version:       "1",
+			LatestVersion: "1.1.0",
+		}
+
+		result := models.StepRunResultsModel{
+			StepInfo: stepInfo,
+			Status:   models.StepRunStatusCodeSuccess,
+			Idx:      0,
+			RunTime:  10000000,
+			ErrorStr: longStr,
+			ExitCode: 1,
+		}
+
+		actual := getRunningStepFooterSubSection(result)
+		expected := "| Update available: 1 (1.0.1) -> 1.1.0                                         |" + "\n" +
 			"| Issue tracker: \x1b[33;1mNot provided\x1b[0m                                                  |" + "\n" +
 			"| Source: \x1b[33;1mNot provided\x1b[0m                                                         |"
 		require.Equal(t, expected, actual)

--- a/bitrise/print_test.go
+++ b/bitrise/print_test.go
@@ -280,6 +280,7 @@ func TestGetRunningStepFooterSubSection(t *testing.T) {
 
 		actual := getRunningStepFooterSubSection(result)
 		expected := "| Update available: 1 (1.0.1) -> 1.1.0                                         |" + "\n" +
+			"|                                                                              |" + "\n" +
 			"| Release notes are available on GitHub                                        |" + "\n" +
 			"| ...-organization/very-long-test-repository-name-exceeding-max-width/releases |" + "\n" +
 			"| Issue tracker: \x1b[33;1mNot provided\x1b[0m                                                  |" + "\n" +
@@ -289,6 +290,7 @@ func TestGetRunningStepFooterSubSection(t *testing.T) {
 		result.StepInfo.Version = "1.0"
 		actual = getRunningStepFooterSubSection(result)
 		expected = "| Update available: 1.0 (1.0.1) -> 1.1.0                                       |" + "\n" +
+			"|                                                                              |" + "\n" +
 			"| Release notes are available on GitHub                                        |" + "\n" +
 			"| ...-organization/very-long-test-repository-name-exceeding-max-width/releases |" + "\n" +
 			"| Issue tracker: \x1b[33;1mNot provided\x1b[0m                                                  |" + "\n" +
@@ -319,6 +321,7 @@ func TestGetRunningStepFooterSubSection(t *testing.T) {
 
 		actual := getRunningStepFooterSubSection(result)
 		expected := "| Update available: 1 (1.0.1) -> 1.1.0                                         |" + "\n" +
+			"|                                                                              |" + "\n" +
 			"| Release notes are available on GitHub                                        |" + "\n" +
 			"| https://github.com/bitrise-steplib/steps-script/releases                     |" + "\n" +
 			"| Issue tracker: \x1b[33;1mNot provided\x1b[0m                                                  |" + "\n" +
@@ -328,6 +331,7 @@ func TestGetRunningStepFooterSubSection(t *testing.T) {
 		result.StepInfo.Version = "1.0"
 		actual = getRunningStepFooterSubSection(result)
 		expected = "| Update available: 1.0 (1.0.1) -> 1.1.0                                       |" + "\n" +
+			"|                                                                              |" + "\n" +
 			"| Release notes are available on GitHub                                        |" + "\n" +
 			"| https://github.com/bitrise-steplib/steps-script/releases                     |" + "\n" +
 			"| Issue tracker: \x1b[33;1mNot provided\x1b[0m                                                  |" + "\n" +

--- a/bitrise/print_test.go
+++ b/bitrise/print_test.go
@@ -276,17 +276,13 @@ func TestGetRunningStepFooterSubSection(t *testing.T) {
 			Status:   models.StepRunStatusCodeSuccess,
 			Idx:      0,
 			RunTime:  10000000,
-			ErrorStr: longStr,
-			ExitCode: 1,
 		}
 
 		actual := getRunningStepFooterSubSection(result)
 		expected := "| Update available: 1 (1.0.1) -> 2.1.0                                         |" + "\n" +
 			"|                                                                              |" + "\n" +
 			"| Release notes are available on GitHub                                        |" + "\n" +
-			"| ...-organization/very-long-test-repository-name-exceeding-max-width/releases |" + "\n" +
-			"| Issue tracker: \x1b[33;1mNot provided\x1b[0m                                                  |" + "\n" +
-			"| Source: ...t-organization/very-long-test-repository-name-exceeding-max-width |"
+			"| ...-organization/very-long-test-repository-name-exceeding-max-width/releases |"
 		require.Equal(t, expected, actual)
 
 		result.StepInfo.Version = "1.0"
@@ -294,9 +290,7 @@ func TestGetRunningStepFooterSubSection(t *testing.T) {
 		expected = "| Update available: 1.0 (1.0.1) -> 2.1.0                                       |" + "\n" +
 			"|                                                                              |" + "\n" +
 			"| Release notes are available on GitHub                                        |" + "\n" +
-			"| ...-organization/very-long-test-repository-name-exceeding-max-width/releases |" + "\n" +
-			"| Issue tracker: \x1b[33;1mNot provided\x1b[0m                                                  |" + "\n" +
-			"| Source: ...t-organization/very-long-test-repository-name-exceeding-max-width |"
+			"| ...-organization/very-long-test-repository-name-exceeding-max-width/releases |"
 		require.Equal(t, expected, actual)
 
 	}
@@ -318,17 +312,13 @@ func TestGetRunningStepFooterSubSection(t *testing.T) {
 			Status:   models.StepRunStatusCodeSuccess,
 			Idx:      0,
 			RunTime:  10000000,
-			ErrorStr: longStr,
-			ExitCode: 1,
 		}
 
 		actual := getRunningStepFooterSubSection(result)
 		expected := "| Update available: 1 (1.0.1) -> 2.1.0                                         |" + "\n" +
 			"|                                                                              |" + "\n" +
 			"| Release notes are available on GitHub                                        |" + "\n" +
-			"| https://github.com/bitrise-steplib/steps-script/releases                     |" + "\n" +
-			"| Issue tracker: \x1b[33;1mNot provided\x1b[0m                                                  |" + "\n" +
-			"| Source: https://github.com/bitrise-steplib/steps-script                      |"
+			"| https://github.com/bitrise-steplib/steps-script/releases                     |"
 		require.Equal(t, expected, actual)
 
 		result.StepInfo.Version = "1.0"
@@ -336,9 +326,7 @@ func TestGetRunningStepFooterSubSection(t *testing.T) {
 		expected = "| Update available: 1.0 (1.0.1) -> 2.1.0                                       |" + "\n" +
 			"|                                                                              |" + "\n" +
 			"| Release notes are available on GitHub                                        |" + "\n" +
-			"| https://github.com/bitrise-steplib/steps-script/releases                     |" + "\n" +
-			"| Issue tracker: \x1b[33;1mNot provided\x1b[0m                                                  |" + "\n" +
-			"| Source: https://github.com/bitrise-steplib/steps-script                      |"
+			"| https://github.com/bitrise-steplib/steps-script/releases                     |"
 		require.Equal(t, expected, actual)
 
 	}
@@ -360,19 +348,15 @@ func TestGetRunningStepFooterSubSection(t *testing.T) {
 			Status:   models.StepRunStatusCodeSuccess,
 			Idx:      0,
 			RunTime:  10000000,
-			ErrorStr: longStr,
-			ExitCode: 1,
 		}
 
 		actual := getRunningStepFooterSubSection(result)
-		expected := "| Issue tracker: \x1b[33;1mNot provided\x1b[0m                                                  |" + "\n" +
-			"| Source: https://github.com/bitrise-steplib/steps-script                      |"
+		expected := ""
 		require.Equal(t, expected, actual)
 
 		result.StepInfo.Version = "1.0"
 		actual = getRunningStepFooterSubSection(result)
-		expected = "| Issue tracker: \x1b[33;1mNot provided\x1b[0m                                                  |" + "\n" +
-			"| Source: https://github.com/bitrise-steplib/steps-script                      |"
+		expected = ""
 		require.Equal(t, expected, actual)
 
 	}

--- a/bitrise/print_test.go
+++ b/bitrise/print_test.go
@@ -262,7 +262,8 @@ func TestGetRunningStepFooterSubSection(t *testing.T) {
 	{
 		stepInfo := stepmanModels.StepInfoModel{
 			Step: stepmanModels.StepModel{
-				Title: pointers.NewStringPtr(longStr),
+				Title:         pointers.NewStringPtr(longStr),
+				SourceCodeURL: pointers.NewStringPtr("https://github.com/bitrise-steplib/steps-script"),
 			},
 			Version:       "1.0",
 			LatestVersion: "1.1.0",
@@ -279,8 +280,10 @@ func TestGetRunningStepFooterSubSection(t *testing.T) {
 
 		actual := getRunningStepFooterSubSection(result)
 		expected := "| Update available: 1.0 (1.0.1) -> 1.1.0                                       |" + "\n" +
+			"| Release notes are available on GitHub                                        |" + "\n" +
+			"| https://github.com/bitrise-steplib/steps-script/releases                     |" + "\n" +
 			"| Issue tracker: \x1b[33;1mNot provided\x1b[0m                                                  |" + "\n" +
-			"| Source: \x1b[33;1mNot provided\x1b[0m                                                         |"
+			"| Source: https://github.com/bitrise-steplib/steps-script                      |"
 		require.Equal(t, expected, actual)
 	}
 
@@ -288,7 +291,8 @@ func TestGetRunningStepFooterSubSection(t *testing.T) {
 	{
 		stepInfo := stepmanModels.StepInfoModel{
 			Step: stepmanModels.StepModel{
-				Title: pointers.NewStringPtr(longStr),
+				Title:         pointers.NewStringPtr(longStr),
+				SourceCodeURL: pointers.NewStringPtr("https://github.com/orgname/a-very-long-repository-name-exceeding-the-maximum-box-width"),
 			},
 			Version:       "1",
 			LatestVersion: "1.1.0",
@@ -305,8 +309,10 @@ func TestGetRunningStepFooterSubSection(t *testing.T) {
 
 		actual := getRunningStepFooterSubSection(result)
 		expected := "| Update available: 1 (1.0.1) -> 1.1.0                                         |" + "\n" +
+			"| Release notes are available on GitHub                                        |" + "\n" +
+			"| ...name/a-very-long-repository-name-exceeding-the-maximum-box-width/releases |" + "\n" +
 			"| Issue tracker: \x1b[33;1mNot provided\x1b[0m                                                  |" + "\n" +
-			"| Source: \x1b[33;1mNot provided\x1b[0m                                                         |"
+			"| Source: ...gname/a-very-long-repository-name-exceeding-the-maximum-box-width |"
 		require.Equal(t, expected, actual)
 	}
 

--- a/bitrise/updates.go
+++ b/bitrise/updates.go
@@ -4,8 +4,6 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/bitrise-io/go-utils/log"
-	"github.com/bitrise-io/go-utils/versions"
 	stepmanModels "github.com/bitrise-io/stepman/models"
 	ver "github.com/hashicorp/go-version"
 )
@@ -15,26 +13,20 @@ func isUpdateAvailable(stepInfo stepmanModels.StepInfoModel) bool {
 		return false
 	}
 
-	if stepInfo.Version != stepInfo.EvaluatedVersion {
-		re := regexp.MustCompile(`\d+`)
-		components := re.FindAllString(stepInfo.Version, -1)
-		normalized := strings.Join(components, ".")
-		locked, _ := ver.NewSemver(normalized)
-		latest, _ := ver.NewSemver(stepInfo.LatestVersion)
+	re := regexp.MustCompile(`\d+`)
+	components := re.FindAllString(stepInfo.Version, -1)
+	normalized := strings.Join(components, ".")
+	locked, _ := ver.NewSemver(normalized)
+	latest, _ := ver.NewSemver(stepInfo.LatestVersion)
 
-		switch len(components) {
-		case 1:
-			return locked.Segments()[0] < latest.Segments()[0]
-		case 2:
-			return locked.Segments()[0] < latest.Segments()[0] || locked.Segments()[1] < latest.Segments()[1]
-
-		}
+	switch len(components) {
+	case 1:
+		return locked.Segments()[0] < latest.Segments()[0]
+	case 2:
+		return locked.Segments()[0] < latest.Segments()[0] || locked.Segments()[1] < latest.Segments()[1]
+	case 3:
+		return locked.LessThan(latest)
+	default:
+		return false
 	}
-
-	res, err := versions.CompareVersions(stepInfo.Version, stepInfo.LatestVersion)
-	if err != nil {
-		log.Errorf("Failed to compare versions, err: %s", err)
-	}
-
-	return (res == 1)
 }

--- a/bitrise/updates.go
+++ b/bitrise/updates.go
@@ -1,0 +1,40 @@
+package bitrise
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/bitrise-io/go-utils/log"
+	"github.com/bitrise-io/go-utils/versions"
+	stepmanModels "github.com/bitrise-io/stepman/models"
+	ver "github.com/hashicorp/go-version"
+)
+
+func isUpdateAvailable(stepInfo stepmanModels.StepInfoModel) bool {
+	if stepInfo.LatestVersion == "" {
+		return false
+	}
+
+	if stepInfo.Version != stepInfo.EvaluatedVersion {
+		re := regexp.MustCompile(`\d+`)
+		components := re.FindAllString(stepInfo.Version, -1)
+		normalized := strings.Join(components, ".")
+		locked, _ := ver.NewSemver(normalized)
+		latest, _ := ver.NewSemver(stepInfo.LatestVersion)
+
+		switch len(components) {
+		case 1:
+			return locked.Segments()[0] < latest.Segments()[0]
+		case 2:
+			return locked.Segments()[0] < latest.Segments()[0] || locked.Segments()[1] < latest.Segments()[1]
+
+		}
+	}
+
+	res, err := versions.CompareVersions(stepInfo.Version, stepInfo.LatestVersion)
+	if err != nil {
+		log.Errorf("Failed to compare versions, err: %s", err)
+	}
+
+	return (res == 1)
+}

--- a/vendor/github.com/bitrise-io/stepman/models/models.go
+++ b/vendor/github.com/bitrise-io/stepman/models/models.go
@@ -168,13 +168,14 @@ type EnvInfoModel struct {
 
 // StepInfoModel ...
 type StepInfoModel struct {
-	Library       string             `json:"library,omitempty" yaml:"library,omitempty"`
-	ID            string             `json:"id,omitempty" yaml:"id,omitempty"`
-	Version       string             `json:"version,omitempty" yaml:"version,omitempty"`
-	LatestVersion string             `json:"latest_version,omitempty" yaml:"latest_version,omitempty"`
-	GroupInfo     StepGroupInfoModel `json:"info,omitempty" yaml:"info,omitempty"`
-	Step          StepModel          `json:"step,omitempty" yaml:"step,omitempty"`
-	DefinitionPth string             `json:"definition_pth,omitempty" yaml:"definition_pth,omitempty"`
+	Library          string             `json:"library,omitempty" yaml:"library,omitempty"`
+	ID               string             `json:"id,omitempty" yaml:"id,omitempty"`
+	Version          string             `json:"version,omitempty" yaml:"version,omitempty"`
+	LatestVersion    string             `json:"latest_version,omitempty" yaml:"latest_version,omitempty"`
+	EvaluatedVersion string             // monkey patched until dependency is updated
+	GroupInfo        StepGroupInfoModel `json:"info,omitempty" yaml:"info,omitempty"`
+	Step             StepModel          `json:"step,omitempty" yaml:"step,omitempty"`
+	DefinitionPth    string             `json:"definition_pth,omitempty" yaml:"definition_pth,omitempty"`
 }
 
 // StepListModel ...


### PR DESCRIPTION
- isUpdateAvailable was moved to a separate file and heavily refactored, because of the new requirements
- update info printing got refactored in a separate function
- **monkey patched SetInfoModel in vendor to make CI pass, until dependency is updated**