### PR TITLE
Update default plugin versions

### DIFF
--- a/bitrise/setup.go
+++ b/bitrise/setup.go
@@ -28,7 +28,7 @@ type PluginDependency struct {
 var PluginDependencyMap = map[string]PluginDependency{
 	"init": {
 		Source:     "https://github.com/bitrise-io/bitrise-plugins-init.git",
-		MinVersion: "1.9.1",
+		MinVersion: "1.10.0",
 	},
 	"step": {
 		Source:     "https://github.com/bitrise-io/bitrise-plugins-step.git",
@@ -40,7 +40,7 @@ var PluginDependencyMap = map[string]PluginDependency{
 	},
 	"analytics": {
 		Source:     "https://github.com/bitrise-io/bitrise-plugins-analytics.git",
-		MinVersion: "0.12.7",
+		MinVersion: "0.13.0",
 	},
 }
 


### PR DESCRIPTION
### Checklist

- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-io/bitrise/blob/master/.github/CONTRIBUTING.md)
- [x] `README.md` is updated with the changes (if needed)

### Version

Requires a *MINOR* [version update](https://semver.org/)

### Context

This PR updates the default plugin versions, to make the [latest analytics plugin](https://github.com/bitrise-io/bitrise-plugins-analytics/releases/tag/0.13.0) the default with the updated analytics service base URL.

### Changes

New default plugin versions:
- init plugin: 1.9.1 -> [1.10.0](https://github.com/bitrise-io/bitrise-plugins-init/releases/tag/1.10.0)
- analytics plugin: 0.12.7 -> [0.13.0](https://github.com/bitrise-io/bitrise-plugins-analytics/releases/tag/0.13.0)
