### PR TITLE
Command logs

### DIFF
--- a/bitrise/dependencies.go
+++ b/bitrise/dependencies.go
@@ -316,7 +316,7 @@ func InstallWithBrewIfNeeded(brewDep stepmanModels.BrewDepModel, isCIMode bool) 
 				return errors.New("(" + brewDep.Name + ") is required for step")
 			}
 		}
-		
+
 		cmd := command.New("brew", "install", brewDep.Name)
 		log.Infof("Installing package: %s...", cmd.PrintableCommandArgs())
 		if out, err := cmd.RunAndReturnTrimmedCombinedOutput(); err != nil {

--- a/cli/json_output.go
+++ b/cli/json_output.go
@@ -38,20 +38,20 @@ func (l RawLogger) Print(f Formatable) {
 	}
 }
 
-// JSONLoger ...
-type JSONLoger struct {
+// JSONLogger ...
+type JSONLogger struct {
 	writer io.Writer
 }
 
-// NewDefaultJSONLoger ...
-func NewDefaultJSONLoger() JSONLoger {
-	return JSONLoger{
+// NewDefaultJSONLogger ...
+func NewDefaultJSONLogger() JSONLogger {
+	return JSONLogger{
 		writer: os.Stdout,
 	}
 }
 
 // Print ...
-func (l JSONLoger) Print(f Formatable) {
+func (l JSONLogger) Print(f Formatable) {
 	if _, err := fmt.Fprint(l.writer, f.JSON()); err != nil {
 		log.Printf("failed to print message: %s, error: %s\n", f.JSON(), err)
 	}

--- a/cli/plugin_info.go
+++ b/cli/plugin_info.go
@@ -89,7 +89,7 @@ func pluginInfo(c *cli.Context) error {
 	var logger Logger
 	logger = NewDefaultRawLogger()
 	if format == output.FormatJSON {
-		logger = NewDefaultJSONLoger()
+		logger = NewDefaultJSONLogger()
 	}
 	// ---
 

--- a/cli/plugin_list.go
+++ b/cli/plugin_list.go
@@ -43,7 +43,7 @@ func pluginList(c *cli.Context) error {
 	var logger Logger
 	logger = NewDefaultRawLogger()
 	if format == output.FormatJSON {
-		logger = NewDefaultJSONLoger()
+		logger = NewDefaultJSONLogger()
 	}
 	// ---
 

--- a/cli/validate.go
+++ b/cli/validate.go
@@ -241,7 +241,7 @@ func validate(c *cli.Context) error {
 	if format == output.FormatRaw {
 		log = NewDefaultRawLogger()
 	} else if format == output.FormatJSON {
-		log = NewDefaultJSONLoger()
+		log = NewDefaultJSONLogger()
 	} else {
 		log.Print(NewValidationError(fmt.Sprintf("Invalid format: %s", format)))
 		os.Exit(1)

--- a/cli/workflow_list.go
+++ b/cli/workflow_list.go
@@ -192,7 +192,7 @@ func workflowList(c *cli.Context) error {
 	var logger Logger
 	logger = NewDefaultRawLogger()
 	if format == output.FormatJSON {
-		logger = NewDefaultJSONLoger()
+		logger = NewDefaultJSONLogger()
 	}
 
 	if minimal && idOnly {

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -2,7 +2,6 @@ package utils
 
 import (
 	"fmt"
-	"os"
 	"os/exec"
 	"strings"
 	"time"
@@ -11,7 +10,6 @@ import (
 // CheckProgramInstalledPath ...
 func CheckProgramInstalledPath(clcommand string) (string, error) {
 	cmd := exec.Command("which", clcommand)
-	cmd.Stderr = os.Stderr
 	outBytes, err := cmd.Output()
 	outStr := string(outBytes)
 	return strings.TrimSpace(outStr), err


### PR DESCRIPTION
### Checklist

- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-io/bitrise/blob/master/.github/CONTRIBUTING.md)
- [x] `README.md` is updated with the changes (if needed)

### Version

Requires a *PATCH* [version update](https://semver.org/)

### Context

This PR fixes a bug with structured logging: before Bitrise CLI installs an apt-get package, an apt-get update command is executed, which was writing to the os.Stdout directly. This resulted in a raw log, even if structured logging was enabled (`--output-format json`)

### Changes

- Hide the apt-get update command output as long as the command succeeds, return the output as part of the returned error otherwise
- Stop CheckProgramInstalledPath to print to os.Stderr
- Typo fix: longer -> logger

### Investigation details

I was searching for `os.Stdout` and `os.Stderr` in the codebase to find all the occurrences where we write directly to the standard output.