### PR TITLE
Remove target_workflow_id from workflow run plan

### DIFF
--- a/cli/run.go
+++ b/cli/run.go
@@ -404,7 +404,6 @@ func createWorkflowRunPlan(targetWorkflow string, workflows map[string]models.Wo
 		NoOutputTimeoutMode:     configs.NoOutputTimeout > 0,
 		SecretFilteringMode:     configs.IsSecretFiltering,
 		SecretEnvsFilteringMode: configs.IsSecretEnvsFiltering,
-		TargetWorkflowID:        targetWorkflow,
 		ExecutionPlan:           executionPlan,
 	}
 }

--- a/models/workflow_run_plan.go
+++ b/models/workflow_run_plan.go
@@ -33,6 +33,5 @@ type WorkflowRunPlan struct {
 	SecretFilteringMode     bool `json:"secret_filtering_mode"`
 	SecretEnvsFilteringMode bool `json:"secret_envs_filtering_mode"`
 
-	TargetWorkflowID string                  `json:"target_workflow_id"`
-	ExecutionPlan    []WorkflowExecutionPlan `json:"execution_plan"`
+	ExecutionPlan []WorkflowExecutionPlan `json:"execution_plan"`
 }


### PR DESCRIPTION
### Checklist

- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-io/bitrise/blob/master/.github/CONTRIBUTING.md)
- [ ] `README.md` is updated with the changes (if needed)

### Version

Requires a *PATCH* [version update](https://semver.org/)

### Context

This PR updates `bitrise run` structured logs by removing the redundant `target_workflow_id` from the workflow run plan model.
Earlier the build log highlighted the target workflow when printing the list of the workflows to be executed, but it isn't anymore.

### Changes

- Remove `target_workflow_id` from WorkflowRunPlan

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->