### PR TITLE
fix: don't log empty messages

### DIFF
--- a/log/logwriter/writer.go
+++ b/log/logwriter/writer.go
@@ -17,6 +17,9 @@ func NewLogWriter(logger log.Logger) LogWriter {
 }
 
 func (w LogWriter) Write(p []byte) (n int, err error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
 	level, message := convertColoredString(string(p))
 	w.logger.LogMessage(message, level)
 	return len(p), nil

--- a/log/logwriter/writer.go
+++ b/log/logwriter/writer.go
@@ -20,6 +20,7 @@ func (w LogWriter) Write(p []byte) (n int, err error) {
 	if len(p) == 0 {
 		return 0, nil
 	}
+
 	level, message := convertColoredString(string(p))
 	w.logger.LogMessage(message, level)
 	return len(p), nil

--- a/log/logwriter/writer_test.go
+++ b/log/logwriter/writer_test.go
@@ -7,11 +7,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-
 	"github.com/bitrise-io/bitrise/log"
 	"github.com/bitrise-io/bitrise/log/logwriter"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func referenceTime() time.Time {

--- a/log/logwriter/writer_test.go
+++ b/log/logwriter/writer_test.go
@@ -7,10 +7,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/bitrise-io/bitrise/log"
-	"github.com/bitrise-io/bitrise/log/logwriter"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/bitrise-io/bitrise/log"
+	"github.com/bitrise-io/bitrise/log/logwriter"
 )
 
 func referenceTime() time.Time {
@@ -18,6 +19,8 @@ func referenceTime() time.Time {
 }
 
 func Test_GivenWriter_WhenStdoutIsUsed_ThenCapturesTheOutput(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name            string
 		producer        log.Producer
@@ -34,10 +37,24 @@ func Test_GivenWriter_WhenStdoutIsUsed_ThenCapturesTheOutput(t *testing.T) {
 		},
 		{
 			name:            "Step JSON log",
-			producer:        log.BitriseCLI,
+			producer:        log.Step,
 			loggerType:      log.JSONLogger,
 			message:         "Test message",
-			expectedMessage: `{"timestamp":"2022-01-01T01:01:01Z","type":"log","producer":"bitrise_cli","level":"normal","message":"Test message"}` + "\n",
+			expectedMessage: `{"timestamp":"2022-01-01T01:01:01Z","type":"log","producer":"step","level":"normal","message":"Test message"}` + "\n",
+		},
+		{
+			name:            "Empty step JSON log",
+			producer:        log.Step,
+			loggerType:      log.JSONLogger,
+			message:         "",
+			expectedMessage: "",
+		},
+		{
+			name:            "New line step JSON log",
+			producer:        log.Step,
+			loggerType:      log.JSONLogger,
+			message:         "\n",
+			expectedMessage: `{"timestamp":"2022-01-01T01:01:01Z","type":"log","producer":"step","level":"normal","message":"\n"}` + "\n",
 		},
 	}
 

--- a/log/logwriter/writer_test.go
+++ b/log/logwriter/writer_test.go
@@ -18,8 +18,6 @@ func referenceTime() time.Time {
 }
 
 func Test_GivenWriter_WhenStdoutIsUsed_ThenCapturesTheOutput(t *testing.T) {
-	t.Parallel()
-
 	tests := []struct {
 		name            string
 		producer        log.Producer


### PR DESCRIPTION
<!--
  Thanks for contributing to the Bitrise CLI!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-io/bitrise/blob/master/.github/CONTRIBUTING.md)
- [ ] `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *PATCH* [version update](https://semver.org/)

### Context

<!--- 
  One sentence summary on why the change is needed.
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->

When structured JSON logging is used, don't log empty messages to reduce the complexity and improve performance by not sending an empty json structure to the build-log-service

<!-- Please link the issue that the PR fixes.
Resolves: #GITHUB_ISSUE_ID or https://link_to_the_issue_on_discuss.bitrise.io.
-->

### Changes

<!-- 
  Details are important, and help maintainers processing your PR.
  Please list additional details, for example:
  - Update dependencies
  - Make `foo` optional in `main.go`
  - `foo` now returns an `error` for better error handling
-->

structured log writer's write method short circuits empty log messages + test coverage to make sure formatting is preserved

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->