### PR TITLE
[PLAT-892] Obscuring secrets with escaped newlines in output

### DIFF
--- a/_tests/integration/log_filter_test.go
+++ b/_tests/integration/log_filter_test.go
@@ -83,6 +83,17 @@ starts in a new line`)
 		require.NotContains(t, out, sshKeyLogChunk)
 	}
 
+	t.Log("escaped newlines")
+	{
+		cmd := command.New(binPath(), "run", "escaped_newline_test", "--config", configPth, "--inventory", secretsPth)
+		out, err := cmd.RunAndReturnTrimmedCombinedOutput()
+		require.NoError(t, err, out)
+		require.Contains(t, out, `SECRET_WITH_NEWLINES_IN_THE_MIDDLE: [REDACTED]
+SECRET_ENDING_WITH_NEWLINE: [REDACTED]
+starts in a new line`)
+		require.NotContains(t, out, sshKeyLogChunk)
+	}
+
 	t.Log("disable filtering test")
 	{
 		secretsPth = "log_filter_disabled_test_secrets.yml"

--- a/_tests/integration/log_filter_test_bitrise.yml
+++ b/_tests/integration/log_filter_test_bitrise.yml
@@ -36,3 +36,14 @@ workflows:
             set -e
             printf "SECRET_ENDING_WITH_NEWLINE: %s" "$SECRET_ENDING_WITH_NEWLINE"
             echo "starts in a new line"
+
+  escaped_newline_test:
+    steps:    
+    - script:
+        inputs:
+        - content: |
+            #!/usr/bin/env bash
+            set -e
+            echo 'SECRET_WITH_NEWLINES_IN_THE_MIDDLE: empty line after this\n\nand before this'
+            echo 'SECRET_ENDING_WITH_NEWLINE: ending with newline\n'
+            echo "starts in a new line"

--- a/tools/filterwriter/filterwriter.go
+++ b/tools/filterwriter/filterwriter.go
@@ -132,78 +132,66 @@ func (w *Writer) matchSecrets(lines [][]byte) (matchMap map[int][]int, partialMa
 	partialMatchIndexes = make(map[int]bool)
 
 	for secretIdx, secret := range w.secrets {
-		matchSecret(lines, secret, secretIdx, matchMap, partialMatchIndexes)
+		secretLine := secret[0] // every match should begin from the secret first line
+		var lineIndexes []int   // the indexes of lines which contains the secret's first line
 
-		var escapedSecret [][]byte
-		for _, line := range secret {
-			escapedLine := strings.ReplaceAll(string(line), "\n", `\n`)
-			escapedSecret = append(escapedSecret, []byte(escapedLine))
+		for i, line := range lines {
+			if bytes.Contains(line, secretLine) {
+				lineIndexes = append(lineIndexes, i)
+			}
 		}
-		matchSecret(lines, escapedSecret, secretIdx, matchMap, partialMatchIndexes)
+
+		if len(lineIndexes) == 0 {
+			// this secret can not be found in the lines
+			continue
+		}
+
+		for _, lineIdx := range lineIndexes {
+			if len(secret) == 1 {
+				// the single line secret found in the lines
+				indexes := matchMap[secretIdx]
+				matchMap[secretIdx] = append(indexes, lineIdx)
+				continue
+			}
+
+			// lineIdx. line matches to a multi line secret's first line
+			// if lines has more line, every subsequent line must match to the secret's subsequent lines
+			partialMatch := true
+			match := false
+
+			for i := lineIdx + 1; i < len(lines); i++ {
+				secretLineIdx := i - lineIdx
+
+				secretLine = secret[secretLineIdx]
+				line := lines[i]
+
+				if !bytes.Contains(line, secretLine) {
+					partialMatch = false
+					break
+				}
+
+				if secretLineIdx == len(secret)-1 {
+					// multi line secret found in the lines
+					match = true
+					break
+				}
+			}
+
+			if match {
+				// multi line secret found in the lines
+				indexes := matchMap[secretIdx]
+				matchMap[secretIdx] = append(indexes, lineIdx)
+				continue
+			}
+
+			if partialMatch {
+				// this secret partially can be found in the lines
+				partialMatchIndexes[lineIdx] = true
+			}
+		}
 	}
 
 	return
-}
-
-func matchSecret(lines [][]byte, secret [][]byte, secretIdx int, matchMap map[int][]int, partialMatchIndexes map[int]bool) {
-	secretLine := secret[0] // every match should begin from the secret first line
-	var lineIndexes []int   // the indexes of lines which contains the secret's first line
-
-	for i, line := range lines {
-		if bytes.Contains(line, secretLine) {
-			lineIndexes = append(lineIndexes, i)
-		}
-	}
-
-	if len(lineIndexes) == 0 {
-		// this secret can not be found in the lines
-		return
-	}
-
-	for _, lineIdx := range lineIndexes {
-		if len(secret) == 1 {
-			// the single line secret found in the lines
-			indexes := matchMap[secretIdx]
-			matchMap[secretIdx] = append(indexes, lineIdx)
-
-			continue
-		}
-
-		// lineIdx. line matches to a multi line secret's first line
-		// if lines has more line, every subsequent line must match to the secret's subsequent lines
-		partialMatch := true
-		match := false
-
-		for i := lineIdx + 1; i < len(lines); i++ {
-			secretLineIdx := i - lineIdx
-
-			secretLine = secret[secretLineIdx]
-			line := lines[i]
-
-			if !bytes.Contains(line, secretLine) {
-				partialMatch = false
-				break
-			}
-
-			if secretLineIdx == len(secret)-1 {
-				// multi line secret found in the lines
-				match = true
-				break
-			}
-		}
-
-		if match {
-			// multi line secret found in the lines
-			indexes := matchMap[secretIdx]
-			matchMap[secretIdx] = append(indexes, lineIdx)
-			continue
-		}
-
-		if partialMatch {
-			// this secret partially can be found in the lines
-			partialMatchIndexes[lineIdx] = true
-		}
-	}
 }
 
 // linesToKeepRange returns the first line index needs to be observed

--- a/tools/filterwriter/filterwriter.go
+++ b/tools/filterwriter/filterwriter.go
@@ -29,9 +29,17 @@ type Writer struct {
 
 // New ...
 func New(secrets []string, target io.Writer) *Writer {
+	extendedSecrets := secrets
+	// adding transformed secrets with escaped newline characters to ensure that these are also obscured if found in logs
+	for _, secret := range secrets {
+		if strings.Contains(secret, "\n") {
+			extendedSecrets = append(extendedSecrets, strings.ReplaceAll(secret, "\n", `\n`))
+		}
+	}
+
 	return &Writer{
 		writer:  target,
-		secrets: secretsByteList(secrets),
+		secrets: secretsByteList(extendedSecrets),
 	}
 }
 

--- a/tools/filterwriter/filterwriter.go
+++ b/tools/filterwriter/filterwriter.go
@@ -131,7 +131,6 @@ func (w *Writer) matchSecrets(lines [][]byte) (matchMap map[int][]int, partialMa
 			escapedLine := strings.ReplaceAll(string(line), "\n", `\n`)
 			escapedSecret = append(escapedSecret, []byte(escapedLine))
 		}
-
 		matchSecret(lines, escapedSecret, secretIdx, matchMap, partialMatchIndexes)
 	}
 

--- a/tools/filterwriter/filterwriter_test.go
+++ b/tools/filterwriter/filterwriter_test.go
@@ -194,6 +194,9 @@ func TestSecrets(t *testing.T) {
 		[][]byte{[]byte("c\n"), []byte("b")},
 		[][]byte{[]byte("x\n"), []byte("c\n"), []byte("b\n"), []byte("d")},
 		[][]byte{[]byte("f")},
+		[][]byte{[]byte(`a\nb\nc`)},
+		[][]byte{[]byte(`c\nb`)},
+		[][]byte{[]byte(`x\nc\nb\nd`)},
 	}, out.secrets)
 }
 


### PR DESCRIPTION
Related to this: https://bitrise.atlassian.net/browse/PLAT-889

This code ensures that secrets stored in env vars are obscured correctly even if they are printed with escaped newlines (literal `\n`).