### PR TITLE
Bump version to 2.2.0

### DIFF
--- a/version/build.go
+++ b/version/build.go
@@ -1,7 +1,7 @@
 package version
 
 // VERSION is the main CLI version number. It's defined at build time using -ldflags
-var VERSION = "2.1.0"
+var VERSION = "2.2.0"
 
 // BuildNumber is the CI build number that creates the release. It's defined at build time using -ldflags
 var BuildNumber = ""


### PR DESCRIPTION
### Checklist

- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-io/bitrise/blob/master/.github/CONTRIBUTING.md)
- [x] `README.md` is updated with the changes (if needed)

### Version

Requires a *MINOR* [version update](https://semver.org/)

### Context

This PR bumps Bitrise CLI version to 2.2.0, for releasing:
- https://github.com/bitrise-io/bitrise/pull/838
- https://github.com/bitrise-io/bitrise/pull/839
- https://github.com/bitrise-io/bitrise/pull/840

### Changes

- version: 2.1.0 -> 2.2.0