### PR TITLE
Add section about additional command-line arguments to Step Development Guidelines

### DIFF
--- a/_docs/step-development-guideline.md
+++ b/_docs/step-development-guideline.md
@@ -189,3 +189,16 @@ Submit your step's icon by:
 
 - adding the svg file into your steplib fork repo at: STEPLIB_FORK_ROOT/steps/YOUR_STEP_ID/assets/icon.svg
 - creating a new pull request to the [steplib repo](https://github.com/bitrise-io/bitrise-steplib)
+
+## Provide input for additional command-line arguments
+For steps that are designed to run or wrap around a command-line tool, always provide an input for additional arguments. This is to ensure users can freely customize the execution of such a command-line tool as dedicated inputs for each argument do not necessarily exist.
+
+For example, Xcode Archive is a step that runs xcodebuild and has an input for additional xcodebuild_options:
+
+```yaml
+- xcodebuild_options:
+  opts:
+    category: xcodebuild configuration
+    title: Additional options for the xcodebuild command
+    summary: Additional options to be added to the executed xcodebuild command.
+```


### PR DESCRIPTION
## Context
* Many steps run as a wrapper around specific command-line tools, such as `xcodebuild`.
* Although steps try to provide inputs for managing most arguments of those tools for ease of use, this is not always the case.
* Therefore, providing additional command-line arguments should always be possible via a dedicated step input (e.g. via `xcodebuild_options` in case of Xcode Archive).
* Steps should follow this as a best practice.

## Changes
* **Added a section about additional command-line arguments to Step Development Guidelines.**