### PR TITLE
Add option to serialize analytics for debugging

### DIFF
--- a/analytics/state_checker.go
+++ b/analytics/state_checker.go
@@ -40,6 +40,5 @@ func (s stateChecker) Enabled() bool {
 }
 
 func (s stateChecker) UseAsync() bool {
-	asyncDisabled := s.envRepository.Get(V2AsyncDisabledEnvKey)
-	return asyncDisabled == "" || asyncDisabled == trueEnv
+	return s.envRepository.Get(V2AsyncDisabledEnvKey) != trueEnv
 }

--- a/analytics/state_checker.go
+++ b/analytics/state_checker.go
@@ -4,15 +4,21 @@ import (
 	"github.com/bitrise-io/go-utils/v2/env"
 )
 
-// DisabledEnvKey controls both the old (analytics plugin) and new (v2) implementations
-const DisabledEnvKey = "BITRISE_ANALYTICS_DISABLED"
+const (
+	// DisabledEnvKey controls both the old (analytics plugin) and new (v2) implementations
+	DisabledEnvKey = "BITRISE_ANALYTICS_DISABLED"
+	// V2DisabledEnvKey controls only the new (v2) implementation
+	V2DisabledEnvKey = "BITRISE_ANALYTICS_V2_DISABLED"
+	// V2AsyncEnvKey can be used to disable the default async queriess
+	V2AsyncEnvKey = "BITRISE_ANALYTICS_V2_ASYNC"
 
-// V2DisabledEnvKey controls only the new (v2) implementation
-const V2DisabledEnvKey = "BITRISE_ANALYTICS_V2_DISABLED"
+	trueEnv = "true"
+)
 
 // StateChecker ...
 type StateChecker interface {
 	Enabled() bool
+	UseAsync() bool
 }
 
 type stateChecker struct {
@@ -26,9 +32,13 @@ func NewStateChecker(repository env.Repository) StateChecker {
 
 // Enabled ...
 func (s stateChecker) Enabled() bool {
-	if s.envRepository.Get(V2DisabledEnvKey) == "true" {
+	if s.envRepository.Get(V2DisabledEnvKey) == trueEnv {
 		return false
 	}
 
-	return s.envRepository.Get(DisabledEnvKey) != "true"
+	return s.envRepository.Get(DisabledEnvKey) != trueEnv
+}
+
+func (s stateChecker) UseAsync() bool {
+	return s.envRepository.Get(V2AsyncEnvKey) == "" || s.envRepository.Get(V2AsyncEnvKey) == trueEnv
 }

--- a/analytics/state_checker.go
+++ b/analytics/state_checker.go
@@ -9,8 +9,8 @@ const (
 	DisabledEnvKey = "BITRISE_ANALYTICS_DISABLED"
 	// V2DisabledEnvKey controls only the new (v2) implementation
 	V2DisabledEnvKey = "BITRISE_ANALYTICS_V2_DISABLED"
-	// V2AsyncEnvKey can be used to disable the default async queries
-	V2AsyncEnvKey = "BITRISE_ANALYTICS_V2_ASYNC"
+	// V2AsyncDisabledEnvKey can be used to disable the default async queries
+	V2AsyncDisabledEnvKey = "BITRISE_ANALYTICS_V2_ASYNC_DISABLED"
 
 	trueEnv = "true"
 )
@@ -40,5 +40,5 @@ func (s stateChecker) Enabled() bool {
 }
 
 func (s stateChecker) UseAsync() bool {
-	return !(s.envRepository.Get(V2AsyncEnvKey) == "false")
+	return s.envRepository.Get(V2AsyncDisabledEnvKey) == trueEnv
 }

--- a/analytics/state_checker.go
+++ b/analytics/state_checker.go
@@ -9,7 +9,7 @@ const (
 	DisabledEnvKey = "BITRISE_ANALYTICS_DISABLED"
 	// V2DisabledEnvKey controls only the new (v2) implementation
 	V2DisabledEnvKey = "BITRISE_ANALYTICS_V2_DISABLED"
-	// V2AsyncEnvKey can be used to disable the default async queriess
+	// V2AsyncEnvKey can be used to disable the default async queries
 	V2AsyncEnvKey = "BITRISE_ANALYTICS_V2_ASYNC"
 
 	trueEnv = "true"
@@ -40,5 +40,5 @@ func (s stateChecker) Enabled() bool {
 }
 
 func (s stateChecker) UseAsync() bool {
-	return s.envRepository.Get(V2AsyncEnvKey) == "" || s.envRepository.Get(V2AsyncEnvKey) == trueEnv
+	return !(s.envRepository.Get(V2AsyncEnvKey) == "false")
 }

--- a/analytics/state_checker.go
+++ b/analytics/state_checker.go
@@ -40,5 +40,6 @@ func (s stateChecker) Enabled() bool {
 }
 
 func (s stateChecker) UseAsync() bool {
-	return s.envRepository.Get(V2AsyncDisabledEnvKey) == trueEnv
+	asyncDisabled := s.envRepository.Get(V2AsyncDisabledEnvKey)
+	return asyncDisabled == "" || asyncDisabled == trueEnv
 }

--- a/analytics/tracker.go
+++ b/analytics/tracker.go
@@ -114,12 +114,18 @@ func NewTracker(analyticsTracker analytics.Tracker, envRepository env.Repository
 // NewDefaultTracker ...
 func NewDefaultTracker() Tracker {
 	envRepository := env.NewRepository()
+	stateChecker := NewStateChecker(envRepository)
 
 	// Adapter between logrus and go-utils log package
 	logger := log.NewLogger()
 	logger.EnableDebugLog(logrus.GetLevel() == logrus.DebugLevel)
 
-	return NewTracker(analytics.NewDefaultTracker(logger), envRepository, NewStateChecker(envRepository))
+	tracker := analytics.NewDefaultSyncTracker(logger)
+	if stateChecker.UseAsync() {
+		tracker = analytics.NewDefaultTracker(logger)
+	}
+
+	return NewTracker(tracker, envRepository, stateChecker)
 }
 
 // SendWorkflowStarted sends `workflow_started` events. `parent_step_execution_id` can be used to filter those

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.16
 require (
 	github.com/bitrise-io/envman v0.0.0-20220401145857-d11e00a5dc55
 	github.com/bitrise-io/go-utils v1.0.2
-	github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.9
+	github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.10
 	github.com/bitrise-io/goinp v0.0.0-20211005113137-305e91b481f4
 	github.com/bitrise-io/gows v0.0.0-20211005113107-14f65e686b88
 	github.com/bitrise-io/stepman v0.0.0-20220718172049-e5ae0a09c2f2

--- a/go.sum
+++ b/go.sum
@@ -9,10 +9,8 @@ github.com/bitrise-io/go-utils v0.0.0-20210505121718-07411d72e36e/go.mod h1:nhda
 github.com/bitrise-io/go-utils v1.0.1/go.mod h1:ZY1DI+fEpZuFpO9szgDeICM4QbqoWVt0RSY3tRI1heY=
 github.com/bitrise-io/go-utils v1.0.2 h1:w4Mz2IvrgDzrFJECuHdvsK1LHO30cdtuy9bBa7Lw2c0=
 github.com/bitrise-io/go-utils v1.0.2/go.mod h1:ZY1DI+fEpZuFpO9szgDeICM4QbqoWVt0RSY3tRI1heY=
-github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.6 h1:hwxfNzeqqte0iMw558Z2n42WZwwuXAuuvluo766etQc=
-github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.6/go.mod h1:mysJdafur1ytXda0TeRsV+GxYCJFDU0QcCmYBgQf2Fc=
-github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.9 h1:IBExYm/rdlLWAL4qjFEOpEoUIUBi8ky9NbZtDZrPSIw=
-github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.9/go.mod h1:Ta/ards3Ih/3Q6X8tBtcj6zTHcNf1hRSXv1E8lPgIYk=
+github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.10 h1:b3sG8BNhsktfYd8YXraVQsKunFKMs0bRELXdx/zhTKA=
+github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.10/go.mod h1:Ta/ards3Ih/3Q6X8tBtcj6zTHcNf1hRSXv1E8lPgIYk=
 github.com/bitrise-io/goinp v0.0.0-20210504152833-8559b0680ab1/go.mod h1:iRbd8zAXLeNy+0gic0eqNCxXvDGe8ZEY/uYX2CCeAoo=
 github.com/bitrise-io/goinp v0.0.0-20211005113137-305e91b481f4 h1:ytUxnO7iSGHlNpbdjhDUefEM5WRy1kD2ElGfBA7r1PE=
 github.com/bitrise-io/goinp v0.0.0-20211005113137-305e91b481f4/go.mod h1:iRbd8zAXLeNy+0gic0eqNCxXvDGe8ZEY/uYX2CCeAoo=
@@ -96,8 +94,6 @@ golang.org/x/sys v0.0.0-20210503173754-0981d6026fa6/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211205182925-97ca703d548d/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a h1:dGzPydgVsqGcTRVwiLJ1jVbufYwmzD3LfVPLKsKg+0k=
-golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220712014510-0a85c31ab51e h1:NHvCuwuS43lGnYhten69ZWqi2QOj/CiDNcKbVqwVoew=
 golang.org/x/sys v0.0.0-20220712014510-0a85c31ab51e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=

--- a/vendor/github.com/bitrise-io/go-utils/v2/analytics/sync_track.go
+++ b/vendor/github.com/bitrise-io/go-utils/v2/analytics/sync_track.go
@@ -1,0 +1,39 @@
+package analytics
+
+import (
+	"bytes"
+	"time"
+
+	"github.com/bitrise-io/go-utils/v2/log"
+)
+
+const syncClientTimeout = 10 * time.Second
+
+type syncTracker struct {
+	client     Client
+	properties []Properties
+}
+
+// NewDefaultSyncTracker ...
+func NewDefaultSyncTracker(logger log.Logger, properties ...Properties) Tracker {
+	return NewSyncTracker(NewDefaultClient(logger, syncClientTimeout), properties...)
+}
+
+// NewSyncTracker ...
+func NewSyncTracker(client Client, properties ...Properties) Tracker {
+	t := syncTracker{client: client, properties: properties}
+	return &t
+}
+
+// Enqueue ...
+func (t syncTracker) Enqueue(eventName string, properties ...Properties) {
+	var b bytes.Buffer
+
+	newEvent(eventName, append(t.properties, properties...)).toJSON(&b)
+	t.client.Send(&b)
+}
+
+// Wait ...
+func (t syncTracker) Wait() {
+	// no-op in sync tracker
+}

--- a/vendor/github.com/bitrise-io/go-utils/v2/analytics/track.go
+++ b/vendor/github.com/bitrise-io/go-utils/v2/analytics/track.go
@@ -11,6 +11,7 @@ import (
 const poolSize = 10
 const bufferSize = 100
 const timeout = 30 * time.Second
+const asyncClientTimeout = 30 * time.Second
 
 // Tracker ...
 type Tracker interface {
@@ -28,7 +29,7 @@ type tracker struct {
 
 // NewDefaultTracker ...
 func NewDefaultTracker(logger log.Logger, properties ...Properties) Tracker {
-	return NewTracker(NewDefaultClient(logger), timeout, properties...)
+	return NewTracker(NewDefaultClient(logger, asyncClientTimeout), timeout, properties...)
 }
 
 // NewTracker ...

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -21,7 +21,7 @@ github.com/bitrise-io/go-utils/sliceutil
 github.com/bitrise-io/go-utils/stringutil
 github.com/bitrise-io/go-utils/urlutil
 github.com/bitrise-io/go-utils/versions
-# github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.9
+# github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.10
 ## explicit
 github.com/bitrise-io/go-utils/v2/analytics
 github.com/bitrise-io/go-utils/v2/env


### PR DESCRIPTION
The *BITRISE_ANALYTICS_V2_ASYNC* env var can be set to `false` to use analytics that blocks when called.