### PR TITLE
Stepman functions

### DIFF
--- a/cli/step_info.go
+++ b/cli/step_info.go
@@ -9,20 +9,20 @@ import (
 )
 
 func printStepLibStep(collectionURI, id, version, format string) error {
+	stepInfo, err := tools.StepmanStepInfo(collectionURI, id, version)
+
 	switch format {
 	case output.FormatRaw:
-		out, err := tools.StepmanRawStepLibStepInfo(collectionURI, id, version)
-		if out != "" {
-			fmt.Println("Step info:")
-			fmt.Printf("%s", out)
+		if err != nil {
+			return err
 		}
-		return err
+		fmt.Println("Step info:")
+		fmt.Printf(stepInfo.String())
 	case output.FormatJSON:
-		outStr, err := tools.StepmanJSONStepLibStepInfo(collectionURI, id, version)
 		if err != nil {
 			return fmt.Errorf("StepmanJSONStepLibStepInfo failed, err: %s", err)
 		}
-		fmt.Println(outStr)
+		fmt.Println(stepInfo.JSON())
 		break
 	default:
 		return fmt.Errorf("Invalid format: %s", format)
@@ -31,20 +31,20 @@ func printStepLibStep(collectionURI, id, version, format string) error {
 }
 
 func printLocalStepInfo(pth, format string) error {
+	stepInfo, err := tools.StepmanStepInfo("path", pth, "")
+
 	switch format {
 	case output.FormatRaw:
-		out, err := tools.StepmanRawLocalStepInfo(pth)
-		if out != "" {
-			fmt.Println("Step info:")
-			fmt.Printf("%s", out)
+		if err != nil {
+			return err
 		}
-		return err
+		fmt.Println("Step info:")
+		fmt.Printf(stepInfo.String())
 	case output.FormatJSON:
-		outStr, err := tools.StepmanJSONLocalStepInfo(pth)
 		if err != nil {
 			return fmt.Errorf("StepmanJSONLocalStepInfo failed, err: %s", err)
 		}
-		fmt.Println(outStr)
+		fmt.Println(stepInfo.JSON())
 		break
 	default:
 		return fmt.Errorf("Invalid format: %s", format)

--- a/cli/step_info.go
+++ b/cli/step_info.go
@@ -23,7 +23,6 @@ func printStepLibStep(collectionURI, id, version, format string) error {
 			return fmt.Errorf("StepmanJSONStepLibStepInfo failed, err: %s", err)
 		}
 		fmt.Println(stepInfo.JSON())
-		break
 	default:
 		return fmt.Errorf("Invalid format: %s", format)
 	}
@@ -45,7 +44,6 @@ func printLocalStepInfo(pth, format string) error {
 			return fmt.Errorf("StepmanJSONLocalStepInfo failed, err: %s", err)
 		}
 		fmt.Println(stepInfo.JSON())
-		break
 	default:
 		return fmt.Errorf("Invalid format: %s", format)
 	}

--- a/cli/step_info.go
+++ b/cli/step_info.go
@@ -17,7 +17,7 @@ func printStepLibStep(collectionURI, id, version, format string) error {
 			return err
 		}
 		fmt.Println("Step info:")
-		fmt.Printf(stepInfo.String())
+		fmt.Println(stepInfo.String())
 	case output.FormatJSON:
 		if err != nil {
 			return fmt.Errorf("StepmanJSONStepLibStepInfo failed, err: %s", err)
@@ -39,7 +39,7 @@ func printLocalStepInfo(pth, format string) error {
 			return err
 		}
 		fmt.Println("Step info:")
-		fmt.Printf(stepInfo.String())
+		fmt.Println(stepInfo.String())
 	case output.FormatJSON:
 		if err != nil {
 			return fmt.Errorf("StepmanJSONLocalStepInfo failed, err: %s", err)

--- a/cli/step_list.go
+++ b/cli/step_list.go
@@ -57,14 +57,12 @@ func stepList(c *cli.Context) error {
 		if err != nil {
 			registerFatal(fmt.Sprintf("Failed to print step info, err: %s", err), warnings, format)
 		}
-		break
 	case output.FormatJSON:
 		outStr, err := tools.StepmanJSONStepList(collectionURI)
 		if err != nil {
 			registerFatal(fmt.Sprintf("Failed to print step info, err: %s", err), warnings, format)
 		}
 		fmt.Println(outStr)
-		break
 	default:
 		registerFatal(fmt.Sprintf("Invalid format: %s", format), warnings, output.FormatJSON)
 	}

--- a/go.mod
+++ b/go.mod
@@ -4,11 +4,11 @@ go 1.16
 
 require (
 	github.com/bitrise-io/envman v0.0.0-20221010094751-a03ce30a5316
-	github.com/bitrise-io/go-utils v1.0.2
+	github.com/bitrise-io/go-utils v1.0.3
 	github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.10
 	github.com/bitrise-io/goinp v0.0.0-20211005113137-305e91b481f4
 	github.com/bitrise-io/gows v0.0.0-20211005113107-14f65e686b88
-	github.com/bitrise-io/stepman v0.0.0-20220808095634-6e12d2726f30
+	github.com/bitrise-io/stepman v0.0.0-20221010110437-a88e9a915b58
 	github.com/gofrs/uuid v4.2.0+incompatible
 	github.com/hashicorp/go-version v1.4.0
 	github.com/ryanuber/go-glob v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -7,8 +7,8 @@ github.com/bitrise-io/envman v0.0.0-20221010094751-a03ce30a5316/go.mod h1:L4WQyg
 github.com/bitrise-io/go-utils v0.0.0-20200224122728-e212188d99b4/go.mod h1:tTEsKvbz1LbzuN/KpVFHXnLtcAPdEgIdM41s0lL407s=
 github.com/bitrise-io/go-utils v0.0.0-20210505121718-07411d72e36e/go.mod h1:nhdaDQFvaMny1CugVV6KjK92/q97ENo0RuKSW5I4fbA=
 github.com/bitrise-io/go-utils v1.0.1/go.mod h1:ZY1DI+fEpZuFpO9szgDeICM4QbqoWVt0RSY3tRI1heY=
-github.com/bitrise-io/go-utils v1.0.2 h1:w4Mz2IvrgDzrFJECuHdvsK1LHO30cdtuy9bBa7Lw2c0=
-github.com/bitrise-io/go-utils v1.0.2/go.mod h1:ZY1DI+fEpZuFpO9szgDeICM4QbqoWVt0RSY3tRI1heY=
+github.com/bitrise-io/go-utils v1.0.3 h1:xKy0WyiJtRPqeKl/HrwQJ0QdjNOOUhiVHs81RMDwD94=
+github.com/bitrise-io/go-utils v1.0.3/go.mod h1:ZY1DI+fEpZuFpO9szgDeICM4QbqoWVt0RSY3tRI1heY=
 github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.10 h1:b3sG8BNhsktfYd8YXraVQsKunFKMs0bRELXdx/zhTKA=
 github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.10/go.mod h1:Ta/ards3Ih/3Q6X8tBtcj6zTHcNf1hRSXv1E8lPgIYk=
 github.com/bitrise-io/goinp v0.0.0-20210504152833-8559b0680ab1/go.mod h1:iRbd8zAXLeNy+0gic0eqNCxXvDGe8ZEY/uYX2CCeAoo=
@@ -16,8 +16,8 @@ github.com/bitrise-io/goinp v0.0.0-20211005113137-305e91b481f4 h1:ytUxnO7iSGHlNp
 github.com/bitrise-io/goinp v0.0.0-20211005113137-305e91b481f4/go.mod h1:iRbd8zAXLeNy+0gic0eqNCxXvDGe8ZEY/uYX2CCeAoo=
 github.com/bitrise-io/gows v0.0.0-20211005113107-14f65e686b88 h1:HObzyO+BJrTSLqxSUHnik0FS1lOHPmtqXLP0doAsE1g=
 github.com/bitrise-io/gows v0.0.0-20211005113107-14f65e686b88/go.mod h1:3Cp9ceJ8wHl1Av6oEE2ff1iWaYLliQuD+oaNdyM0NWQ=
-github.com/bitrise-io/stepman v0.0.0-20220808095634-6e12d2726f30 h1:6Ra9CW9GMBRpT1FfRabM77breQTEZ9AzD/WQiW330RM=
-github.com/bitrise-io/stepman v0.0.0-20220808095634-6e12d2726f30/go.mod h1:25vk5IaQiOpXLMcjyJjY6RmZe6JEOqMe8TJoTvKgyuw=
+github.com/bitrise-io/stepman v0.0.0-20221007133439-b50a78a98b4c h1:0lN1oQV57qdBl8rGmN85it9b3DHJiZdN1DJooUY+E2Q=
+github.com/bitrise-io/stepman v0.0.0-20221007133439-b50a78a98b4c/go.mod h1:Lwt05EyClntmh83XkXkK2QWfqHj5mdm5RQ+A68kwHA4=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.1 h1:r/myEWzV9lfsM1tFLgDyu0atFtJ1fXn261LKYj/3DxU=
 github.com/cpuguy83/go-md2man/v2 v2.0.1/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,6 @@
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/bitrise-io/colorstring v0.0.0-20180614154802-a8cd70115192 h1:vSHYT6kCL/iOT9BVuUPm0tVcbW57r5zldLWg0aB7qbQ=
 github.com/bitrise-io/colorstring v0.0.0-20180614154802-a8cd70115192/go.mod h1:CIHVcxZUvsG99XUJV6JlR7okNsMMGY81jMvPC20W+O0=
-github.com/bitrise-io/envman v0.0.0-20211026063720-03283f9c3f32/go.mod h1:L4WQyg88d87Z4dxNwrYEa0Cwd9/W0gSfXsibw30r8Vw=
 github.com/bitrise-io/envman v0.0.0-20221010094751-a03ce30a5316 h1:gRQReCvmNxUVvm71SJYpx8d6wz4ln6ChapNkDStco58=
 github.com/bitrise-io/envman v0.0.0-20221010094751-a03ce30a5316/go.mod h1:L4WQyg88d87Z4dxNwrYEa0Cwd9/W0gSfXsibw30r8Vw=
 github.com/bitrise-io/go-utils v0.0.0-20200224122728-e212188d99b4/go.mod h1:tTEsKvbz1LbzuN/KpVFHXnLtcAPdEgIdM41s0lL407s=
@@ -16,8 +15,8 @@ github.com/bitrise-io/goinp v0.0.0-20211005113137-305e91b481f4 h1:ytUxnO7iSGHlNp
 github.com/bitrise-io/goinp v0.0.0-20211005113137-305e91b481f4/go.mod h1:iRbd8zAXLeNy+0gic0eqNCxXvDGe8ZEY/uYX2CCeAoo=
 github.com/bitrise-io/gows v0.0.0-20211005113107-14f65e686b88 h1:HObzyO+BJrTSLqxSUHnik0FS1lOHPmtqXLP0doAsE1g=
 github.com/bitrise-io/gows v0.0.0-20211005113107-14f65e686b88/go.mod h1:3Cp9ceJ8wHl1Av6oEE2ff1iWaYLliQuD+oaNdyM0NWQ=
-github.com/bitrise-io/stepman v0.0.0-20221007133439-b50a78a98b4c h1:0lN1oQV57qdBl8rGmN85it9b3DHJiZdN1DJooUY+E2Q=
-github.com/bitrise-io/stepman v0.0.0-20221007133439-b50a78a98b4c/go.mod h1:Lwt05EyClntmh83XkXkK2QWfqHj5mdm5RQ+A68kwHA4=
+github.com/bitrise-io/stepman v0.0.0-20221010110437-a88e9a915b58 h1:xrEcHh9p9ZD/tEJLxv3dc/x4gS+GUsr/c1rVnkW8A6w=
+github.com/bitrise-io/stepman v0.0.0-20221010110437-a88e9a915b58/go.mod h1:4BBUXFxB5UlF/tZHXrNFjAy9yNvjZ7Lf/TeIpMwjsow=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.1 h1:r/myEWzV9lfsM1tFLgDyu0atFtJ1fXn261LKYj/3DxU=
 github.com/cpuguy83/go-md2man/v2 v2.0.1/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -19,7 +19,10 @@ import (
 	envmanEnv "github.com/bitrise-io/envman/env"
 	envmanModels "github.com/bitrise-io/envman/models"
 	"github.com/bitrise-io/go-utils/command"
+	utilslog "github.com/bitrise-io/go-utils/log"
 	"github.com/bitrise-io/go-utils/pathutil"
+	stepman "github.com/bitrise-io/stepman/cli"
+	stepmanModels "github.com/bitrise-io/stepman/models"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
 )
@@ -134,70 +137,22 @@ func InstallFromURL(toolBinName, downloadURL string) error {
 
 // StepmanSetup ...
 func StepmanSetup(collection string) error {
-	logLevel := log.GetLevel().String()
-	args := []string{"--loglevel", logLevel, "setup", "--collection", collection}
-	return command.RunCommand("stepman", args...)
-}
-
-// StepmanActivate ...
-func StepmanActivate(collection, stepID, stepVersion, dir, ymlPth string) error {
-	logLevel := log.GetLevel().String()
-	args := []string{"--loglevel", logLevel, "activate", "--collection", collection,
-		"--id", stepID, "--version", stepVersion, "--path", dir, "--copyyml", ymlPth}
-	return command.RunCommand("stepman", args...)
+	return stepman.Setup(collection, "", utilslog.NewDefaultLogger(false))
 }
 
 // StepmanUpdate ...
 func StepmanUpdate(collection string) error {
-	logLevel := log.GetLevel().String()
-	args := []string{"--loglevel", logLevel, "update", "--collection", collection}
-	return command.RunCommand("stepman", args...)
+	return stepman.UpdateLibrary(collection, utilslog.NewDefaultLogger(false))
 }
 
-// StepmanRawStepLibStepInfo ...
-func StepmanRawStepLibStepInfo(collection, stepID, stepVersion string) (string, error) {
-	logLevel := log.GetLevel().String()
-	args := []string{"--loglevel", logLevel, "step-info", "--collection", collection,
-		"--id", stepID, "--version", stepVersion, "--format", "raw"}
-	return command.RunCommandAndReturnCombinedStdoutAndStderr("stepman", args...)
+// StepmanActivate ...
+func StepmanActivate(collection, stepID, stepVersion, dir, ymlPth string) error {
+	return stepman.Activate(collection, stepID, stepVersion, dir, ymlPth, false, utilslog.NewDefaultLogger(false))
 }
 
-// StepmanRawLocalStepInfo ...
-func StepmanRawLocalStepInfo(pth string) (string, error) {
-	logLevel := log.GetLevel().String()
-	args := []string{"--loglevel", logLevel, "step-info", "--step-yml", pth, "--format", "raw"}
-	return command.RunCommandAndReturnCombinedStdoutAndStderr("stepman", args...)
-}
-
-// StepmanJSONStepLibStepInfo ...
-func StepmanJSONStepLibStepInfo(collection, stepID, stepVersion string) (string, error) {
-	logLevel := log.GetLevel().String()
-	args := []string{"--loglevel", logLevel, "step-info", "--collection", collection,
-		"--id", stepID, "--version", stepVersion, "--format", "json"}
-
-	var outBuffer bytes.Buffer
-	var errBuffer bytes.Buffer
-
-	if err := command.RunCommandWithWriters(io.Writer(&outBuffer), io.Writer(&errBuffer), "stepman", args...); err != nil {
-		return outBuffer.String(), fmt.Errorf("Error: %s, details: %s", err, errBuffer.String())
-	}
-
-	return outBuffer.String(), nil
-}
-
-// StepmanJSONLocalStepInfo ...
-func StepmanJSONLocalStepInfo(pth string) (string, error) {
-	logLevel := log.GetLevel().String()
-	args := []string{"--loglevel", logLevel, "step-info", "--step-yml", pth, "--format", "json"}
-
-	var outBuffer bytes.Buffer
-	var errBuffer bytes.Buffer
-
-	if err := command.RunCommandWithWriters(io.Writer(&outBuffer), io.Writer(&errBuffer), "stepman", args...); err != nil {
-		return outBuffer.String(), fmt.Errorf("Error: %s, details: %s", err, errBuffer.String())
-	}
-
-	return outBuffer.String(), nil
+// StepmanStepInfo ...
+func StepmanStepInfo(collection, stepID, stepVersion string) (stepmanModels.StepInfoModel, error) {
+	return stepman.QueryStepInfo(collection, stepID, stepVersion, utilslog.NewDefaultLogger(false))
 }
 
 // StepmanRawStepList ...

--- a/tools/tools_test.go
+++ b/tools/tools_test.go
@@ -80,14 +80,13 @@ func TestStepmanJSONStepLibStepInfo(t *testing.T) {
 	// Valid params -- Err should empty, output filled
 	require.Equal(t, nil, StepmanSetup("https://github.com/bitrise-io/bitrise-steplib"))
 
-	outStr, err := StepmanJSONStepLibStepInfo("https://github.com/bitrise-io/bitrise-steplib", "script", "0.9.0")
+	info, err := StepmanStepInfo("https://github.com/bitrise-io/bitrise-steplib", "script", "0.9.0")
 	require.NoError(t, err)
-	require.NotEqual(t, "", outStr)
+	require.NotEqual(t, "", info.JSON())
 
-	// Invalid params -- Err should empty, output filled
-	outStr, err = StepmanJSONStepLibStepInfo("https://github.com/bitrise-io/bitrise-steplib", "script", "2.x")
+	// Invalid params -- Err returned, output is invalid
+	info, err = StepmanStepInfo("https://github.com/bitrise-io/bitrise-steplib", "script", "2.x")
 	require.Error(t, err)
-	require.Equal(t, "", outStr)
 }
 
 func TestEnvmanJSONPrint(t *testing.T) {

--- a/vendor/github.com/bitrise-io/go-utils/versions/versions.go
+++ b/vendor/github.com/bitrise-io/go-utils/versions/versions.go
@@ -1,7 +1,7 @@
 package versions
 
 import (
-	"log"
+	"fmt"
 	"strconv"
 	"strings"
 )
@@ -36,14 +36,12 @@ func CompareVersions(version1, version2 string) (int, error) {
 	for i, num := range version1Slice {
 		num1, err := strconv.ParseInt(num, 0, 64)
 		if err != nil {
-			log.Println("Failed to parse int:", err)
-			return -2, err
+			return -2, fmt.Errorf("failed to parse int (%s): %s", num, err)
 		}
 
 		num2, err2 := strconv.ParseInt(version2Slice[i], 0, 64)
 		if err2 != nil {
-			log.Println("Failed to parse int:", err2)
-			return -2, err
+			return -2, fmt.Errorf("failed to parse int (%s): %s", version2Slice[i], err2)
 		}
 
 		if num2 > num1 {

--- a/vendor/github.com/bitrise-io/stepman/cli/activate.go
+++ b/vendor/github.com/bitrise-io/stepman/cli/activate.go
@@ -45,8 +45,7 @@ var activateCommand = cli.Command{
 	},
 	Action: func(c *cli.Context) error {
 		if err := activate(c); err != nil {
-			log.Errorf("Command failed: %s", err)
-			os.Exit(1)
+			failf("Command failed: %s", err)
 		}
 		return nil
 	},

--- a/vendor/github.com/bitrise-io/stepman/cli/audit.go
+++ b/vendor/github.com/bitrise-io/stepman/cli/audit.go
@@ -5,9 +5,9 @@ import (
 	"strings"
 	"time"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/bitrise-io/go-utils/colorstring"
 	"github.com/bitrise-io/go-utils/command/git"
+	"github.com/bitrise-io/go-utils/log"
 	"github.com/bitrise-io/go-utils/pathutil"
 	"github.com/bitrise-io/go-utils/retry"
 	"github.com/bitrise-io/stepman/models"
@@ -129,34 +129,34 @@ func audit(c *cli.Context) error {
 	collectionURI := c.String("collection")
 	if collectionURI != "" {
 		if beforePR {
-			log.Warnln("before-pr flag is used only for Step audit")
+			log.Warnf("before-pr flag is used only for Step audit")
 		}
 
 		if err := auditStepLibBeforeSharePullRequest(collectionURI); err != nil {
-			log.Fatalf("Audit Step Collection failed, err: %s", err)
+			failf("Audit Step Collection failed, err: %s", err)
 		}
 	} else {
 		stepYMLPath := c.String("step-yml")
 		if stepYMLPath != "" {
 			if exist, err := pathutil.IsPathExists(stepYMLPath); err != nil {
-				log.Fatalf("Failed to check path (%s), err: %s", stepYMLPath, err)
+				failf("Failed to check path (%s), err: %s", stepYMLPath, err)
 			} else if !exist {
-				log.Fatalf("step.yml doesn't exist at: %s", stepYMLPath)
+				failf("step.yml doesn't exist at: %s", stepYMLPath)
 			}
 
 			if beforePR {
 				if err := auditStepBeforeSharePullRequest(stepYMLPath); err != nil {
-					log.Fatalf("Step audit failed, err: %s", err)
+					failf("Step audit failed, err: %s", err)
 				}
 			} else {
 				if err := auditStepBeforeShare(stepYMLPath); err != nil {
-					log.Fatalf("Step audit failed, err: %s", err)
+					failf("Step audit failed, err: %s", err)
 				}
 			}
 
 			log.Infof(" * "+colorstring.Greenf("[OK] ")+"Success audit (%s)", stepYMLPath)
 		} else {
-			log.Fatalln("'stepman audit' command needs --collection or --step-yml flag")
+			failf("'stepman audit' command needs --collection or --step-yml flag")
 		}
 	}
 

--- a/vendor/github.com/bitrise-io/stepman/cli/cli.go
+++ b/vendor/github.com/bitrise-io/stepman/cli/cli.go
@@ -5,34 +5,23 @@ import (
 	"os"
 	"path"
 
+	"github.com/bitrise-io/go-utils/log"
 	"github.com/bitrise-io/stepman/stepman"
 	"github.com/bitrise-io/stepman/version"
-	log "github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 )
 
-func initLogFormatter() {
-	log.SetFormatter(&log.TextFormatter{
-		ForceColors:     true,
-		FullTimestamp:   true,
-		TimestampFormat: "15:04:05",
-	})
-}
-
 func before(c *cli.Context) error {
-	initLogFormatter()
 	initHelpAndVersionFlags()
 	initAppHelpTemplate()
 
 	// Log level
-	logLevel, err := log.ParseLevel(c.String(LogLevelKey))
-	if err != nil {
-		return fmt.Errorf("Failed to parse log level, error: %s", err)
+	if c.String(LogLevelKey) == "debug" {
+		log.SetEnableDebugLog(true)
 	}
-	log.SetLevel(logLevel)
 
 	// Setup
-	err = stepman.CreateStepManDirIfNeeded()
+	err := stepman.CreateStepManDirIfNeeded()
 	if err != nil {
 		return err
 	}
@@ -62,6 +51,11 @@ func Run() {
 	app.Commands = commands
 
 	if err := app.Run(os.Args); err != nil {
-		log.Fatal(err)
+		failf(err.Error())
 	}
+}
+
+func failf(format string, v ...interface{}) {
+	log.Errorf(format, v...)
+	os.Exit(1)
 }

--- a/vendor/github.com/bitrise-io/stepman/cli/collections.go
+++ b/vendor/github.com/bitrise-io/stepman/cli/collections.go
@@ -3,7 +3,6 @@ package cli
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 
 	"github.com/bitrise-io/go-utils/colorstring"
 	flog "github.com/bitrise-io/go-utils/log"
@@ -80,8 +79,7 @@ func collections(c *cli.Context) error {
 	} else if format == OutputFormatJSON {
 		log = flog.NewDefaultJSONLoger()
 	} else {
-		fmt.Printf("%s: invalid format: %s\n", colorstring.Red("Error"), format)
-		os.Exit(1)
+		failf("invalid format: %s", format)
 	}
 
 	steplibInfos := []models.SteplibInfoModel{}
@@ -89,8 +87,11 @@ func collections(c *cli.Context) error {
 	for _, steplibURI := range stepLibURIs {
 		route, found := stepman.ReadRoute(steplibURI)
 		if !found {
-			log.Print(NewErrorOutput("No routing found for steplib: %s", steplibURI))
-			os.Exit(1)
+			out := NewErrorOutput("No routing found for steplib: %s", steplibURI)
+			if format == OutputFormatJSON {
+				failf(out.JSON())
+			}
+			failf(out.String())
 		}
 
 		specPth := stepman.GetStepSpecPath(route)

--- a/vendor/github.com/bitrise-io/stepman/cli/delete_steplib.go
+++ b/vendor/github.com/bitrise-io/stepman/cli/delete_steplib.go
@@ -3,7 +3,7 @@ package cli
 import (
 	"fmt"
 
-	log "github.com/sirupsen/logrus"
+	"github.com/bitrise-io/go-utils/log"
 	"github.com/bitrise-io/stepman/stepman"
 	"github.com/urfave/cli"
 )

--- a/vendor/github.com/bitrise-io/stepman/cli/download.go
+++ b/vendor/github.com/bitrise-io/stepman/cli/download.go
@@ -1,7 +1,7 @@
 package cli
 
 import (
-	log "github.com/sirupsen/logrus"
+	"github.com/bitrise-io/go-utils/log"
 	"github.com/bitrise-io/stepman/stepman"
 	"github.com/urfave/cli"
 )
@@ -10,28 +10,28 @@ func download(c *cli.Context) error {
 	// Input validation
 	collectionURI := c.String(CollectionKey)
 	if collectionURI == "" {
-		log.Fatalf("No step collection specified")
+		failf("No step collection specified")
 	}
 	route, found := stepman.ReadRoute(collectionURI)
 	if !found {
-		log.Fatalf("No route found for lib: %s", collectionURI)
+		failf("No route found for lib: %s", collectionURI)
 	}
 
 	id := c.String(IDKey)
 	if id == "" {
-		log.Fatalf("Missing step id")
+		failf("Missing step id")
 	}
 
 	collection, err := stepman.ReadStepSpec(collectionURI)
 	if err != nil {
-		log.Fatalf("Failed to read step spec, error: %s", err)
+		failf("Failed to read step spec, error: %s", err)
 	}
 
 	version := c.String(VersionKey)
 	if version == "" {
 		latest, err := collection.GetLatestStepVersion(id)
 		if err != nil {
-			log.Fatalf("Failed to get step latest version, error: %s", err)
+			failf("Failed to get step latest version, error: %s", err)
 		}
 		version = latest
 	}
@@ -49,31 +49,31 @@ func download(c *cli.Context) error {
 			}
 
 			if err := stepman.ReGenerateLibrarySpec(route); err != nil {
-				log.Fatalf("Failed to update collection:%s error:%v", collectionURI, err)
+				failf("Failed to update collection:%s error:%v", collectionURI, err)
 			}
 
 			if _, stepFound, versionFound := collection.GetStep(id, version); !stepFound || !versionFound {
 				if !stepFound {
-					log.Fatalf("Even the updated collection doesn't contain step with id: %s", id)
+					failf("Even the updated collection doesn't contain step with id: %s", id)
 				} else if !versionFound {
-					log.Fatalf("Even the updated collection doesn't contain step (%s) with version: %s", id, version)
+					failf("Even the updated collection doesn't contain step (%s) with version: %s", id, version)
 				}
 			}
 		} else {
 			if !stepFound {
-				log.Fatalf("Collection doesn't contain step with id: %s -- Updating StepLib", id)
+				failf("Collection doesn't contain step with id: %s -- Updating StepLib", id)
 			} else if !versionFound {
-				log.Fatalf("Collection doesn't contain step (%s) with version: %s -- Updating StepLib", id, version)
+				failf("Collection doesn't contain step (%s) with version: %s -- Updating StepLib", id, version)
 			}
 		}
 	}
 
 	if step.Source == nil {
-		log.Fatalf("Missing step's (%s) Source property", id)
+		failf("Missing step's (%s) Source property", id)
 	}
 
-	if err := stepman.DownloadStep(collectionURI, collection, id, version, step.Source.Commit); err != nil {
-		log.Fatalf("Failed to download step, error: %s", err)
+	if err := stepman.DownloadStep(collectionURI, collection, id, version, step.Source.Commit, log.NewDefaultLogger(false)); err != nil {
+		failf("Failed to download step, error: %s", err)
 	}
 
 	return nil

--- a/vendor/github.com/bitrise-io/stepman/cli/export.go
+++ b/vendor/github.com/bitrise-io/stepman/cli/export.go
@@ -6,8 +6,8 @@ import (
 	"os"
 	"path/filepath"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/bitrise-io/go-utils/fileutil"
+	"github.com/bitrise-io/go-utils/log"
 	"github.com/bitrise-io/go-utils/pathutil"
 	"github.com/bitrise-io/stepman/models"
 	"github.com/bitrise-io/stepman/stepman"
@@ -101,7 +101,7 @@ func export(c *cli.Context) error {
 		return fmt.Errorf("Failed to check if setup was done for StepLib, error: %s", err)
 	} else if !exist {
 		log.Infof("StepLib does not exist, setup...")
-		if err := stepman.SetupLibrary(steplibURI); err != nil {
+		if err := stepman.SetupLibrary(steplibURI, log.NewDefaultLogger(false)); err != nil {
 			return fmt.Errorf("Failed to setup StepLib, error: %s", err)
 		}
 	}
@@ -109,7 +109,7 @@ func export(c *cli.Context) error {
 	// Prepare spec
 	stepLibSpec, err := stepman.ReadStepSpec(steplibURI)
 	if err != nil {
-		log.Fatalf("Failed to read StepLib spec, error: %s", err)
+		failf("Failed to read StepLib spec, error: %s", err)
 	}
 
 	switch exportType {

--- a/vendor/github.com/bitrise-io/stepman/cli/setup.go
+++ b/vendor/github.com/bitrise-io/stepman/cli/setup.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/bitrise-io/go-utils/command"
@@ -15,8 +14,7 @@ func setup(c *cli.Context) error {
 	// Input validation
 	steplibURI := c.String(CollectionKey)
 	if steplibURI == "" {
-		log.Errorf("No step collection specified")
-		os.Exit(1)
+		failf("No step collection specified")
 	}
 
 	copySpecJSONPath := c.String(CopySpecJSONKey)

--- a/vendor/github.com/bitrise-io/stepman/cli/setup.go
+++ b/vendor/github.com/bitrise-io/stepman/cli/setup.go
@@ -2,10 +2,11 @@ package cli
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/bitrise-io/go-utils/command"
+	"github.com/bitrise-io/go-utils/log"
 	"github.com/bitrise-io/stepman/stepman"
 	"github.com/urfave/cli"
 )
@@ -14,14 +15,15 @@ func setup(c *cli.Context) error {
 	// Input validation
 	steplibURI := c.String(CollectionKey)
 	if steplibURI == "" {
-		log.Fatal("No step collection specified")
+		log.Errorf("No step collection specified")
+		os.Exit(1)
 	}
 
 	copySpecJSONPath := c.String(CopySpecJSONKey)
 
 	if c.IsSet(LocalCollectionKey) {
-		log.Warn("'local' flag is deprecated")
-		log.Warn("use 'file://' prefix in steplib path instead")
+		log.Warnf("'local' flag is deprecated")
+		log.Warnf("use 'file://' prefix in steplib path instead")
 		fmt.Println()
 	}
 
@@ -34,23 +36,30 @@ func setup(c *cli.Context) error {
 		}
 	}
 
+	return Setup(steplibURI, copySpecJSONPath, log.NewDefaultLogger(false))
+}
+
+// Setup ...
+func Setup(steplibURI, copySpecJSONPath string, log stepman.Logger) error {
+	if steplibURI == "" {
+		return fmt.Errorf("no step library specified")
+	}
+
 	// Setup
-	if err := stepman.SetupLibrary(steplibURI); err != nil {
-		log.Fatalf("Setup failed, error: %s", err)
+	if err := stepman.SetupLibrary(steplibURI, log); err != nil {
+		return fmt.Errorf("setup failed: %s", err)
 	}
 
 	// Copy spec.json
 	if copySpecJSONPath != "" {
-		log.Infof("Copying spec YML to path: %s", copySpecJSONPath)
-
 		route, found := stepman.ReadRoute(steplibURI)
 		if !found {
-			log.Fatalf("No route found for steplib (%s)", steplibURI)
+			return fmt.Errorf("no route found for steplib (%s)", steplibURI)
 		}
 
 		sourceSpecJSONPth := stepman.GetStepSpecPath(route)
 		if err := command.CopyFile(sourceSpecJSONPth, copySpecJSONPath); err != nil {
-			log.Fatalf("Failed to copy spec.json from (%s) to (%s), error: %s", sourceSpecJSONPth, copySpecJSONPath, err)
+			return fmt.Errorf("failed to copy spec.json from (%s) to (%s): %s", sourceSpecJSONPth, copySpecJSONPath, err)
 		}
 	}
 

--- a/vendor/github.com/bitrise-io/stepman/cli/share_audit.go
+++ b/vendor/github.com/bitrise-io/stepman/cli/share_audit.go
@@ -24,7 +24,7 @@ func shareAudit(c *cli.Context) error {
 	share, err := ReadShareSteplibFromFile()
 	if err != nil {
 		log.Errorf(err.Error())
-		fail("You have to start sharing with `stepman share start`, or you can read instructions with `stepman share`")
+		failf("You have to start sharing with `stepman share start`, or you can read instructions with `stepman share`")
 	}
 	log.Donef("all inputs are valid")
 
@@ -32,11 +32,11 @@ func shareAudit(c *cli.Context) error {
 	log.Infof("Auditing the StepLib...")
 	_, found := stepman.ReadRoute(share.Collection)
 	if !found {
-		fail("No route found for collectionURI (%s)", share.Collection)
+		failf("No route found for collectionURI (%s)", share.Collection)
 	}
 
 	if err := auditStepLibBeforeSharePullRequest(share.Collection); err != nil {
-		fail("Audit Step Collection failed, err: %s", err)
+		failf("Audit Step Collection failed, err: %s", err)
 	}
 
 	printFinishAudit(share, toolMode)

--- a/vendor/github.com/bitrise-io/stepman/cli/share_finish.go
+++ b/vendor/github.com/bitrise-io/stepman/cli/share_finish.go
@@ -45,12 +45,12 @@ func finish(c *cli.Context) error {
 	share, err := ReadShareSteplibFromFile()
 	if err != nil {
 		log.Errorf(err.Error())
-		fail("You have to start sharing with `stepman share start`, or you can read instructions with `stepman share`")
+		failf("You have to start sharing with `stepman share start`, or you can read instructions with `stepman share`")
 	}
 
 	route, found := stepman.ReadRoute(share.Collection)
 	if !found {
-		fail("No route found for collectionURI (%s)", share.Collection)
+		failf("No route found for collectionURI (%s)", share.Collection)
 	}
 
 	collectionDir := stepman.GetLibraryBaseDirPath(route)
@@ -60,12 +60,12 @@ func finish(c *cli.Context) error {
 	log.Infof("Checking StepLib changes...")
 	repo, err := git.New(collectionDir)
 	if err != nil {
-		fail(err.Error())
+		failf(err.Error())
 	}
 
 	gitstatus, err := repo.Status("-u", "--porcelain").RunAndReturnTrimmedCombinedOutput()
 	if err != nil {
-		fail(err.Error())
+		failf(err.Error())
 	}
 	if gitstatus == "" {
 		log.Warnf("No git changes, it seems you already called this command")
@@ -78,23 +78,23 @@ func finish(c *cli.Context) error {
 	stepYMLPathInSteplib := filepath.Join(stepDirInSteplib, "step.yml")
 	log.Printf("new step.yml: %s", stepYMLPathInSteplib)
 	if err := repo.Add(stepYMLPathInSteplib).Run(); err != nil {
-		fail(err.Error())
+		failf(err.Error())
 	}
 	// add auto generated step-info.yml for new steps
 	if err := addStepGroupSpecIfExists(route, share.StepID, gitstatus, repo); err != nil {
-		fail(err.Error())
+		failf(err.Error())
 	}
 
 	fmt.Println()
 	log.Infof("Submitting the changes...")
 	msg := share.StepID + " " + share.StepTag
 	if err := repo.Commit(msg).Run(); err != nil {
-		fail(err.Error())
+		failf(err.Error())
 	}
 
 	log.Printf("pushing to your fork: %s", share.Collection)
 	if out, err := repo.Push(share.ShareBranchName()).RunAndReturnTrimmedCombinedOutput(); err != nil {
-		fail(out)
+		failf(out)
 	}
 
 	fmt.Println()

--- a/vendor/github.com/bitrise-io/stepman/cli/share_start.go
+++ b/vendor/github.com/bitrise-io/stepman/cli/share_start.go
@@ -13,11 +13,6 @@ import (
 	"github.com/urfave/cli"
 )
 
-func fail(format string, v ...interface{}) {
-	log.Errorf(format, v...)
-	os.Exit(1)
-}
-
 func showSubcommandHelp(c *cli.Context) {
 	if err := cli.ShowSubcommandHelp(c); err != nil {
 		log.Warnf("Failed to show help, error: %s", err)
@@ -47,11 +42,11 @@ func start(c *cli.Context) error {
 		log.Printf("StepLib found locally at: %s", collLocalPth)
 		log.Warnf("For sharing it's required to work with a clean StepLib repository.")
 		if val, err := goinp.AskForBool("Would you like to remove the local version (your forked StepLib repository) and re-clone it?"); err != nil {
-			fail("Failed to ask for input, error: %s", err)
+			failf("Failed to ask for input, error: %s", err)
 		} else {
 			if !val {
 				log.Errorf("Unfortunately we can't continue with sharing without a clean StepLib repository.")
-				fail("Please finish your changes, run this command again and allow it to remove the local StepLib folder!")
+				failf("Please finish your changes, run this command again and allow it to remove the local StepLib folder!")
 			}
 			if err := stepman.CleanupRoute(route); err != nil {
 				log.Errorf("Failed to cleanup route for uri: %s", collectionURI)
@@ -61,7 +56,7 @@ func start(c *cli.Context) error {
 
 	// cleanup
 	if err := DeleteShareSteplibFile(); err != nil {
-		fail("Failed to delete share steplib file, error: %s", err)
+		failf("Failed to delete share steplib file, error: %s", err)
 	}
 
 	var route stepman.SteplibRoute
@@ -72,7 +67,7 @@ func start(c *cli.Context) error {
 				log.Errorf("Failed to cleanup route for uri: %s", collectionURI)
 			}
 			if err := DeleteShareSteplibFile(); err != nil {
-				fail("Failed to delete share steplib file, error: %s", err)
+				failf("Failed to delete share steplib file, error: %s", err)
 			}
 		}
 	}()
@@ -92,21 +87,21 @@ func start(c *cli.Context) error {
 		}
 		return repo.Clone(collectionURI).Run()
 	}); err != nil {
-		fail("Failed to setup step spec (url: %s) version (%s), error: %s", collectionURI, pth, err)
+		failf("Failed to setup step spec (url: %s) version (%s), error: %s", collectionURI, pth, err)
 	}
 
 	specPth := stepman.GetStepCollectionSpecPath(route)
 	collection, err := stepman.ParseStepCollection(specPth)
 	if err != nil {
-		fail("Failed to read step spec, error: %s", err)
+		failf("Failed to read step spec, error: %s", err)
 	}
 
 	if err := stepman.WriteStepSpecToFile(collection, route); err != nil {
-		fail("Failed to save step spec, error: %s", err)
+		failf("Failed to save step spec, error: %s", err)
 	}
 
 	if err := stepman.AddRoute(route); err != nil {
-		fail("Failed to setup routing, error: %s", err)
+		failf("Failed to setup routing, error: %s", err)
 	}
 
 	log.Donef("StepLib prepared at: %s", pth)
@@ -115,7 +110,7 @@ func start(c *cli.Context) error {
 		Collection: collectionURI,
 	}
 	if err := WriteShareSteplibToFile(share); err != nil {
-		fail("Failed to save share steplib to file, error: %s", err)
+		failf("Failed to save share steplib to file, error: %s", err)
 	}
 
 	isSuccess = true

--- a/vendor/github.com/bitrise-io/stepman/cli/share_start.go
+++ b/vendor/github.com/bitrise-io/stepman/cli/share_start.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"fmt"
-	"os"
 	"time"
 
 	"github.com/bitrise-io/go-utils/command/git"
@@ -27,9 +26,8 @@ func start(c *cli.Context) error {
 
 	collectionURI := c.String(CollectionKey)
 	if collectionURI == "" {
-		log.Errorf("No step collection specified\n")
 		showSubcommandHelp(c)
-		os.Exit(1)
+		failf("No step collection specified")
 	}
 
 	log.Donef("all inputs are valid")

--- a/vendor/github.com/bitrise-io/stepman/cli/step_info.go
+++ b/vendor/github.com/bitrise-io/stepman/cli/step_info.go
@@ -2,13 +2,12 @@ package cli
 
 import (
 	"fmt"
-	"log"
+	"os"
+	"path/filepath"
 	"time"
 
-	"path/filepath"
-
 	"github.com/bitrise-io/go-utils/command/git"
-	flog "github.com/bitrise-io/go-utils/log"
+	"github.com/bitrise-io/go-utils/log"
 	"github.com/bitrise-io/go-utils/pathutil"
 	"github.com/bitrise-io/go-utils/retry"
 	"github.com/bitrise-io/stepman/models"
@@ -53,7 +52,8 @@ var stepInfoCommand = cli.Command{
 	},
 	Action: func(c *cli.Context) error {
 		if err := stepInfo(c); err != nil {
-			log.Fatalf("Command failed: %s", err)
+			log.Errorf("Command failed: %s", err)
+			os.Exit(1)
 		}
 		return nil
 	},
@@ -93,31 +93,31 @@ func stepInfo(c *cli.Context) error {
 		return fmt.Errorf("step info: invalid format value: %s, valid values: [%s, %s]", format, OutputFormatRaw, OutputFormatJSON)
 	}
 
-	var log flog.Logger
-	log = flog.NewDefaultRawLogger()
+	var logger log.Logger
+	logger = log.NewDefaultRawLogger()
 	if format == OutputFormatJSON {
-		log = flog.NewDefaultJSONLoger()
+		logger = log.NewDefaultJSONLoger()
 	}
 
-	stepInfo, err := QueryStepInfo(library, id, version)
+	stepInfo, err := QueryStepInfo(library, id, version, log.NewDefaultLogger(false))
 	if err != nil {
 		return err
 	}
 
-	log.Print(stepInfo)
+	logger.Print(stepInfo)
 	return nil
 }
 
 // QueryStepInfo returns a matching step info.
 // In cases of git and path sources the step.yml is read, otherwise the step is looked up in a step library.
-func QueryStepInfo(library, id, version string) (models.StepInfoModel, error) {
+func QueryStepInfo(library, id, version string, log stepman.Logger) (models.StepInfoModel, error) {
 	switch library {
 	case "git":
 		return QueryStepInfoFromGit(id, version)
 	case "path":
 		return QueryStepInfoFromPath(id)
 	default: // library step
-		return QueryStepInfoFromLibrary(library, id, version)
+		return QueryStepInfoFromLibrary(library, id, version, log)
 	}
 }
 
@@ -187,12 +187,12 @@ func QueryStepInfoFromPath(dir string) (models.StepInfoModel, error) {
 }
 
 // QueryStepInfoFromLibrary returns a step version based on the version string, which can be latest or locked to major or minor versions
-func QueryStepInfoFromLibrary(library, id, version string) (models.StepInfoModel, error) {
+func QueryStepInfoFromLibrary(library, id, version string, log stepman.Logger) (models.StepInfoModel, error) {
 	// Check if setup was done for collection
 	if exist, err := stepman.RootExistForLibrary(library); err != nil {
 		return models.StepInfoModel{}, fmt.Errorf("query steplib step info: check if setup was done for %s: %s", library, err)
 	} else if !exist {
-		if err := stepman.SetupLibrary(library); err != nil {
+		if err := stepman.SetupLibrary(library, log); err != nil {
 			return models.StepInfoModel{}, fmt.Errorf("query steplib step info: setup %s: %s", library, err)
 		}
 	}

--- a/vendor/github.com/bitrise-io/stepman/cli/step_info.go
+++ b/vendor/github.com/bitrise-io/stepman/cli/step_info.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 	"time"
 
@@ -52,8 +51,7 @@ var stepInfoCommand = cli.Command{
 	},
 	Action: func(c *cli.Context) error {
 		if err := stepInfo(c); err != nil {
-			log.Errorf("Command failed: %s", err)
-			os.Exit(1)
+			failf("Command failed: %s", err)
 		}
 		return nil
 	},

--- a/vendor/github.com/bitrise-io/stepman/cli/step_list.go
+++ b/vendor/github.com/bitrise-io/stepman/cli/step_list.go
@@ -4,8 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/bitrise-io/go-utils/colorstring"
+	"github.com/bitrise-io/go-utils/log"
 	"github.com/bitrise-io/go-utils/pointers"
 	"github.com/bitrise-io/go-utils/stringutil"
 	"github.com/bitrise-io/stepman/models"
@@ -60,13 +60,13 @@ func printJSONStepList(stepLibURI string, stepLib models.StepCollectionModel, is
 	return nil
 }
 
-func listSteps(stepLibURI, format string) error {
+func listSteps(stepLibURI, format string, log stepman.Logger) error {
 	// Check if setup was done for collection
 	if exist, err := stepman.RootExistForLibrary(stepLibURI); err != nil {
 		return err
 	} else if !exist {
-		if err := stepman.SetupLibrary(stepLibURI); err != nil {
-			log.Fatal("Failed to setup steplib")
+		if err := stepman.SetupLibrary(stepLibURI, log); err != nil {
+			failf("Failed to setup steplib")
 		}
 	}
 
@@ -104,11 +104,11 @@ func stepList(c *cli.Context) error {
 	if format == "" {
 		format = OutputFormatRaw
 	} else if !(format == OutputFormatRaw || format == OutputFormatJSON) {
-		log.Fatalf("Invalid format: %s", format)
+		failf("Invalid format: %s", format)
 	}
 
 	for _, URI := range stepLibURIs {
-		if err := listSteps(URI, format); err != nil {
+		if err := listSteps(URI, format, log.NewDefaultLogger(false)); err != nil {
 			log.Errorf("Failed to list steps in StepLib (%s), err: %s", URI, err)
 		}
 	}

--- a/vendor/github.com/bitrise-io/stepman/cli/update.go
+++ b/vendor/github.com/bitrise-io/stepman/cli/update.go
@@ -3,7 +3,7 @@ package cli
 import (
 	"fmt"
 
-	log "github.com/sirupsen/logrus"
+	"github.com/bitrise-io/go-utils/log"
 	"github.com/bitrise-io/stepman/stepman"
 	"github.com/urfave/cli"
 )
@@ -14,22 +14,28 @@ func update(c *cli.Context) error {
 	// StepSpec collection path
 	collectionURI := c.String(CollectionKey)
 	if collectionURI == "" {
-		log.Info("No StepLib specified, update all...")
+		log.Infof("No StepLib specified, update all...")
 		collectionURIs = stepman.GetAllStepCollectionPath()
 	} else {
 		collectionURIs = []string{collectionURI}
 	}
 
 	if len(collectionURIs) == 0 {
-		log.Info("No local StepLib found, nothing to update...")
+		log.Infof("No local StepLib found, nothing to update...")
 	}
 
 	for _, URI := range collectionURIs {
 		log.Infof("Update StepLib (%s)...", URI)
-		if _, err := stepman.UpdateLibrary(URI); err != nil {
+		if err := UpdateLibrary(URI, log.NewDefaultLogger(false)); err != nil {
 			return fmt.Errorf("Failed to update StepLib (%s), error: %s", URI, err)
 		}
 	}
 
 	return nil
+}
+
+// UpdateLibrary ...
+func UpdateLibrary(uri string, log stepman.Logger) error {
+	_, err := stepman.UpdateLibrary(uri, log)
+	return err
 }

--- a/vendor/github.com/bitrise-io/stepman/cli/version.go
+++ b/vendor/github.com/bitrise-io/stepman/cli/version.go
@@ -3,7 +3,6 @@ package cli
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 	"runtime"
 
 	flog "github.com/bitrise-io/go-utils/log"
@@ -64,8 +63,7 @@ func printVersionCmd(c *cli.Context) error {
 	} else if format == "json" {
 		log = flog.NewDefaultJSONLoger()
 	} else {
-		flog.Errorf("Invalid format: %s\n", format)
-		os.Exit(1)
+		failf("Invalid format: %s", format)
 	}
 
 	versionOutput := VersionOutputModel{}

--- a/vendor/github.com/bitrise-io/stepman/models/version_constraint.go
+++ b/vendor/github.com/bitrise-io/stepman/models/version_constraint.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
-
-	"github.com/bitrise-io/go-utils/log"
 )
 
 // Semver represents a semantic version
@@ -154,7 +152,6 @@ func latestMatchingStepVersion(constraint VersionConstraint, stepVersions StepGr
 			for fullVersion, step := range stepVersions.Versions {
 				stepVersion, err := parseSemver(fullVersion)
 				if err != nil {
-					log.Warnf("Invalid step (%s) version: %s", step.Source, fullVersion)
 					continue
 				}
 				if stepVersion.Major != constraint.Version.Major ||
@@ -184,7 +181,6 @@ func latestMatchingStepVersion(constraint VersionConstraint, stepVersions StepGr
 			for fullVersion, step := range stepVersions.Versions {
 				stepVersion, err := parseSemver(fullVersion)
 				if err != nil {
-					log.Warnf("Invalid step (%s) version: %s", step.Source, fullVersion)
 					continue
 				}
 				if stepVersion.Major != constraint.Version.Major {

--- a/vendor/github.com/bitrise-io/stepman/stepman/paths.go
+++ b/vendor/github.com/bitrise-io/stepman/stepman/paths.go
@@ -8,9 +8,9 @@ import (
 	"path/filepath"
 	"time"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/bitrise-io/go-utils/command"
 	"github.com/bitrise-io/go-utils/fileutil"
+	"github.com/bitrise-io/go-utils/log"
 	"github.com/bitrise-io/go-utils/pathutil"
 )
 
@@ -39,10 +39,8 @@ func (routes SteplibRoutes) GetRoute(URI string) (route SteplibRoute, found bool
 			pth := filepath.Join(GetCollectionsDirPath(), route.FolderAlias)
 			exist, err := pathutil.IsPathExists(pth)
 			if err != nil {
-				log.Warnf("Failed to read path %s", pth)
 				return SteplibRoute{}, false
 			} else if !exist {
-				log.Warnf("Failed to read path %s", pth)
 				return SteplibRoute{}, false
 			}
 			return route, true

--- a/vendor/github.com/bitrise-io/stepman/stepman/util.go
+++ b/vendor/github.com/bitrise-io/stepman/stepman/util.go
@@ -14,7 +14,6 @@ import (
 	"github.com/bitrise-io/go-utils/command"
 	"github.com/bitrise-io/go-utils/command/git"
 	"github.com/bitrise-io/go-utils/fileutil"
-	"github.com/bitrise-io/go-utils/log"
 	"github.com/bitrise-io/go-utils/pathutil"
 	"github.com/bitrise-io/go-utils/retry"
 	"github.com/bitrise-io/go-utils/urlutil"
@@ -107,7 +106,7 @@ func ParseStepCollection(pth string) (models.StepCollectionModel, error) {
 }
 
 // DownloadStep ...
-func DownloadStep(collectionURI string, collection models.StepCollectionModel, id, version, commithash string) error {
+func DownloadStep(collectionURI string, collection models.StepCollectionModel, id, version, commithash string, log Logger) error {
 	downloadLocations, err := collection.GetDownloadLocations(id, version)
 	if err != nil {
 		return err

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -8,7 +8,7 @@ github.com/bitrise-io/envman/envman
 github.com/bitrise-io/envman/models
 github.com/bitrise-io/envman/output
 github.com/bitrise-io/envman/version
-# github.com/bitrise-io/go-utils v1.0.2
+# github.com/bitrise-io/go-utils v1.0.3
 ## explicit
 github.com/bitrise-io/go-utils/colorstring
 github.com/bitrise-io/go-utils/command
@@ -36,7 +36,7 @@ github.com/bitrise-io/goinp/goinp
 # github.com/bitrise-io/gows v0.0.0-20211005113107-14f65e686b88
 ## explicit
 github.com/bitrise-io/gows/gows
-# github.com/bitrise-io/stepman v0.0.0-20220808095634-6e12d2726f30
+# github.com/bitrise-io/stepman v0.0.0-20221010110437-a88e9a915b58
 ## explicit
 github.com/bitrise-io/stepman/cli
 github.com/bitrise-io/stepman/models


### PR DESCRIPTION
### Checklist

- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-io/bitrise/blob/master/.github/CONTRIBUTING.md)
- [ ] `README.md` is updated with the changes (if needed)

### Version

Requires a *MINOR* [version update](https://semver.org/)

### Context

This PR makes Bitrise CLI use stepman functionalities through exported functions rather than through envman binary calls.

### Changes

- Update `tools.Stepman<Function>s` to use stepman exported functions.
  - stepman `step-list` and `share` functions were not migrated because they are not used by the workflow run command

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->