### PR TITLE
Introduce triggers for plugins.

### DIFF
--- a/cli/run_test.go
+++ b/cli/run_test.go
@@ -1542,25 +1542,25 @@ route_map:
 			"GivenPluginRegisteredForTrigger_ThenPluginTriggeredOnce",
 			"trigger: DidFinishRun",
 			"trigger: DidFinishRun",
-			[]string{"-event DidFinishRun"},
+			[]string{"event:DidFinishRun"},
 		},
 		{
 			"GivenPluginRegisteredForSingleTriggers_ThenPluginTriggeredOnce",
 			"triggers:\n  - DidFinishRun",
 			"triggers:\n      - DidFinishRun",
-			[]string{"-event DidFinishRun"},
+			[]string{"event:DidFinishRun"},
 		},
 		{
 			"GivenPluginRegisteredForMultipleTriggers_ThenPluginTriggeredTwice",
 			"triggers:\n  - WillStartRun\n  - DidFinishRun",
 			"triggers:\n      - WillStartRun\n      - DidFinishRun",
-			[]string{"-event WillStartRun", "-event DidFinishRun"},
+			[]string{"event:WillStartRun", "event:DidFinishRun"},
 		},
 		{
 			"GivenPluginRegisteredForMultipleTriggers_ThenPluginTriggeredTwice",
 			"trigger: WillStartRun\ntriggers:\n  - DidFinishRun",
 			"trigger: WillStartRun\n    triggers:\n      - DidFinishRun",
-			[]string{"-event WillStartRun", "-event DidFinishRun"},
+			[]string{"event:WillStartRun", "event:DidFinishRun"},
 		},
 	}
 
@@ -1614,7 +1614,7 @@ func givenPlugin(t *testing.T, pluginContent, pluginName, pluginSpec string) str
 	pluginScriptPth := filepath.Join(pluginSrcDir, "bitrise-plugin.sh")
 	pluginSHContent := fmt.Sprintf(`
   #!/bin/bash
-  echo "$1 $2"
+  echo "$1"
   echo "%s-called"
   `, pluginName)
 	write(t, pluginSHContent, pluginScriptPth)

--- a/cli/run_test.go
+++ b/cli/run_test.go
@@ -1542,25 +1542,25 @@ route_map:
 			"GivenPluginRegisteredForTrigger_ThenPluginTriggeredOnce",
 			"trigger: DidFinishRun",
 			"trigger: DidFinishRun",
-			[]string{"event:DidFinishRun"},
+			[]string{`"event_name":"DidFinishRun"`},
 		},
 		{
 			"GivenPluginRegisteredForSingleTriggers_ThenPluginTriggeredOnce",
 			"triggers:\n  - DidFinishRun",
 			"triggers:\n      - DidFinishRun",
-			[]string{"event:DidFinishRun"},
+			[]string{`"event_name":"DidFinishRun"`},
 		},
 		{
 			"GivenPluginRegisteredForMultipleTriggers_ThenPluginTriggeredTwice",
 			"triggers:\n  - WillStartRun\n  - DidFinishRun",
 			"triggers:\n      - WillStartRun\n      - DidFinishRun",
-			[]string{"event:WillStartRun", "event:DidFinishRun"},
+			[]string{`"event_name":"WillStartRun"`, `"event_name":"DidFinishRun"`},
 		},
 		{
 			"GivenPluginRegisteredForMultipleTriggers_ThenPluginTriggeredTwice",
 			"trigger: WillStartRun\ntriggers:\n  - DidFinishRun",
 			"trigger: WillStartRun\n    triggers:\n      - DidFinishRun",
-			[]string{"event:WillStartRun", "event:DidFinishRun"},
+			[]string{`"event_name":"WillStartRun"`, `"event_name":"DidFinishRun"`},
 		},
 	}
 
@@ -1614,7 +1614,9 @@ func givenPlugin(t *testing.T, pluginContent, pluginName, pluginSpec string) str
 	pluginScriptPth := filepath.Join(pluginSrcDir, "bitrise-plugin.sh")
 	pluginSHContent := fmt.Sprintf(`
   #!/bin/bash
-  echo "$1"
+
+  cat /dev/stdin
+
   echo "%s-called"
   `, pluginName)
 	write(t, pluginSHContent, pluginScriptPth)

