### PR TITLE
Print workflow ID in summary title

### DIFF
--- a/bitrise/print.go
+++ b/bitrise/print.go
@@ -2,6 +2,7 @@ package bitrise
 
 import (
 	"fmt"
+	"math"
 	"strings"
 	"time"
 	"unicode/utf8"
@@ -280,7 +281,7 @@ func getDeprecateNotesRows(notes string) string {
 	line := ""
 
 	for i, word := range words {
-		isLastLine := (i == len(words)-1)
+		isLastLine := i == len(words)-1
 
 		expectedLine := ""
 		if line == "" {
@@ -592,11 +593,18 @@ func PrintSummary(buildRunResults models.BuildRunResultsModel) {
 	log.Print()
 	log.Print()
 	log.Printf("+%s+", strings.Repeat("-", stepRunSummaryBoxWidthInChars-2))
-	whitespaceWidth := (stepRunSummaryBoxWidthInChars - 2 - len("bitrise summary ")) / 2
-	log.Printf("|%sbitrise summary %s|", strings.Repeat(" ", whitespaceWidth), strings.Repeat(" ", whitespaceWidth))
+
+	title := fmt.Sprintf("bitrise summary: %s", buildRunResults.WorkflowID)
+	whitespace := float64(stepRunSummaryBoxWidthInChars - 2 - len(title))
+	if whitespace < 0 {
+		whitespace = 0
+	}
+	leftPadding := int(math.Floor(whitespace / 2.0))
+	rightPadding := int(math.Ceil(whitespace / 2.0))
+	log.Printf("|%s%s%s|", strings.Repeat(" ", leftPadding), title, strings.Repeat(" ", rightPadding))
 	log.Printf("+%s+%s+%s+", strings.Repeat("-", iconBoxWidth), strings.Repeat("-", titleBoxWidth), strings.Repeat("-", timeBoxWidth))
 
-	whitespaceWidth = stepRunSummaryBoxWidthInChars - len("|   | title") - len("| time (s) |")
+	whitespaceWidth := stepRunSummaryBoxWidthInChars - len("|   | title") - len("| time (s) |")
 	log.Printf("|   | title%s| time (s) |", strings.Repeat(" ", whitespaceWidth))
 	log.Printf("+%s+%s+%s+", strings.Repeat("-", iconBoxWidth), strings.Repeat("-", titleBoxWidth), strings.Repeat("-", timeBoxWidth))
 

--- a/bitrise/print_test.go
+++ b/bitrise/print_test.go
@@ -3,6 +3,7 @@ package bitrise
 import (
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/bitrise-io/bitrise/models"
 	"github.com/bitrise-io/go-utils/pointers"
@@ -503,6 +504,7 @@ func TestPrintSummary(t *testing.T) {
 
 	buildResults := models.BuildRunResultsModel{
 		WorkflowID:     "my_workflow",
+		StartTime:      time.Now(),
 		StepmanUpdates: map[string]int{},
 		SuccessSteps:   []models.StepRunResultsModel{result1, result2},
 	}

--- a/bitrise/print_test.go
+++ b/bitrise/print_test.go
@@ -3,7 +3,6 @@ package bitrise
 import (
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/bitrise-io/bitrise/models"
 	"github.com/bitrise-io/go-utils/pointers"
@@ -503,7 +502,7 @@ func TestPrintSummary(t *testing.T) {
 	}
 
 	buildResults := models.BuildRunResultsModel{
-		StartTime:      time.Now(),
+		WorkflowID:     "my_workflow",
 		StepmanUpdates: map[string]int{},
 		SuccessSteps:   []models.StepRunResultsModel{result1, result2},
 	}

--- a/cli/run_test.go
+++ b/cli/run_test.go
@@ -674,7 +674,6 @@ func Test0Steps1Workflows(t *testing.T) {
 	require.NoError(t, err)
 
 	buildRunResults := models.BuildRunResultsModel{
-		StartTime:      time.Now(),
 		StepmanUpdates: map[string]int{},
 	}
 
@@ -722,7 +721,6 @@ func Test0Steps3WorkflowsBeforeAfter(t *testing.T) {
 	require.NoError(t, err)
 
 	buildRunResults := models.BuildRunResultsModel{
-		StartTime:      time.Now(),
 		StepmanUpdates: map[string]int{},
 	}
 
@@ -823,7 +821,6 @@ workflows:
 	require.Equal(t, true, found)
 
 	buildRunResults := models.BuildRunResultsModel{
-		StartTime:      time.Now(),
 		StepmanUpdates: map[string]int{},
 	}
 

--- a/cli/run_test.go
+++ b/cli/run_test.go
@@ -674,6 +674,7 @@ func Test0Steps1Workflows(t *testing.T) {
 	require.NoError(t, err)
 
 	buildRunResults := models.BuildRunResultsModel{
+		StartTime:      time.Now(),
 		StepmanUpdates: map[string]int{},
 	}
 
@@ -721,6 +722,7 @@ func Test0Steps3WorkflowsBeforeAfter(t *testing.T) {
 	require.NoError(t, err)
 
 	buildRunResults := models.BuildRunResultsModel{
+		StartTime:      time.Now(),
 		StepmanUpdates: map[string]int{},
 	}
 
@@ -821,6 +823,7 @@ workflows:
 	require.Equal(t, true, found)
 
 	buildRunResults := models.BuildRunResultsModel{
+		StartTime:      time.Now(),
 		StepmanUpdates: map[string]int{},
 	}
 

--- a/cli/run_util.go
+++ b/cli/run_util.go
@@ -1027,11 +1027,9 @@ func runWorkflowWithConfiguration(
 		log.Warnf("Failed to trigger WillStartRun, error: %s", err)
 	}
 
-	//
 	buildRunResults := models.BuildRunResultsModel{
-		StartTime:      startTime,
+		WorkflowID:     workflowToRunID,
 		StepmanUpdates: map[string]int{},
-		ProjectType:    bitriseConfig.ProjectType,
 	}
 
 	buildIDProperties := coreanalytics.Properties{analytics.BuildExecutionID: uuid.Must(uuid.NewV4()).String()}
@@ -1048,7 +1046,6 @@ func runWorkflowWithConfiguration(
 	bitrise.PrintSummary(buildRunResults)
 
 	// Trigger WorkflowRunDidFinish
-	buildRunResults.EventName = string(plugins.DidFinishRun)
 	if err := plugins.TriggerEvent(plugins.DidFinishRun, buildRunResults); err != nil {
 		log.Warnf("Failed to trigger WorkflowRunDidFinish, error: %s", err)
 	}

--- a/cli/run_util.go
+++ b/cli/run_util.go
@@ -1046,6 +1046,7 @@ func runWorkflowWithConfiguration(
 	bitrise.PrintSummary(buildRunResults)
 
 	// Trigger WorkflowRunDidFinish
+	buildRunResults.EventName = string(plugins.DidFinishRun)
 	if err := plugins.TriggerEvent(plugins.DidFinishRun, buildRunResults); err != nil {
 		log.Warnf("Failed to trigger WorkflowRunDidFinish, error: %s", err)
 	}

--- a/cli/run_util.go
+++ b/cli/run_util.go
@@ -1029,7 +1029,9 @@ func runWorkflowWithConfiguration(
 
 	buildRunResults := models.BuildRunResultsModel{
 		WorkflowID:     workflowToRunID,
+		StartTime:      startTime,
 		StepmanUpdates: map[string]int{},
+		ProjectType:    bitriseConfig.ProjectType,
 	}
 
 	buildIDProperties := coreanalytics.Properties{analytics.BuildExecutionID: uuid.Must(uuid.NewV4()).String()}

--- a/models/models.go
+++ b/models/models.go
@@ -134,6 +134,8 @@ type BuildRunStartModel struct {
 type BuildRunResultsModel struct {
 	WorkflowID           string                `json:"workflow_id" yaml:"workflow_id"`
 	EventName            string                `json:"event_name" yaml:"event_name"`
+	ProjectType          string                `json:"project_type" yaml:"project_type"`
+	StartTime            time.Time             `json:"start_time" yaml:"start_time"`
 	StepmanUpdates       map[string]int        `json:"stepman_updates" yaml:"stepman_updates"`
 	SuccessSteps         []StepRunResultsModel `json:"success_steps" yaml:"success_steps"`
 	FailedSteps          []StepRunResultsModel `json:"failed_steps" yaml:"failed_steps"`

--- a/models/models.go
+++ b/models/models.go
@@ -133,6 +133,7 @@ type BuildRunStartModel struct {
 // BuildRunResultsModel ...
 type BuildRunResultsModel struct {
 	WorkflowID           string                `json:"workflow_id" yaml:"workflow_id"`
+	EventName            string                `json:"event_name" yaml:"event_name"`
 	StepmanUpdates       map[string]int        `json:"stepman_updates" yaml:"stepman_updates"`
 	SuccessSteps         []StepRunResultsModel `json:"success_steps" yaml:"success_steps"`
 	FailedSteps          []StepRunResultsModel `json:"failed_steps" yaml:"failed_steps"`

--- a/models/models.go
+++ b/models/models.go
@@ -132,9 +132,7 @@ type BuildRunStartModel struct {
 
 // BuildRunResultsModel ...
 type BuildRunResultsModel struct {
-	EventName            string                `json:"event_name" yaml:"event_name"`
-	ProjectType          string                `json:"project_type" yaml:"project_type"`
-	StartTime            time.Time             `json:"start_time" yaml:"start_time"`
+	WorkflowID           string                `json:"workflow_id" yaml:"workflow_id"`
 	StepmanUpdates       map[string]int        `json:"stepman_updates" yaml:"stepman_updates"`
 	SuccessSteps         []StepRunResultsModel `json:"success_steps" yaml:"success_steps"`
 	FailedSteps          []StepRunResultsModel `json:"failed_steps" yaml:"failed_steps"`


### PR DESCRIPTION
<!--
  Thanks for contributing to the Bitrise CLI!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [X] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-io/bitrise/blob/master/.github/CONTRIBUTING.md)
- [X] `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *MAJOR/MINOR/PATCH* [version update](https://semver.org/)

### Context

The ASCII summary table printed at the end of the workflow doesn't tell which workflow's summary this is. Running the CLI locally, it would be really useful to see the workflow name (without scrolling up to see the beginning of the logs or the executed command)

### Changes

- Add the workflow ID to the `BuildRunResultsModel` struct
- Print the workflow ID and do some proper center-alignment in the ASCII table header

Preview of summary after the changes:

```
+------------------------------------------------------------------------------+
|                            bitrise summary: check                            |
+---+---------------------------------------------------------------+----------+
|   | title                                                         | time (s) |
+---+---------------------------------------------------------------+----------+
| x | git::https://github.com/bitrise-steplib/step... (exit code: 1)| 13.15 sec|
+---+---------------------------------------------------------------+----------+
| Issue tracker: Not provided                                                  |
| Source: Not provided                                                         |
+---+---------------------------------------------------------------+----------+
| - | go-list                                                       | 1.95 sec |
+---+---------------------------------------------------------------+----------+
| - | Go test                                                       | 0.37 sec |
+---+---------------------------------------------------------------+----------+
| Total runtime: 15.47 sec                                                     |
+------------------------------------------------------------------------------+
```

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->