### PR TITLE
TOOL-1907 fix flaky CI test case

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -16,7 +16,7 @@ workflows:
     - script:
         title: Go test
         inputs:
-        - content: go test $BITRISE_GO_PACKAGES
+        - content: go test -p 1 $BITRISE_GO_PACKAGES
     - script:
         title: Run integration tests
         inputs:

--- a/bitrise/util_test.go
+++ b/bitrise/util_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/bitrise-io/bitrise/configs"
 	envmanModels "github.com/bitrise-io/envman/models"
 	stepmanModels "github.com/bitrise-io/stepman/models"
 	"github.com/stretchr/testify/require"
@@ -136,80 +137,80 @@ func TestTimeToFormattedSeconds(t *testing.T) {
 	}
 }
 
-// func TestRemoveConfigRedundantFieldsAndFillStepOutputs(t *testing.T) {
-// 	// setup
-// 	require.NoError(t, configs.InitPaths())
+func TestRemoveConfigRedundantFieldsAndFillStepOutputs(t *testing.T) {
+	// setup
+	require.NoError(t, configs.InitPaths())
 
-// 	configStr := `
-//   format_version: 1.3.0
-//   default_step_lib_source: "https://github.com/bitrise-io/bitrise-steplib.git"
+	configStr := `
+  format_version: 1.3.0
+  default_step_lib_source: "https://github.com/bitrise-io/bitrise-steplib.git"
 
-//   workflows:
-//     remove_test:
-//       steps:
-//       - script:
-//           inputs:
-//           - content: |
-//               #!/bin/bash
-//               set -v
-//               exit 2
-//             opts:
-//               is_expand: true
-//       - timestamp:
-//           title: Generate timestamps
-//     `
+  workflows:
+    remove_test:
+      steps:
+      - script:
+          inputs:
+          - content: |
+              #!/bin/bash
+              set -v
+              exit 2
+            opts:
+              is_expand: true
+      - timestamp:
+          title: Generate timestamps
+    `
 
-// 	config, warnings, err := ConfigModelFromYAMLBytes([]byte(configStr))
-// 	require.Equal(t, nil, err)
-// 	require.Equal(t, 0, len(warnings))
+	config, warnings, err := ConfigModelFromYAMLBytes([]byte(configStr))
+	require.Equal(t, nil, err)
+	require.Equal(t, 0, len(warnings))
 
-// 	require.Equal(t, nil, RemoveConfigRedundantFieldsAndFillStepOutputs(&config))
+	require.Equal(t, nil, RemoveConfigRedundantFieldsAndFillStepOutputs(&config))
 
-// 	for workflowID, workflow := range config.Workflows {
-// 		if workflowID == "remove_test" {
-// 			for _, stepListItem := range workflow.Steps {
-// 				for stepID, step := range stepListItem {
-// 					if stepID == "script" {
-// 						for _, input := range step.Inputs {
-// 							key, _, err := input.GetKeyValuePair()
-// 							require.Equal(t, nil, err)
+	for workflowID, workflow := range config.Workflows {
+		if workflowID == "remove_test" {
+			for _, stepListItem := range workflow.Steps {
+				for stepID, step := range stepListItem {
+					if stepID == "script" {
+						for _, input := range step.Inputs {
+							key, _, err := input.GetKeyValuePair()
+							require.Equal(t, nil, err)
 
-// 							if key == "content" {
-// 								opts, err := input.GetOptions()
-// 								require.Equal(t, nil, err)
+							if key == "content" {
+								opts, err := input.GetOptions()
+								require.Equal(t, nil, err)
 
-// 								// script content should keep is_expand: true, because it's different from spec default
-// 								require.Equal(t, true, *opts.IsExpand)
-// 							}
-// 						}
-// 					} else if stepID == "timestamp" {
-// 						// timestamp title should be nil, because it's the same as spec value
-// 						require.Equal(t, (*string)(nil), step.Title)
+								// script content should keep is_expand: true, because it's different from spec default
+								require.Equal(t, true, *opts.IsExpand)
+							}
+						}
+					} else if stepID == "timestamp" {
+						// timestamp title should be nil, because it's the same as spec value
+						require.Equal(t, (*string)(nil), step.Title)
 
-// 						for _, output := range step.Outputs {
-// 							key, _, err := output.GetKeyValuePair()
-// 							require.Equal(t, nil, err)
+						for _, output := range step.Outputs {
+							key, _, err := output.GetKeyValuePair()
+							require.Equal(t, nil, err)
 
-// 							if key == "UNIX_TIMESTAMP" {
-// 								// timestamp outputs should filled with key-value & opts.Title
-// 								opts, err := output.GetOptions()
-// 								require.Equal(t, nil, err)
+							if key == "UNIX_TIMESTAMP" {
+								// timestamp outputs should filled with key-value & opts.Title
+								opts, err := output.GetOptions()
+								require.Equal(t, nil, err)
 
-// 								require.Equal(t, "unix style", *opts.Title)
-// 								require.Equal(t, (*bool)(nil), opts.IsExpand)
-// 								require.Equal(t, (*bool)(nil), opts.IsDontChangeValue)
-// 								require.Equal(t, (*bool)(nil), opts.IsRequired)
-// 							}
-// 						}
-// 					}
-// 				}
-// 			}
-// 		}
-// 	}
+								require.Equal(t, "unix style", *opts.Title)
+								require.Equal(t, (*bool)(nil), opts.IsExpand)
+								require.Equal(t, (*bool)(nil), opts.IsDontChangeValue)
+								require.Equal(t, (*bool)(nil), opts.IsRequired)
+							}
+						}
+					}
+				}
+			}
+		}
+	}
 
-// 	// timestamp outputs should filled with key-value & opts.Title
+	// timestamp outputs should filled with key-value & opts.Title
 
-// }
+}
 
 func TestSsStringSliceWithSameElements(t *testing.T) {
 	s1 := []string{}


### PR DESCRIPTION
`$ go help testflag`

```
-parallel n
	    Allow parallel execution of test functions that call t.Parallel.
	    The value of this flag is the maximum number of tests to run
	    simultaneously; by default, it is set to the value of GOMAXPROCS.
	    Note that -parallel only applies within a single test binary.
	    The 'go test' command may run tests for different packages
	    in parallel as well, according to the setting of the -p flag
	    (see 'go help build').
```

`$ go help build`

```
	-p n
		the number of programs, such as build commands or
		test binaries, that can be run in parallel.
		The default is the number of CPUs available.
```

Created a test case run timeline graph with the default settings:
![cli_failure](https://user-images.githubusercontent.com/1564933/77671425-e3b85d00-6f87-11ea-8ff2-25cb3ff10560.png)

Also created a graph with `-p 1`:
![cli_ok](https://user-images.githubusercontent.com/1564933/77671460-f3d03c80-6f87-11ea-95ab-2de64e9151dc.png)

So it is clearly visible that packages are running in parallel and also that it can be turned off.