### PR TITLE
Append `--formula` arugment to "brew list"

### DIFF
--- a/cli/update.go
+++ b/cli/update.go
@@ -100,9 +100,8 @@ func installedWithBrew() (bool, error) {
 		return false, nil
 	}
 
-	out, err := exec.Command("brew", "list").CombinedOutput()
+	out, err := exec.Command("brew", "list", "--formula").Output()
 	if err != nil {
-		log.Errorf("brew list failed, %s", string(out))
 		return false, err
 	}
 	formulas := strings.Split(string(out), "\n")

--- a/cli/update.go
+++ b/cli/update.go
@@ -102,6 +102,7 @@ func installedWithBrew() (bool, error) {
 
 	out, err := exec.Command("brew", "list").CombinedOutput()
 	if err != nil {
+		log.Errorf("brew list failed, %s", string(out))
 		return false, err
 	}
 	formulas := strings.Split(string(out), "\n")

--- a/cli/update.go
+++ b/cli/update.go
@@ -100,7 +100,7 @@ func installedWithBrew() (bool, error) {
 		return false, nil
 	}
 
-	out, err := exec.Command("brew", "list").Output()
+	out, err := exec.Command("brew", "list").CombinedOutput()
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
Fixing failing CI due to the change in brew.

> brew list failed, Error: Calling `brew list` to only list formulae is disabled! Use `brew list --formula` instead.
