### PR TITLE
Add version as input to Bitrise CLI header

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -144,7 +144,11 @@ func (m *defaultLogger) PrintBitriseStartedEvent(plan models.WorkflowRunPlan) {
 			EventType: "bitrise_started",
 		})
 	} else {
-		m.PrintBitriseASCIIArt()
+		v := strings.TrimSpace(plan.Version)
+		if v == "" {
+			v = version.VERSION
+		}
+		m.PrintBitriseASCIIArt(v)
 		m.Warnf("CI mode: %v", plan.CIMode)
 		m.Warnf("PR mode: %v", plan.PRMode)
 		m.Warnf("Debug mode: %v", plan.DebugMode)
@@ -169,7 +173,7 @@ func (m *defaultLogger) PrintBitriseStartedEvent(plan models.WorkflowRunPlan) {
 }
 
 // PrintBitriseASCIIArt ...
-func (m *defaultLogger) PrintBitriseASCIIArt() {
+func (m *defaultLogger) PrintBitriseASCIIArt(version string) {
 	m.Print(`
 ██████╗ ██╗████████╗██████╗ ██╗███████╗███████╗
 ██╔══██╗██║╚══██╔══╝██╔══██╗██║██╔════╝██╔════╝
@@ -177,7 +181,7 @@ func (m *defaultLogger) PrintBitriseASCIIArt() {
 ██╔══██╗██║   ██║   ██╔══██╗██║╚════██║██╔══╝
 ██████╔╝██║   ██║   ██║  ██║██║███████║███████╗
 ╚═════╝ ╚═╝   ╚═╝   ╚═╝  ╚═╝╚═╝╚══════╝╚══════╝`)
-	m.Printf("version: %s", version.VERSION)
+	m.Printf("version: %s", version)
 	m.Print()
 }
 

--- a/log/log.go
+++ b/log/log.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/bitrise-io/bitrise/log/corelog"
 	"github.com/bitrise-io/bitrise/models"
-	"github.com/bitrise-io/bitrise/version"
 )
 
 const rfc3339MicroTimeLayout = "2006-01-02T15:04:05.999999Z07:00"
@@ -144,11 +143,7 @@ func (m *defaultLogger) PrintBitriseStartedEvent(plan models.WorkflowRunPlan) {
 			EventType: "bitrise_started",
 		})
 	} else {
-		v := strings.TrimSpace(plan.Version)
-		if v == "" {
-			v = version.VERSION
-		}
-		m.PrintBitriseASCIIArt(v)
+		m.PrintBitriseASCIIArt(plan.Version)
 		m.Warnf("CI mode: %v", plan.CIMode)
 		m.Warnf("PR mode: %v", plan.PRMode)
 		m.Warnf("Debug mode: %v", plan.DebugMode)

--- a/log/log_functions.go
+++ b/log/log_functions.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/bitrise-io/bitrise/log/corelog"
 	"github.com/bitrise-io/bitrise/models"
+	"github.com/bitrise-io/bitrise/version"
 )
 
 var globalLogger *defaultLogger
@@ -104,7 +105,7 @@ func PrintBitriseStartedEvent(plan models.WorkflowRunPlan) {
 }
 
 func PrintBitriseASCIIArt() {
-	getGlobalLogger().PrintBitriseASCIIArt()
+	getGlobalLogger().PrintBitriseASCIIArt(version.VERSION)
 }
 
 func PrintStepStartedEvent(params StepStartedParams) {

--- a/log/logger.go
+++ b/log/logger.go
@@ -25,5 +25,5 @@ type Logger interface {
 	PrintBitriseStartedEvent(plan models.WorkflowRunPlan)
 	PrintStepStartedEvent(params StepStartedParams)
 	PrintStepFinishedEvent(params StepFinishedParams)
-	PrintBitriseASCIIArt()
+	PrintBitriseASCIIArt(version string)
 }


### PR DESCRIPTION
Use the version from the `models.WorkflowRunPlan` when printing the Bitrise CLI header.