### PR TITLE
[BE-198] Set different exit status for aborted builds

### DIFF
--- a/_tests/integration/helper.go
+++ b/_tests/integration/helper.go
@@ -29,6 +29,6 @@ func withRunningTimeCheck(f func(), ms time.Duration) time.Duration {
 	start := time.Now()
 	f()
 	end := time.Now()
- 
+
 	return end.Sub(start)
 }

--- a/_tests/integration/timeout_no_output_test.go
+++ b/_tests/integration/timeout_no_output_test.go
@@ -20,5 +20,5 @@ func Test_GivenHangDetectionOn_WhenOutputSlowsDown_ThenAborts(t *testing.T) {
 	cmd := command.New(binPath(), "run", "output_slows_down", "--config", configPath)
 	out, err := cmd.RunAndReturnTrimmedCombinedOutput()
 
-	require.Error(t, err, "Bitrise CLI did not abort hanged build, output: %s", out)
+	require.EqualError(t, err, "exit status 12", "Bitrise CLI did not abort hanged build, output: %s", out)
 }

--- a/_tests/integration/timeout_test.go
+++ b/_tests/integration/timeout_test.go
@@ -34,7 +34,7 @@ func Test_TimeoutTest(t *testing.T) {
 
 		out, err := cmd.RunAndReturnTrimmedCombinedOutput()
 
-		require.EqualError(t, err, "exit status 1", out)
+		require.EqualError(t, err, "exit status 11", out)
 
 		t.Log("Should exist")
 		{
@@ -71,7 +71,7 @@ func Test_TimeoutTest(t *testing.T) {
 
 		out, err := cmd.RunAndReturnTrimmedCombinedOutput()
 
-		require.NoError(t, err, "exit status 1", out)
+		require.NoError(t, err, out)
 
 		t.Log("Should exist")
 		{

--- a/cli/run.go
+++ b/cli/run.go
@@ -10,6 +10,7 @@ import (
 	"github.com/bitrise-io/bitrise/analytics"
 	"github.com/bitrise-io/bitrise/bitrise"
 	"github.com/bitrise-io/bitrise/configs"
+	"github.com/bitrise-io/bitrise/exitcode"
 	"github.com/bitrise-io/bitrise/models"
 	"github.com/bitrise-io/bitrise/version"
 	envmanModels "github.com/bitrise-io/envman/models"
@@ -141,14 +142,14 @@ func getExitCodeFromFailedBuild(buildRunResults models.BuildRunResultsModel) int
 	}
 
 	if buildRunResults.IsBuildAbortedWithNoOutputTimeout() {
-		return 12
+		return exitcode.CLIAbortedWithNoOutputTimeout
 	}
 
 	if buildRunResults.IsBuildAbortedWithTimeout() {
-		return 11
+		return exitcode.CLIAbortedWithCustomTimeout
 	}
 
-	return 1
+	return exitcode.CLIFailed
 }
 
 func logExit(exitCode int) {

--- a/cli/run.go
+++ b/cli/run.go
@@ -140,12 +140,12 @@ func getExitCodeFromFailedBuild(buildRunResults models.BuildRunResultsModel) int
 		return 0
 	}
 
-	if buildRunResults.IsBuildAbortedWithTimeout() {
-		return 11
-	}
-
 	if buildRunResults.IsBuildAbortedWithNoOutputTimeout() {
 		return 12
+	}
+
+	if buildRunResults.IsBuildAbortedWithTimeout() {
+		return 11
 	}
 
 	return 1

--- a/cli/run.go
+++ b/cli/run.go
@@ -10,7 +10,6 @@ import (
 	"github.com/bitrise-io/bitrise/analytics"
 	"github.com/bitrise-io/bitrise/bitrise"
 	"github.com/bitrise-io/bitrise/configs"
-	"github.com/bitrise-io/bitrise/exitcode"
 	"github.com/bitrise-io/bitrise/models"
 	"github.com/bitrise-io/bitrise/version"
 	envmanModels "github.com/bitrise-io/envman/models"
@@ -123,7 +122,7 @@ func runAndExit(bitriseConfig models.BitriseDataModel, inventoryEnvironments []e
 		log.Fatalf("Failed to run workflow, error: %s", err)
 	} else if buildRunResults.IsBuildFailed() {
 		tracker.Wait()
-		exitCode := getExitCodeFromFailedBuild(buildRunResults)
+		exitCode := buildRunResults.ExitCode()
 		logExit(exitCode)
 		os.Exit(exitCode)
 	}
@@ -134,22 +133,6 @@ func runAndExit(bitriseConfig models.BitriseDataModel, inventoryEnvironments []e
 	tracker.Wait()
 	logExit(0)
 	os.Exit(0)
-}
-
-func getExitCodeFromFailedBuild(buildRunResults models.BuildRunResultsModel) int {
-	if !buildRunResults.IsBuildFailed() {
-		return 0
-	}
-
-	if buildRunResults.IsBuildAbortedWithNoOutputTimeout() {
-		return exitcode.CLIAbortedWithNoOutputTimeout
-	}
-
-	if buildRunResults.IsBuildAbortedWithTimeout() {
-		return exitcode.CLIAbortedWithCustomTimeout
-	}
-
-	return exitcode.CLIFailed
 }
 
 func logExit(exitCode int) {

--- a/exitcode/exitcode.go
+++ b/exitcode/exitcode.go
@@ -1,0 +1,8 @@
+package exitcode
+
+const (
+	CLISuccess                    = 0
+	CLIFailed                     = 1
+	CLIAbortedWithCustomTimeout   = 11
+	CLIAbortedWithNoOutputTimeout = 12
+)

--- a/models/models_methods.go
+++ b/models/models_methods.go
@@ -1166,24 +1166,40 @@ func (sIDData StepIDData) IsUniqueResourceID() bool {
 // ----------------------------
 // --- BuildRunResults
 
-// IsStepLibUpdated ...
 func (buildRes BuildRunResultsModel) IsStepLibUpdated(stepLib string) bool {
 	return (buildRes.StepmanUpdates[stepLib] > 0)
 }
 
-// IsBuildFailed ...
 func (buildRes BuildRunResultsModel) IsBuildFailed() bool {
 	return len(buildRes.FailedSteps) > 0
 }
 
-// HasFailedSkippableSteps ...
 func (buildRes BuildRunResultsModel) HasFailedSkippableSteps() bool {
 	return len(buildRes.FailedSkippableSteps) > 0
 }
 
-// ResultsCount ...
 func (buildRes BuildRunResultsModel) ResultsCount() int {
 	return len(buildRes.SuccessSteps) + len(buildRes.FailedSteps) + len(buildRes.FailedSkippableSteps) + len(buildRes.SkippedSteps)
+}
+
+func (buildRes BuildRunResultsModel) IsBuildAbortedWithTimeout() bool {
+	for _, stepResult := range buildRes.FailedSteps {
+		if stepResult.Status == StepRunStatusAbortedTimeout {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (buildRes BuildRunResultsModel) IsBuildAbortedWithNoOutputTimeout() bool {
+	for _, stepResult := range buildRes.FailedSteps {
+		if stepResult.Status == StepRunStatusAbortedNoOutputTimeout {
+			return true
+		}
+	}
+
+	return false
 }
 
 func (buildRes BuildRunResultsModel) unorderedResults() []StepRunResultsModel {
@@ -1193,7 +1209,6 @@ func (buildRes BuildRunResultsModel) unorderedResults() []StepRunResultsModel {
 	return append(results, buildRes.SkippedSteps...)
 }
 
-//OrderedResults ...
 func (buildRes BuildRunResultsModel) OrderedResults() []StepRunResultsModel {
 	results := make([]StepRunResultsModel, buildRes.ResultsCount())
 	unorderedResults := buildRes.unorderedResults()


### PR DESCRIPTION
### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-io/bitrise/blob/master/.github/CONTRIBUTING.md)
- [x] `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *PATCH* [version update](https://semver.org/)

### Context

Set different exit codes based if there were Steps which were aborted:

- Step aborted by custom timeout set in the bitrise.yml: 11
- Step aborted by no output timeout: 12
- Any other failure: 1

These will be used to display a relevant message on the frontend.

Resolves: https://bitrise.atlassian.net/browse/BE-198
### Changes

<!-- 
  Details are important, and help maintainers processing your PR.
  Please list additional details, for example:
  - Update dependencies
  - Make `foo` optional in `main.go`
  - `foo` now returns an `error` for better error handling
-->

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->