### PR TITLE
Set CLI version automatically by the release process

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -16,6 +16,7 @@ builds:
   - goos: linux
     goarch: arm64
   ldflags:
+  - -X github.com/bitrise-io/bitrise/version.VERSION={{ .Version }}
   - -X github.com/bitrise-io/bitrise/version.Commit={{ .FullCommit }}
   - -X github.com/bitrise-io/bitrise/version.BuildNumber={{ index .Env "BITRISE_BUILD_NUMBER" }}
 

--- a/_tests/integration/version_test.go
+++ b/_tests/integration/version_test.go
@@ -5,22 +5,12 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/bitrise-io/bitrise/version"
 	"github.com/bitrise-io/go-utils/command"
 	"github.com/stretchr/testify/require"
 )
 
-const (
-	expectedCLIVersion = "1.49.1"
-)
-
 func Test_VersionOutput(t *testing.T) {
-	t.Log("Version")
-	{
-		out, err := command.RunCommandAndReturnCombinedStdoutAndStderr(binPath(), "version")
-		require.NoError(t, err)
-		require.Equal(t, expectedCLIVersion, out)
-	}
-
 	t.Log("Version --full")
 	{
 		out, err := command.RunCommandAndReturnCombinedStdoutAndStderr(binPath(), "version", "--full")
@@ -32,7 +22,7 @@ format version: 11
 os: %s
 go: %s
 build number: 
-commit:`, expectedCLIVersion, expectedOSVersion, runtime.Version())
+commit:`, version.VERSION, expectedOSVersion, runtime.Version())
 
 		require.Equal(t, expectedVersionOut, out)
 	}

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -39,7 +39,7 @@ workflows:
 
             $current_bitrise setup
 
-            go test -v ./_tests/integration/...
+            go test -v ./_tests/integration/
 
   create-release:
     description: Creates Linux and Darwin binaries, then publishes a GitHub release

--- a/plugins/model_methods_test.go
+++ b/plugins/model_methods_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/bitrise-io/bitrise/version"
 	"github.com/bitrise-io/go-utils/fileutil"
 	"github.com/bitrise-io/go-utils/pathutil"
 	"github.com/stretchr/testify/assert"
@@ -13,6 +14,8 @@ import (
 )
 
 func TestParseAndValidatePluginFromYML(t *testing.T) {
+	version.VERSION = "1.49.3"
+
 	t.Log("simple plugin - with executables")
 	{
 		// Given

--- a/version/build.go
+++ b/version/build.go
@@ -1,5 +1,8 @@
 package version
 
+// VERSION is the main CLI version number. It's defined at build time using -ldflags
+var VERSION = ""
+
 // BuildNumber is the CI build number that creates the release. It's defined at build time using -ldflags
 var BuildNumber = ""
 

--- a/version/build.go
+++ b/version/build.go
@@ -1,7 +1,7 @@
 package version
 
 // VERSION is the main CLI version number. It's defined at build time using -ldflags
-var VERSION = ""
+var VERSION = "0.0.0-development"
 
 // BuildNumber is the CI build number that creates the release. It's defined at build time using -ldflags
 var BuildNumber = ""

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,0 @@
-package version
-
-// VERSION ...
-const VERSION = "1.49.1"


### PR DESCRIPTION
Instead of hardcoding the version number into the source code (which we forgot to increment multiple times), inject the version string using Goreleaser and LDFLAGS. This way the single source of truth is the git tag that triggers the release process (Goreleaser picks up that tag).

Note: I removed a version test case on purpose. This didn't save us from forgetting to bump the version, and one more place to edit the version number manually, so I don't think this test has any value.