### PR TITLE
Remove temporary directory generation for `BITRISE_CACHE_DIR`

### DIFF
--- a/configs/paths.go
+++ b/configs/paths.go
@@ -38,8 +38,6 @@ const (
 	BitriseTestDeployDirEnvKey = "BITRISE_TEST_DEPLOY_DIR"
 	// BitrisePerStepTestResultDirEnvKey is a unique subdirectory in BITRISE_TEST_DEPLOY_DIR for each step run, steps should place test reports and attachments into this directory
 	BitrisePerStepTestResultDirEnvKey = "BITRISE_TEST_RESULT_DIR"
-	// BitriseCacheDirEnvKey ...
-	BitriseCacheDirEnvKey = "BITRISE_CACHE_DIR"
 	// BitriseTmpDirEnvKey ...
 	BitriseTmpDirEnvKey = "BITRISE_TMP_DIR"
 )
@@ -188,18 +186,6 @@ func InitPaths() error {
 
 		if err := os.Setenv(BitriseTestDeployDirEnvKey, testsDir); err != nil {
 			return fmt.Errorf("Failed to set %s, error: %s", BitriseTestDeployDirEnvKey, err)
-		}
-	}
-
-	// BITRISE_CACHE_DIR
-	if os.Getenv(BitriseCacheDirEnvKey) == "" {
-		cacheDir, err := pathutil.NormalizedOSTempDirPath("cache")
-		if err != nil {
-			return fmt.Errorf("Failed to set cache dir, error: %s", err)
-		}
-
-		if err := os.Setenv(BitriseCacheDirEnvKey, cacheDir); err != nil {
-			return fmt.Errorf("Failed to set BITRISE_CACHE_DIR, error: %s", err)
 		}
 	}
 

--- a/configs/paths_test.go
+++ b/configs/paths_test.go
@@ -88,21 +88,6 @@ func TestInitPaths(t *testing.T) {
 	require.Equal(t, "$HOME/test", os.Getenv(BitriseTestDeployDirEnvKey))
 
 	//
-	// BITRISE_CACHE_DIR
-
-	// Unset BITRISE_CACHE_DIR -> after InitPaths BITRISE_CACHE_DIR should be temp dir
-	if os.Getenv(BitriseCacheDirEnvKey) != "" {
-		require.Equal(t, nil, os.Unsetenv(BitriseCacheDirEnvKey))
-	}
-	require.Equal(t, nil, InitPaths())
-	require.NotEqual(t, "", os.Getenv(BitriseCacheDirEnvKey))
-
-	// Set BITRISE_CACHE_DIR -> after InitPaths BITRISE_CACHE_DIR should keep content
-	require.Equal(t, nil, os.Setenv(BitriseCacheDirEnvKey, "$HOME/test"))
-	require.Equal(t, nil, InitPaths())
-	require.Equal(t, "$HOME/test", os.Getenv(BitriseCacheDirEnvKey))
-
-	//
 	// BITRISE_TMP_DIR
 
 	// Unset BITRISE_TMP_DIR -> after InitPaths BITRISE_TMP_DIR should be temp dir


### PR DESCRIPTION
Having a temporary directory created to be included in the cache push
step has no value as it changes on each workflow run. Anything put there
would be dropped by the next iteration and the user would not be able
to access the content easily anyway.

[STEP-447]

[STEP-447]: https://bitrise.atlassian.net/browse/STEP-447