### PR TITLE
[BE-198] Forward wrapped bitrise status

### DIFF
--- a/_tests/integration/timeout_no_output_test.go
+++ b/_tests/integration/timeout_no_output_test.go
@@ -20,5 +20,5 @@ func Test_GivenHangDetectionOn_WhenOutputSlowsDown_ThenAborts(t *testing.T) {
 	cmd := command.New(binPath(), "run", "output_slows_down", "--config", configPath)
 	out, err := cmd.RunAndReturnTrimmedCombinedOutput()
 
-	require.EqualError(t, err, "exit status 12", "Bitrise CLI did not abort hanged build, output: %s", out)
+	require.EqualError(t, err, "exit status 92", "Bitrise CLI did not abort hanged build, output: %s", out)
 }

--- a/_tests/integration/timeout_test.go
+++ b/_tests/integration/timeout_test.go
@@ -34,7 +34,7 @@ func Test_TimeoutTest(t *testing.T) {
 
 		out, err := cmd.RunAndReturnTrimmedCombinedOutput()
 
-		require.EqualError(t, err, "exit status 11", out)
+		require.EqualError(t, err, "exit status 91", out)
 
 		t.Log("Should exist")
 		{

--- a/analytics/tracker.go
+++ b/analytics/tracker.go
@@ -283,14 +283,14 @@ func mapStepResultToEvent(result StepResult) (string, analytics.Properties, erro
 		eventName = stepFinishedEventName
 		extraProperties = analytics.Properties{statusProperty: failedValue}
 		extraProperties.AppendIfNotEmpty(errorMessageProperty, result.ErrorMessage)
-	case models.StepRunStatusAbortedTimeout:
+	case models.StepRunStatusAbortedWithCustomTimeout:
 		eventName = stepAbortedEventName
 		extraProperties = analytics.Properties{reasonProperty: customTimeoutValue}
 
 		if result.Timeout >= 0 {
 			extraProperties[timeoutProperty] = int64(result.Timeout.Seconds())
 		}
-	case models.StepRunStatusAbortedNoOutputTimeout:
+	case models.StepRunStatusAbortedWithNoOutputTimeout:
 		eventName = stepAbortedEventName
 		extraProperties = analytics.Properties{reasonProperty: noOutputTimeoutValue}
 

--- a/analytics/tracker_test.go
+++ b/analytics/tracker_test.go
@@ -86,7 +86,7 @@ func Test_mapStepResultToEvent(t *testing.T) {
 		{
 			name: "Step timeout",
 			result: StepResult{
-				Status:  models.StepRunStatusAbortedTimeout,
+				Status:  models.StepRunStatusAbortedWithCustomTimeout,
 				Timeout: time.Second,
 			},
 			expectedEvent: "step_aborted",
@@ -98,7 +98,7 @@ func Test_mapStepResultToEvent(t *testing.T) {
 		{
 			name: "Step timeout",
 			result: StepResult{
-				Status:          models.StepRunStatusAbortedNoOutputTimeout,
+				Status:          models.StepRunStatusAbortedWithNoOutputTimeout,
 				NoOutputTimeout: time.Second,
 			},
 			expectedEvent: "step_aborted",

--- a/bitrise/print.go
+++ b/bitrise/print.go
@@ -63,9 +63,9 @@ func getTrimmedStepName(stepRunResult models.StepRunResultsModel) string {
 		suffix = ""
 	case models.StepRunStatusCodeFailed, models.StepRunStatusCodePreparationFailed, models.StepRunStatusCodeFailedSkippable:
 		suffix = fmt.Sprintf("(exit code: %d)", stepRunResult.ExitCode)
-	case models.StepRunStatusAbortedTimeout:
+	case models.StepRunStatusAbortedWithCustomTimeout:
 		suffix = "(timed out)"
-	case models.StepRunStatusAbortedNoOutputTimeout:
+	case models.StepRunStatusAbortedWithNoOutputTimeout:
 		suffix = "(timed out due to no output)"
 	default:
 		log.Errorf("Unknown result code")
@@ -216,7 +216,7 @@ func getRunningStepFooterMainSection(stepRunResult models.StepRunResultsModel) s
 	case models.StepRunStatusCodeFailed, models.StepRunStatusCodePreparationFailed:
 		icon = "x"
 		coloringFunc = colorstring.Red
-	case models.StepRunStatusAbortedTimeout, models.StepRunStatusAbortedNoOutputTimeout:
+	case models.StepRunStatusAbortedWithCustomTimeout, models.StepRunStatusAbortedWithNoOutputTimeout:
 		icon = "/"
 		coloringFunc = colorstring.Red
 	case models.StepRunStatusCodeFailedSkippable:

--- a/bitrise/print_test.go
+++ b/bitrise/print_test.go
@@ -166,7 +166,7 @@ func Test_getRunningStepFooterMainSection(t *testing.T) {
 			name: "aborted step due to no output",
 			result: models.StepRunResultsModel{
 				StepInfo: longTitleInfo,
-				Status:   models.StepRunStatusAbortedNoOutputTimeout,
+				Status:   models.StepRunStatusAbortedWithNoOutputTimeout,
 				Idx:      0,
 				RunTime:  10000000,
 				ErrorStr: longStr,

--- a/exitcode/exitcode.go
+++ b/exitcode/exitcode.go
@@ -3,6 +3,6 @@ package exitcode
 const (
 	CLISuccess                    = 0
 	CLIFailed                     = 1
-	CLIAbortedWithCustomTimeout   = 11
-	CLIAbortedWithNoOutputTimeout = 12
+	CLIAbortedWithCustomTimeout   = 91
+	CLIAbortedWithNoOutputTimeout = 92
 )

--- a/models/models.go
+++ b/models/models.go
@@ -14,10 +14,10 @@ const (
 	StepRunStatusCodeSkipped           = 3
 	StepRunStatusCodeSkippedWithRunIf  = 4
 	StepRunStatusCodePreparationFailed = 5
-	// StepRunStatusAbortedTimeout is used when a step times out due to a custom timeout
-	StepRunStatusAbortedTimeout = 7
-	// StepRunStatusAbortedNoOutputTimeout is used when a step times out due to no output received (hang)
-	StepRunStatusAbortedNoOutputTimeout = 8
+	// StepRunStatusAbortedWithCustomTimeout is used when a step times out due to a custom timeout
+	StepRunStatusAbortedWithCustomTimeout = 7
+	// StepRunStatusAbortedWithNoOutputTimeout is used when a step times out due to no output received (hang)
+	StepRunStatusAbortedWithNoOutputTimeout = 8
 
 	// Version ...
 	Version = "12"

--- a/models/models_methods.go
+++ b/models/models_methods.go
@@ -1201,7 +1201,7 @@ func (buildRes BuildRunResultsModel) ResultsCount() int {
 
 func (buildRes BuildRunResultsModel) isBuildAbortedWithTimeout() bool {
 	for _, stepResult := range buildRes.FailedSteps {
-		if stepResult.Status == StepRunStatusAbortedTimeout {
+		if stepResult.Status == StepRunStatusAbortedWithCustomTimeout {
 			return true
 		}
 	}
@@ -1211,7 +1211,7 @@ func (buildRes BuildRunResultsModel) isBuildAbortedWithTimeout() bool {
 
 func (buildRes BuildRunResultsModel) isBuildAbortedWithNoOutputTimeout() bool {
 	for _, stepResult := range buildRes.FailedSteps {
-		if stepResult.Status == StepRunStatusAbortedNoOutputTimeout {
+		if stepResult.Status == StepRunStatusAbortedWithNoOutputTimeout {
 			return true
 		}
 	}

--- a/tools/hangdetector/hang_detector_test.go
+++ b/tools/hangdetector/hang_detector_test.go
@@ -121,11 +121,11 @@ func Test_tickerSettings(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			actualInterval, actualTickLimit, actualHearthbeatAtTick := tickerSettings(tt.timeout)
+			actualInterval, actualTickLimit, actualHeartbeatAtTick := tickerSettings(tt.timeout)
 
 			require.Equal(t, tt.expectedInterval, actualInterval)
 			require.Equal(t, tt.expectedTickLimit, actualTickLimit)
-			require.Equal(t, tt.expectedHeartbeatAtTick, actualHearthbeatAtTick)
+			require.Equal(t, tt.expectedHeartbeatAtTick, actualHeartbeatAtTick)
 		})
 	}
 }


### PR DESCRIPTION
<!--
  Thanks for contributing to the Bitrise CLI!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-io/bitrise/blob/master/.github/CONTRIBUTING.md)
- [x] `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *PATCH* [version update](https://semver.org/)

### Context

- Forward timeouts from Steps and wrapped bitrise processes.
- Added heartbeat message, this helps avoiding the case where a wrapper bitrise process aborts earlier then the wrapped bitirse process (if both use the same timeout).
- Updated exit codes to less common numbers to avoid confusion with exit codes from shell scripts.

Resolves: https://bitrise.atlassian.net/browse/BE-198

### Changes

<!-- 
  Details are important, and help maintainers processing your PR.
  Please list additional details, for example:
  - Update dependencies
  - Make `foo` optional in `main.go`
  - `foo` now returns an `error` for better error handling
-->

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->