--- a/cli/run_test.go
+++ b/cli/run_test.go
@@ -2,16 +2,23 @@ package cli
 
 import (
 	"fmt"
+	"index/suffixarray"
+	"io/ioutil"
 	"os"
 	"path/filepath"
+	"regexp"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/bitrise-io/bitrise/bitrise"
 	"github.com/bitrise-io/bitrise/configs"
 	"github.com/bitrise-io/bitrise/models"
+	"github.com/bitrise-io/bitrise/plugins"
 	envmanModels "github.com/bitrise-io/envman/models"
+	"github.com/bitrise-io/go-utils/fileutil"
 	"github.com/bitrise-io/go-utils/pathutil"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -1487,4 +1494,162 @@ workflows:
 	last, err := lastWorkflowIDInConfig("target", config)
 	require.NoError(t, err)
 	require.Equal(t, "after2", last)
+}
+
+func TestPluginTriggered(t *testing.T) {
+	bitriseYML := `
+  format_version: 1.3.0
+  default_step_lib_source: "https://github.com/bitrise-io/bitrise-steplib.git"
+  
+  workflows:
+    test:
+      steps:
+      - script:
+          inputs:
+          - content: |
+              #!/bin/bash
+              echo "test"
+  `
+
+	pluginYMFormat := `
+name: testplugin
+description: |-
+  Manage Bitrise CLI steps
+%s
+executable:
+  osx: {executable_url}
+  linux: {executable_url}
+`
+
+	pluginSpecYMLFormat := `
+route_map:
+  testplugin:
+    name: testplugin
+    source: https://whatever.com
+    version: 1.3.0
+    commit_hash: ""
+    %s
+    latest_available_version: ""
+`
+
+	type testCase struct {
+		name                 string
+		pluginTrigger        string
+		specTrigger          string
+		expectedTriggerCount int
+	}
+
+	testCases := []testCase{
+		{
+			"GivenPluginRegisteredForTrigger_ThenPluginTriggeredOnce",
+			"trigger: DidFinishRun",
+			"trigger: DidFinishRun",
+			1,
+		},
+		{
+			"GivenPluginRegisteredForSingleTriggers_ThenPluginTriggeredOnce",
+			"triggers:\n  - DidFinishRun",
+			"triggers:\n      - DidFinishRun",
+			1},
+		{
+			"GivenPluginRegisteredForMultipleTriggers_ThenPluginTriggeredTwice",
+			"triggers:\n  - WillStartRun\n  - DidFinishRun",
+			"triggers:\n      - WillStartRun\n      - DidFinishRun",
+			2},
+	}
+
+	for _, test := range testCases {
+		t.Log(test.name)
+		{
+			// Given
+			config := givenWorkflowLoaded(t, bitriseYML)
+			pluginYML := fmt.Sprintf(pluginYMFormat, test.pluginTrigger)
+			pluginSpec := fmt.Sprintf(pluginSpecYMLFormat, test.specTrigger)
+			givenPluginInstalled(t, pluginYML, "testplugin", pluginSpec)
+
+			// When
+			var err error
+			output := captureOutput(func() {
+				_, err = runWorkflowWithConfiguration(time.Now(), "test", config, []envmanModels.EnvironmentItemModel{})
+			})
+
+			// Then
+			require.NoError(t, err)
+			assert.Equal(t, test.expectedTriggerCount, occurances("testplugin-called", output))
+		}
+	}
+}
+
+func givenWorkflowLoaded(t *testing.T, workflow string) models.BitriseDataModel {
+	require.NoError(t, configs.InitPaths())
+	config, warnings, err := bitrise.ConfigModelFromYAMLBytes([]byte(workflow))
+	require.NoError(t, err)
+	require.Equal(t, 0, len(warnings))
+
+	return config
+}
+
+func givenPluginInstalled(t *testing.T, pluginContent, pluginName, pluginSpec string) {
+	bitrisePath := givenPlugin(t, pluginContent, pluginName, pluginSpec)
+	plugins.ForceInitPaths(bitrisePath)
+}
+
+func givenPlugin(t *testing.T, pluginContent, pluginName, pluginSpec string) string {
+	tmpDir, err := pathutil.NormalizedOSTempDirPath("__plugin_test__")
+	require.NoError(t, err)
+
+	bitriseDir := filepath.Join(tmpDir, ".bitrise")
+	pluginsDir := filepath.Join(bitriseDir, "plugins")
+	pluginSrcDir := filepath.Join(pluginsDir, pluginName, "src")
+
+	// Create bitrise-plugin.sh
+	pluginScriptPth := filepath.Join(pluginSrcDir, "bitrise-plugin.sh")
+	pluginSHContent := fmt.Sprintf(`
+  #!/bin/bash
+  echo "%s-called"
+  `, pluginName)
+	write(t, pluginSHContent, pluginScriptPth)
+	os.Chmod(pluginScriptPth, 0777)
+
+	// Create bitrise-plugin.yml
+	pluginYMLContent := strings.ReplaceAll(pluginContent, "{executable_url}", "file://"+pluginScriptPth)
+	pluginYMLPth := filepath.Join(pluginSrcDir, "bitrise-plugin.yml")
+	write(t, pluginYMLContent, pluginYMLPth)
+
+	// Create spec.yml
+	specYMLContent := strings.ReplaceAll(pluginSpec, "{executable_url}", "file://"+pluginScriptPth)
+	specYMLPth := filepath.Join(pluginsDir, "spec.yml")
+	write(t, specYMLContent, specYMLPth)
+
+	return bitriseDir
+}
+
+func captureOutput(function func()) string {
+	old := os.Stdout // keep backup of the real stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	function()
+
+	w.Close()
+	out, _ := ioutil.ReadAll(r)
+	os.Stdout = old
+
+	return string(out)
+}
+
+func write(t *testing.T, content, toPth string) {
+	toDir := filepath.Dir(toPth)
+	exist, err := pathutil.IsDirExists(toDir)
+	require.NoError(t, err)
+	if !exist {
+		require.NoError(t, os.MkdirAll(toDir, 0700))
+	}
+	require.NoError(t, fileutil.WriteStringToFile(toPth, content))
+}
+
+func occurances(subString string, inString string) int {
+	regexp := regexp.MustCompile(subString)
+	index := suffixarray.New([]byte(inString))
+	return len(index.FindAllIndex(regexp, -1))
 }

