### PR TITLE
Remove envman envstore usage.

### DIFF
--- a/cli/analytics_test.go
+++ b/cli/analytics_test.go
@@ -3,14 +3,14 @@ package cli
 import (
 	"testing"
 
-	envmanModels "github.com/bitrise-io/envman/models"
+	"github.com/bitrise-io/envman/models"
 	"github.com/stretchr/testify/require"
 )
 
-func Test_expandStepInputsForAnalytics(t *testing.T) {
+func Test_redactStepInputs(t *testing.T) {
 	type args struct {
-		environments []envmanModels.EnvironmentItemModel
-		inputs       []envmanModels.EnvironmentItemModel
+		environments map[string]string
+		inputs       []models.EnvironmentItemModel
 		secretValues []string
 	}
 	tests := []struct {
@@ -21,11 +21,9 @@ func Test_expandStepInputsForAnalytics(t *testing.T) {
 		{
 			name: "Secret filtering",
 			args: args{
-				environments: []envmanModels.EnvironmentItemModel{
-					{"secret_simulator_device": "secret_a_secret_b_secret_c", "opts": map[string]interface{}{"is_sensitive": false}},
-				},
-				inputs: []envmanModels.EnvironmentItemModel{
-					{"secret_simulator_device": ""},
+				environments: map[string]string{"secret_simulator_device": "secret_a_secret_b_secret_c"},
+				inputs: []models.EnvironmentItemModel{
+					{"secret_simulator_device": "---xxxx---"},
 				},
 				secretValues: []string{"secret_a_secret_b_secret_c"},
 			},
@@ -36,8 +34,8 @@ func Test_expandStepInputsForAnalytics(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := expandStepInputsForAnalytics(tt.args.environments, tt.args.inputs, tt.args.secretValues)
-			require.NoError(t, err, "expandStepInputsForAnalytics")
+			got, err := redactStepInputs(tt.args.environments, tt.args.inputs, tt.args.secretValues)
+			require.NoError(t, err, "redactStepInputs()")
 			require.Equal(t, got, tt.want)
 		})
 	}

--- a/plugins/run.go
+++ b/plugins/run.go
@@ -132,13 +132,6 @@ func runPlugin(plugin Plugin, args []string, envs PluginConfig, input []byte) er
 		return err
 	}
 
-	// Add plugin inputs
-	for key, value := range envs {
-		if err := tools.EnvmanAdd(pluginEnvstorePath, key, value, false, false); err != nil {
-			return err
-		}
-	}
-
 	// Run plugin executable
 	pluginExecutable, isBin, err := GetPluginExecutablePath(plugin.Name)
 	if err != nil {
@@ -153,7 +146,7 @@ func runPlugin(plugin Plugin, args []string, envs PluginConfig, input []byte) er
 		cmd = append([]string{"bash", pluginExecutable}, args...)
 	}
 
-	if _, err := tools.EnvmanRun(pluginEnvstorePath, "", cmd, -1, nil, input); err != nil {
+	if _, err := tools.EnvmanRun(envs, pluginEnvstorePath, "", cmd, -1, nil, input); err != nil {
 		return err
 	}
 

--- a/tools/timeoutcmd/timeoutcmd.go
+++ b/tools/timeoutcmd/timeoutcmd.go
@@ -41,6 +41,18 @@ func (c *Command) AppendEnv(env string) {
 	c.cmd.Env = append(os.Environ(), env)
 }
 
+// SetEnvironment sets the environment for the process
+func (c *Command) SetEnvironment(envs map[string]string) {
+	newEnvs := make([]string, len(envs))
+	i := 0
+	for envKey, envValue := range envs {
+		newEnvs[i] = envKey + "=" + envValue
+		i++
+	}
+
+	c.cmd.Env = newEnvs
+}
+
 // SetStandardIO sets the input and outputs of the command.
 func (c *Command) SetStandardIO(in io.Reader, out, err io.Writer) {
 	c.cmd.Stdin, c.cmd.Stdout, c.cmd.Stderr = in, out, err

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -356,7 +356,8 @@ func GetSecretValues(secrets []envmanModels.EnvironmentItemModel) []string {
 }
 
 // EnvmanRun runs a command through envman.
-func EnvmanRun(envstorePth,
+func EnvmanRun(stepInputs map[string]string,
+	envstorePth,
 	workDirPth string,
 	cmdArgs []string,
 	timeout time.Duration,
@@ -388,7 +389,9 @@ func EnvmanRun(envstorePth,
 	cmd := timeoutcmd.New(workDirPth, "envman", args...)
 	cmd.SetStandardIO(inReader, outWriter, errWriter)
 	cmd.SetTimeout(timeout)
-	cmd.AppendEnv("PWD=" + workDirPth)
+
+	stepInputs["PWD"] = workDirPth
+	cmd.SetEnvironment(stepInputs)
 
 	err := cmd.Start()
 


### PR DESCRIPTION
- Environemnt is set directly to the command (Still the envman process).
The envstore is initialized, but it is empty.
Envman no longer needs to do environment expansion, and the Bitrise process
only needs to do it once.