### PR TITLE
Update version to 2.0.1

### DIFF
--- a/version/build.go
+++ b/version/build.go
@@ -1,7 +1,7 @@
 package version
 
 // VERSION is the main CLI version number. It's defined at build time using -ldflags
-var VERSION = "1.99.0-development"
+var VERSION = "2.0.1"
 
 // BuildNumber is the CI build number that creates the release. It's defined at build time using -ldflags
 var BuildNumber = ""


### PR DESCRIPTION
### Checklist

- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-io/bitrise/blob/master/.github/CONTRIBUTING.md)
- [x] `README.md` is updated with the changes (if needed)

### Version

Requires a *PATCH* [version update](https://semver.org/)

### Context

Currently, Bitrise CLI has a template version hardcoded, which gets overridden when it is built on CI.
When Bitrise CLI is built in any other way, it will print the template version.

When running an experiment on a new Bitrise CLI version, the CLI gets updated with `go install github.com/bitrise-io/bitrise@<revision>`. 
When using a version tag as revision printing the template version (`1.99.0-development`) is unexpected.

This PR sets the version number to the next version to be released (2.0.1).

### Changes

- update the version number to 2.0.1

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->