--- a/cli/run_util.go
+++ b/cli/run_util.go
@@ -1093,6 +1093,7 @@ func runWorkflowWithConfiguration(
 
 	// Trigger WillStartRun
 	buildRunStartModel := models.BuildRunStartModel{
+		EventName:   string(plugins.WillStartRun),
 		StartTime:   startTime,
 		ProjectType: bitriseConfig.ProjectType,
 	}
@@ -1120,6 +1121,7 @@ func runWorkflowWithConfiguration(
 	bitrise.PrintSummary(buildRunResults)
 
 	// Trigger WorkflowRunDidFinish
+	buildRunResults.EventName = string(plugins.DidFinishRun)
 	if err := plugins.TriggerEvent(plugins.DidFinishRun, buildRunResults); err != nil {
 		log.Warnf("Failed to trigger WorkflowRunDidFinish, error: %s", err)
 	}

--- a/cli/run_util.go
+++ b/cli/run_util.go
@@ -1091,6 +1091,15 @@ func runWorkflowWithConfiguration(
 		}
 	}
 
+	// Trigger WillStartRun
+	buildRunStartModel := models.BuildRunStartModel{
+		StartTime:   startTime,
+		ProjectType: bitriseConfig.ProjectType,
+	}
+	if err := plugins.TriggerEvent(plugins.WillStartRun, buildRunStartModel); err != nil {
+		log.Warnf("Failed to trigger WillStartRun, error: %s", err)
+	}
+
 	//
 	buildRunResults := models.BuildRunResultsModel{
 		StartTime:      startTime,

--- a/models/models.go
+++ b/models/models.go
@@ -125,12 +125,14 @@ type StepIDData struct {
 
 // BuildRunStartModel ...
 type BuildRunStartModel struct {
+	EventName   string    `json:"event_name" yaml:"event_name"`
 	ProjectType string    `json:"project_type" yaml:"project_type"`
 	StartTime   time.Time `json:"start_time" yaml:"start_time"`
 }
 
 // BuildRunResultsModel ...
 type BuildRunResultsModel struct {
+	EventName            string                `json:"event_name" yaml:"event_name"`
 	ProjectType          string                `json:"project_type" yaml:"project_type"`
 	StartTime            time.Time             `json:"start_time" yaml:"start_time"`
 	StepmanUpdates       map[string]int        `json:"stepman_updates" yaml:"stepman_updates"`

--- a/models/models.go
+++ b/models/models.go
@@ -123,6 +123,12 @@ type StepIDData struct {
 	Version string
 }
 
+// BuildRunStartModel ...
+type BuildRunStartModel struct {
+	ProjectType string    `json:"project_type" yaml:"project_type"`
+	StartTime   time.Time `json:"start_time" yaml:"start_time"`
+}
+
 // BuildRunResultsModel ...
 type BuildRunResultsModel struct {
 	ProjectType          string                `json:"project_type" yaml:"project_type"`

--- a/plugins/events.go
+++ b/plugins/events.go
@@ -3,12 +3,17 @@ package plugins
 import (
 	"encoding/json"
 	"fmt"
+
+	"github.com/bitrise-io/go-utils/sliceutil"
 )
 
 // TriggerEventName ...
 type TriggerEventName string
 
 const (
+	// WillStartRun ...
+	WillStartRun TriggerEventName = "WillStartRun"
+
 	// DidFinishRun ...
 	DidFinishRun TriggerEventName = "DidFinishRun"
 )
@@ -50,7 +55,8 @@ func LoadPlugins(eventName string) ([]Plugin, error) {
 
 	pluginNames := []string{}
 	for name, route := range routing.RouteMap {
-		if route.TriggerEvent == eventName {
+		if route.TriggerEvent == eventName ||
+			sliceutil.IsStringInSlice(eventName, route.TriggerEvents) {
 			pluginNames = append(pluginNames, name)
 		}
 	}

--- a/plugins/events.go
+++ b/plugins/events.go
@@ -38,7 +38,7 @@ func TriggerEvent(name TriggerEventName, payload interface{}) error {
 
 	// Run plugins
 	for _, plugin := range plugins {
-		if err := RunPluginByEvent(name, plugin, pluginConfig, payloadBytes); err != nil {
+		if err := RunPluginByEvent(plugin, pluginConfig, payloadBytes); err != nil {
 			return err
 		}
 	}

--- a/plugins/events.go
+++ b/plugins/events.go
@@ -38,7 +38,7 @@ func TriggerEvent(name TriggerEventName, payload interface{}) error {
 
 	// Run plugins
 	for _, plugin := range plugins {
-		if err := RunPluginByEvent(plugin, pluginConfig, payloadBytes); err != nil {
+		if err := RunPluginByEvent(name, plugin, pluginConfig, payloadBytes); err != nil {
 			return err
 		}
 	}

--- a/plugins/models.go
+++ b/plugins/models.go
@@ -11,13 +11,14 @@ const (
 
 // PluginRoute ...
 type PluginRoute struct {
-	Name                   string `yaml:"name"`
-	Source                 string `yaml:"source"`
-	Version                string `yaml:"version"`
-	CommitHash             string `yaml:"commit_hash"`
-	Executable             string `yaml:"executable"`
-	TriggerEvent           string `yaml:"trigger"`
-	LatestAvailableVersion string `yaml:"latest_available_version"`
+	Name                   string   `yaml:"name"`
+	Source                 string   `yaml:"source"`
+	Version                string   `yaml:"version"`
+	CommitHash             string   `yaml:"commit_hash"`
+	Executable             string   `yaml:"executable"`
+	TriggerEvent           string   `yaml:"trigger"`
+	TriggerEvents          []string `yaml:"triggers"`
+	LatestAvailableVersion string   `yaml:"latest_available_version"`
 }
 
 // PluginRouting ...
@@ -40,11 +41,12 @@ type Requirement struct {
 
 // Plugin ...
 type Plugin struct {
-	Name         string          `yaml:"name,omitempty"`
-	Description  string          `yaml:"description,omitempty"`
-	Executable   ExecutableModel `yaml:"executable,omitempty"`
-	TriggerEvent string          `yaml:"trigger,omitempty"`
-	Requirements []Requirement   `yaml:"requirements,omitempty"`
+	Name          string          `yaml:"name,omitempty"`
+	Description   string          `yaml:"description,omitempty"`
+	Executable    ExecutableModel `yaml:"executable,omitempty"`
+	TriggerEvent  string          `yaml:"trigger,omitempty"`
+	TriggerEvents []string        `yaml:"triggers,omitempty"`
+	Requirements  []Requirement   `yaml:"requirements,omitempty"`
 }
 
 // PluginInfoModel ...

--- a/plugins/paths.go
+++ b/plugins/paths.go
@@ -184,3 +184,9 @@ func InitPaths() error {
 
 	return nil
 }
+
+// ForceInitPaths ...
+func ForceInitPaths(bitriseDir string) {
+	pluginsDir = filepath.Join(bitriseDir, pluginsDirName)
+	pluginsRoutingPth = filepath.Join(pluginsDir, pluginSpecFileName)
+}

--- a/plugins/run.go
+++ b/plugins/run.go
@@ -16,7 +16,7 @@ import (
 )
 
 const (
-	eventArgument = "event"
+	eventArgument = "event:"
 )
 
 //=======================================
@@ -67,8 +67,7 @@ func RunPluginByEvent(eventName TriggerEventName, plugin Plugin, pluginConfig Pl
 	pluginConfig[PluginConfigPluginModeKey] = string(TriggerMode)
 
 	args := []string{
-		"-" + eventArgument,
-		string(eventName),
+		eventArgument + string(eventName),
 	}
 
 	return runPlugin(plugin, args, pluginConfig, input)

--- a/plugins/run.go
+++ b/plugins/run.go
@@ -15,10 +15,6 @@ import (
 	"github.com/bitrise-io/go-utils/pathutil"
 )
 
-const (
-	eventArgument = "event:"
-)
-
 //=======================================
 // Util
 //=======================================
@@ -63,14 +59,10 @@ func strip(str string) string {
 //=======================================
 
 // RunPluginByEvent ...
-func RunPluginByEvent(eventName TriggerEventName, plugin Plugin, pluginConfig PluginConfig, input []byte) error {
+func RunPluginByEvent(plugin Plugin, pluginConfig PluginConfig, input []byte) error {
 	pluginConfig[PluginConfigPluginModeKey] = string(TriggerMode)
 
-	args := []string{
-		eventArgument + string(eventName),
-	}
-
-	return runPlugin(plugin, args, pluginConfig, input)
+	return runPlugin(plugin, []string{}, pluginConfig, input)
 }
 
 // RunPluginByCommand ...

--- a/plugins/run.go
+++ b/plugins/run.go
@@ -15,6 +15,10 @@ import (
 	"github.com/bitrise-io/go-utils/pathutil"
 )
 
+const (
+	eventArgument = "event"
+)
+
 //=======================================
 // Util
 //=======================================
@@ -59,10 +63,15 @@ func strip(str string) string {
 //=======================================
 
 // RunPluginByEvent ...
-func RunPluginByEvent(plugin Plugin, pluginConfig PluginConfig, input []byte) error {
+func RunPluginByEvent(eventName TriggerEventName, plugin Plugin, pluginConfig PluginConfig, input []byte) error {
 	pluginConfig[PluginConfigPluginModeKey] = string(TriggerMode)
 
-	return runPlugin(plugin, []string{}, pluginConfig, input)
+	args := []string{
+		"-" + eventArgument,
+		string(eventName),
+	}
+
+	return runPlugin(plugin, args, pluginConfig, input)
 }
 
 // RunPluginByCommand ...


### PR DESCRIPTION
### Checklist

- Requires _MINOR_ [version update](https://semver.org/)

### Context

Extend Bitrise CLI with trigger capability so plugins are capable of listening to multiple Triggers

Resolves: [STEP-377](https://bitrise.atlassian.net/browse/STEP-377)

### Changes

- Extended both `Plugin` and `PluginRoute` with `TriggerEvents` property to enable adding multiple events to a plugin.
- Introduce `WillStartRun` trigger which is called before the build is started.
- Introduce `BuildRunStartModel`
- Added `TestPluginTriggered` test in `run_test.go` to cover plugins being called.
  - Created a `ForceInitPaths` function in  `plugins` package to mock the plugins installed. 

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->