### PR TITLE
Fix for the no output timeout related crash

### DIFF
--- a/cli/build_run_result_collector.go
+++ b/cli/build_run_result_collector.go
@@ -97,6 +97,9 @@ func (r buildRunResultCollector) registerStepRunResults(
 		ErrorStr:   errStr,
 		ExitCode:   exitCode,
 		StartTime:  stepStartTime,
+
+		Timeout:         timeout,
+		NoOutputTimeout: noOutputTimeout,
 	}
 
 	r.tracker.SendStepFinishedEvent(properties, analytics.StepResult{

--- a/cli/run_config.go
+++ b/cli/run_config.go
@@ -49,7 +49,3 @@ func readNoOutputTimoutConfiguration(inventoryEnvironments []envmanModels.Enviro
 
 	return time.Duration(timeout) * time.Second
 }
-
-func registerNoOutputTimeout(timeout time.Duration) {
-	configs.NoOutputTimeout = timeout
-}

--- a/cli/run_test.go
+++ b/cli/run_test.go
@@ -57,7 +57,8 @@ workflows:
 		require.NoError(t, configs.InitPaths())
 
 		runConfig := RunConfig{Config: config, Workflow: "skip_if_empty"}
-		buildRunResults, err := runWorkflows(runConfig, noOpTracker{})
+		runner := NewWorkflowRunner(runConfig)
+		buildRunResults, err := runner.runWorkflows(noOpTracker{})
 		require.NoError(t, err)
 		require.Equal(t, 1, len(buildRunResults.SuccessSteps))
 		require.Equal(t, 0, len(buildRunResults.FailedSteps))
@@ -97,7 +98,8 @@ workflows:
 		require.NoError(t, configs.InitPaths())
 
 		runConfig := RunConfig{Config: config, Workflow: "skip_if_empty"}
-		buildRunResults, err := runWorkflows(runConfig, noOpTracker{})
+		runner := NewWorkflowRunner(runConfig)
+		buildRunResults, err := runner.runWorkflows(noOpTracker{})
 		require.NoError(t, err)
 		require.Equal(t, 1, len(buildRunResults.SuccessSteps))
 		require.Equal(t, 0, len(buildRunResults.FailedSteps))
@@ -156,7 +158,8 @@ workflows:
 	require.NoError(t, configs.InitPaths())
 
 	runConfig := RunConfig{Config: config, Workflow: "test"}
-	buildRunResults, err := runWorkflows(runConfig, noOpTracker{})
+	runner := NewWorkflowRunner(runConfig)
+	buildRunResults, err := runner.runWorkflows(noOpTracker{})
 	require.NoError(t, err)
 	require.Equal(t, 4, len(buildRunResults.SuccessSteps))
 	require.Equal(t, 0, len(buildRunResults.FailedSteps))
@@ -221,7 +224,8 @@ workflows:
 	require.NoError(t, configs.InitPaths())
 
 	runConfig := RunConfig{Config: config, Workflow: "test", Secrets: inventory.Envs}
-	buildRunResults, err := runWorkflows(runConfig, noOpTracker{})
+	runner := NewWorkflowRunner(runConfig)
+	buildRunResults, err := runner.runWorkflows(noOpTracker{})
 	require.NoError(t, err)
 	require.Equal(t, 5, len(buildRunResults.SuccessSteps))
 	require.Equal(t, 0, len(buildRunResults.FailedSteps))
@@ -265,7 +269,8 @@ workflows:
 	require.NoError(t, configs.InitPaths())
 
 	runConfig := RunConfig{Config: config, Workflow: "test"}
-	buildRunResults, err := runWorkflows(runConfig, noOpTracker{})
+	runner := NewWorkflowRunner(runConfig)
+	buildRunResults, err := runner.runWorkflows(noOpTracker{})
 	require.NoError(t, err)
 	require.Equal(t, 1, len(buildRunResults.SuccessSteps))
 	require.Equal(t, 0, len(buildRunResults.FailedSteps))
@@ -327,7 +332,8 @@ workflows:
 		require.NoError(t, configs.InitPaths())
 
 		runConfig := RunConfig{Config: config, Workflow: "test", Secrets: inventory.Envs}
-		_, err = runWorkflows(runConfig, noOpTracker{})
+		runner := NewWorkflowRunner(runConfig)
+		_, err = runner.runWorkflows(noOpTracker{})
 		require.NoError(t, err)
 	}
 
@@ -369,7 +375,8 @@ workflows:
 		require.NoError(t, configs.InitPaths())
 
 		runConfig := RunConfig{Config: config, Workflow: "test", Secrets: inventory.Envs}
-		_, err = runWorkflows(runConfig, noOpTracker{})
+		runner := NewWorkflowRunner(runConfig)
+		_, err = runner.runWorkflows(noOpTracker{})
 		require.NoError(t, err)
 	}
 
@@ -413,7 +420,8 @@ workflows:
 		require.NoError(t, configs.InitPaths())
 
 		runConfig := RunConfig{Config: config, Workflow: "test", Secrets: inventory.Envs}
-		_, err = runWorkflows(runConfig, noOpTracker{})
+		runner := NewWorkflowRunner(runConfig)
+		_, err = runner.runWorkflows(noOpTracker{})
 		require.NoError(t, err)
 	}
 
@@ -463,7 +471,8 @@ workflows:
 		require.NoError(t, configs.InitPaths())
 
 		runConfig := RunConfig{Config: config, Workflow: "test", Secrets: inventory.Envs}
-		_, err = runWorkflows(runConfig, noOpTracker{})
+		runner := NewWorkflowRunner(runConfig)
+		_, err = runner.runWorkflows(noOpTracker{})
 		require.NoError(t, err)
 	}
 }
@@ -504,7 +513,8 @@ workflows:
 		require.NoError(t, configs.InitPaths())
 
 		runConfig := RunConfig{Config: config, Workflow: "test", Secrets: inventory.Envs}
-		_, err = runWorkflows(runConfig, noOpTracker{})
+		runner := NewWorkflowRunner(runConfig)
+		_, err = runner.runWorkflows(noOpTracker{})
 		require.NoError(t, err)
 	}
 
@@ -548,7 +558,8 @@ workflows:
 		require.NoError(t, configs.InitPaths())
 
 		runConfig := RunConfig{Config: config, Workflow: "test", Secrets: inventory.Envs}
-		_, err = runWorkflows(runConfig, noOpTracker{})
+		runner := NewWorkflowRunner(runConfig)
+		_, err = runner.runWorkflows(noOpTracker{})
 		require.NoError(t, err)
 	}
 
@@ -593,7 +604,8 @@ workflows:
 		require.NoError(t, configs.InitPaths())
 
 		runConfig := RunConfig{Config: config, Workflow: "test", Secrets: inventory.Envs}
-		_, err = runWorkflows(runConfig, noOpTracker{})
+		runner := NewWorkflowRunner(runConfig)
+		_, err = runner.runWorkflows(noOpTracker{})
 		require.NoError(t, err)
 	}
 
@@ -641,7 +653,8 @@ workflows:
 		require.NoError(t, configs.InitPaths())
 
 		runConfig := RunConfig{Config: config, Workflow: "test", Secrets: inventory.Envs}
-		_, err = runWorkflows(runConfig, noOpTracker{})
+		runner := NewWorkflowRunner(runConfig)
+		_, err = runner.runWorkflows(noOpTracker{})
 		require.NoError(t, err)
 	}
 }
@@ -675,7 +688,8 @@ func Test0Steps1Workflows(t *testing.T) {
 	require.NoError(t, configs.InitPaths())
 
 	runConfig := RunConfig{Config: config, Workflow: "zero_steps"}
-	buildRunResults, err = runWorkflows(runConfig, noOpTracker{})
+	runner := NewWorkflowRunner(runConfig)
+	buildRunResults, err = runner.runWorkflows(noOpTracker{})
 	require.NoError(t, err)
 	require.Equal(t, 0, len(buildRunResults.SuccessSteps))
 	require.Equal(t, 0, len(buildRunResults.FailedSteps))
@@ -723,7 +737,8 @@ func Test0Steps3WorkflowsBeforeAfter(t *testing.T) {
 	require.NoError(t, configs.InitPaths())
 
 	runConfig := RunConfig{Config: config, Workflow: "target"}
-	buildRunResults, err = runWorkflows(runConfig, noOpTracker{})
+	runner := NewWorkflowRunner(runConfig)
+	buildRunResults, err = runner.runWorkflows(noOpTracker{})
 
 	require.NoError(t, err)
 	require.Equal(t, 0, len(buildRunResults.SuccessSteps))
@@ -781,7 +796,8 @@ workflows:
 	require.NoError(t, configs.InitPaths())
 
 	runConfig := RunConfig{Config: config, Workflow: "trivial_fail"}
-	buildRunResults, err = runWorkflows(runConfig, noOpTracker{})
+	runner := NewWorkflowRunner(runConfig)
+	buildRunResults, err = runner.runWorkflows(noOpTracker{})
 
 	require.NoError(t, err)
 	require.Equal(t, 3, len(buildRunResults.SuccessSteps))
@@ -863,7 +879,8 @@ workflows:
 	require.NoError(t, configs.InitPaths())
 
 	runConfig := RunConfig{Config: config, Workflow: "target"}
-	buildRunResults, err := runWorkflows(runConfig, noOpTracker{})
+	runner := NewWorkflowRunner(runConfig)
+	buildRunResults, err := runner.runWorkflows(noOpTracker{})
 	require.NoError(t, err)
 	require.Equal(t, 3, len(buildRunResults.SuccessSteps))
 	require.Equal(t, 2, len(buildRunResults.FailedSteps))
@@ -970,7 +987,8 @@ workflows:
 	require.NoError(t, configs.InitPaths())
 
 	runConfig := RunConfig{Config: config, Workflow: "target"}
-	buildRunResults, err := runWorkflows(runConfig, noOpTracker{})
+	runner := NewWorkflowRunner(runConfig)
+	buildRunResults, err := runner.runWorkflows(noOpTracker{})
 	require.NoError(t, err)
 	require.Equal(t, 3, len(buildRunResults.SuccessSteps))
 	require.Equal(t, 1, len(buildRunResults.FailedSteps))
@@ -1026,7 +1044,8 @@ workflows:
 	require.NoError(t, configs.InitPaths())
 
 	runConfig := RunConfig{Config: config, Workflow: "target"}
-	buildRunResults, err := runWorkflows(runConfig, noOpTracker{})
+	runner := NewWorkflowRunner(runConfig)
+	buildRunResults, err := runner.runWorkflows(noOpTracker{})
 	require.NoError(t, err)
 	require.Equal(t, 3, len(buildRunResults.SuccessSteps))
 	require.Equal(t, 1, len(buildRunResults.FailedSteps))
@@ -1060,7 +1079,8 @@ workflows:
 	require.NoError(t, configs.InitPaths())
 
 	runConfig := RunConfig{Config: config, Workflow: "target"}
-	buildRunResults, err := runWorkflows(runConfig, noOpTracker{})
+	runner := NewWorkflowRunner(runConfig)
+	buildRunResults, err := runner.runWorkflows(noOpTracker{})
 	require.NoError(t, err)
 	require.Equal(t, 1, len(buildRunResults.SuccessSteps))
 	require.Equal(t, 0, len(buildRunResults.FailedSteps))
@@ -1117,7 +1137,8 @@ workflows:
 	require.NoError(t, configs.InitPaths())
 
 	runConfig := RunConfig{Config: config, Workflow: "target"}
-	buildRunResults, err := runWorkflows(runConfig, noOpTracker{})
+	runner := NewWorkflowRunner(runConfig)
+	buildRunResults, err := runner.runWorkflows(noOpTracker{})
 	require.NoError(t, err)
 	require.Equal(t, 1, len(buildRunResults.SuccessSteps))
 	require.Equal(t, 1, len(buildRunResults.FailedSteps))
@@ -1177,7 +1198,8 @@ workflows:
 	require.NoError(t, configs.InitPaths())
 
 	runConfig := RunConfig{Config: config, Workflow: "target"}
-	buildRunResults, err := runWorkflows(runConfig, noOpTracker{})
+	runner := NewWorkflowRunner(runConfig)
+	buildRunResults, err := runner.runWorkflows(noOpTracker{})
 	require.NoError(t, err)
 	require.Equal(t, 2, len(buildRunResults.SuccessSteps))
 	require.Equal(t, 0, len(buildRunResults.FailedSteps))
@@ -1237,7 +1259,8 @@ workflows:
 	require.NoError(t, configs.InitPaths())
 
 	runConfig := RunConfig{Config: config, Workflow: "target"}
-	buildRunResults, err := runWorkflows(runConfig, noOpTracker{})
+	runner := NewWorkflowRunner(runConfig)
+	buildRunResults, err := runner.runWorkflows(noOpTracker{})
 	require.NoError(t, err)
 	require.Equal(t, 2, len(buildRunResults.SuccessSteps))
 	require.Equal(t, 0, len(buildRunResults.FailedSteps))
@@ -1285,7 +1308,8 @@ workflows:
 	require.NoError(t, configs.InitPaths())
 
 	runConfig := RunConfig{Config: config, Workflow: "target"}
-	buildRunResults, err := runWorkflows(runConfig, noOpTracker{})
+	runner := NewWorkflowRunner(runConfig)
+	buildRunResults, err := runner.runWorkflows(noOpTracker{})
 	require.NoError(t, err)
 	require.Equal(t, 1, len(buildRunResults.SuccessSteps))
 	require.Equal(t, 0, len(buildRunResults.FailedSteps))
@@ -1341,7 +1365,8 @@ workflows:
 	require.NoError(t, configs.InitPaths())
 
 	runConfig := RunConfig{Config: config, Workflow: "target"}
-	buildRunResults, err := runWorkflows(runConfig, noOpTracker{})
+	runner := NewWorkflowRunner(runConfig)
+	buildRunResults, err := runner.runWorkflows(noOpTracker{})
 	require.NoError(t, err)
 	require.Equal(t, 2, len(buildRunResults.SuccessSteps))
 	require.Equal(t, 0, len(buildRunResults.FailedSteps))
@@ -1401,7 +1426,8 @@ workflows:
 	require.NoError(t, configs.InitPaths())
 
 	runConfig := RunConfig{Config: config, Workflow: "out-test"}
-	buildRunResults, err := runWorkflows(runConfig, noOpTracker{})
+	runner := NewWorkflowRunner(runConfig)
+	buildRunResults, err := runner.runWorkflows(noOpTracker{})
 	require.Equal(t, 0, len(buildRunResults.SkippedSteps))
 	require.Equal(t, 3, len(buildRunResults.SuccessSteps))
 	require.Equal(t, 1, len(buildRunResults.FailedSteps))
@@ -1450,7 +1476,8 @@ workflows:
 	require.NoError(t, configs.InitPaths())
 
 	runConfig := RunConfig{Config: config, Workflow: "test"}
-	buildRunResults, err := runWorkflows(runConfig, noOpTracker{})
+	runner := NewWorkflowRunner(runConfig)
+	buildRunResults, err := runner.runWorkflows(noOpTracker{})
 	require.NoError(t, err)
 	require.Equal(t, 2, len(buildRunResults.SuccessSteps))
 	require.Equal(t, 0, len(buildRunResults.FailedSteps))
@@ -1503,7 +1530,8 @@ workflows:
 	require.NoError(t, configs.InitPaths())
 
 	runConfig := RunConfig{Config: config, Workflow: "test"}
-	buildRunResults, err := runWorkflows(runConfig, noOpTracker{})
+	runner := NewWorkflowRunner(runConfig)
+	buildRunResults, err := runner.runWorkflows(noOpTracker{})
 	require.Equal(t, nil, err)
 	require.Equal(t, 0, len(buildRunResults.SkippedSteps))
 	require.Equal(t, 2, len(buildRunResults.SuccessSteps))
@@ -1532,7 +1560,8 @@ workflows:
 	require.NoError(t, configs.InitPaths())
 
 	runConfig := RunConfig{Config: config, Workflow: "target"}
-	results, err := runWorkflows(runConfig, noOpTracker{})
+	runner := NewWorkflowRunner(runConfig)
+	results, err := runner.runWorkflows(noOpTracker{})
 	require.Equal(t, 1, len(results.StepmanUpdates))
 }
 
@@ -1624,7 +1653,8 @@ route_map:
 			log.InitGlobalLogger(opts)
 
 			runConfig := RunConfig{Config: config, Workflow: "test"}
-			_, err := runWorkflows(runConfig, noOpTracker{})
+			runner := NewWorkflowRunner(runConfig)
+			_, err := runner.runWorkflows(noOpTracker{})
 			opts.Writer = origWiter
 
 			// Then

--- a/cli/trigger.go
+++ b/cli/trigger.go
@@ -197,7 +197,8 @@ func trigger(c *cli.Context) error {
 		Secrets:  inventoryEnvironments,
 	}
 
-	exitCode, err := runWorkflowsWithSetupAndCheckForUpdate(runConfig)
+	runner := NewWorkflowRunner(runConfig)
+	exitCode, err := runner.RunWorkflowsWithSetupAndCheckForUpdate()
 	if err != nil {
 		if err == workflowRunFailedErr {
 			msg := createWorkflowRunStatusMessage(exitCode)

--- a/configs/configs.go
+++ b/configs/configs.go
@@ -33,9 +33,6 @@ var (
 	IsSecretFiltering = false
 	// IsSecretEnvsFiltering ...
 	IsSecretEnvsFiltering = false
-
-	// NoOutputTimeout is the timeout after Steps are aborted, when no output is received
-	NoOutputTimeout time.Duration
 )
 
 // ---------------------------

--- a/models/models.go
+++ b/models/models.go
@@ -144,6 +144,9 @@ type StepRunResultsModel struct {
 	StartTime  time.Time                   `json:"start_time" yaml:"start_time"`
 	ErrorStr   string                      `json:"error_str" yaml:"error_str"`
 	ExitCode   int                         `json:"exit_code" yaml:"exit_code"`
+
+	Timeout         time.Duration `json:"-"`
+	NoOutputTimeout time.Duration `json:"-"`
 }
 
 // StepError ...
@@ -208,9 +211,9 @@ func (s StepRunResultsModel) error() []StepError {
 		StepRunStatusCodePreparationFailed:
 		message = s.ErrorStr
 	case StepRunStatusAbortedWithCustomTimeout:
-		message = fmt.Sprintf("This Step timed out after %s.", formatStatusReasonTimeInterval(*s.StepInfo.Step.Timeout))
+		message = fmt.Sprintf("This Step timed out after %s.", formatStatusReasonTimeInterval(s.Timeout))
 	case StepRunStatusAbortedWithNoOutputTimeout:
-		message = fmt.Sprintf("This Step failed, because it has not sent any output for %s.", formatStatusReasonTimeInterval(*s.StepInfo.Step.NoOutputTimeout))
+		message = fmt.Sprintf("This Step failed, because it has not sent any output for %s.", formatStatusReasonTimeInterval(s.NoOutputTimeout))
 	}
 
 	return []StepError{{
@@ -219,8 +222,8 @@ func (s StepRunResultsModel) error() []StepError {
 	}}
 }
 
-func formatStatusReasonTimeInterval(timeInterval int) string {
-	var remaining int = timeInterval
+func formatStatusReasonTimeInterval(timeInterval time.Duration) string {
+	var remaining int = int(timeInterval / time.Second)
 	h := int(remaining / 3600)
 	remaining = remaining - h*3600
 	m := int(remaining / 60)

--- a/models/models_test.go
+++ b/models/models_test.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"testing"
+	"time"
 
 	"github.com/bitrise-io/stepman/models"
 	"github.com/stretchr/testify/assert"
@@ -95,11 +96,9 @@ The "run_if" expression was: 2+2==4`
 }
 
 func TestStatusReasonCustomTimeout(t *testing.T) {
-	var timeout int = 32450
-	var model models.StepModel = models.StepModel{
-		Timeout: &timeout,
-	}
-	var info models.StepInfoModel = models.StepInfoModel{
+	timeout := 32450 * time.Second
+	model := models.StepModel{}
+	info := models.StepInfoModel{
 		Step: model,
 	}
 	var s StepRunResultsModel = StepRunResultsModel{
@@ -107,6 +106,7 @@ func TestStatusReasonCustomTimeout(t *testing.T) {
 		StepInfo: info,
 		ExitCode: 5,
 		ErrorStr: "This won't be used.",
+		Timeout:  timeout,
 	}
 	expectedStatusReason := ""
 	expectedStepErrors := []StepError{{Code: 5, Message: "This Step timed out after 9h 50s."}}
@@ -117,18 +117,17 @@ func TestStatusReasonCustomTimeout(t *testing.T) {
 }
 
 func TestStatusReasonNoOutputTimeout(t *testing.T) {
-	var noOutputTimeout int = 32
-	var model models.StepModel = models.StepModel{
-		NoOutputTimeout: &noOutputTimeout,
-	}
-	var info models.StepInfoModel = models.StepInfoModel{
+	noOutputTimeout := 32 * time.Second
+	model := models.StepModel{}
+	info := models.StepInfoModel{
 		Step: model,
 	}
 	var s StepRunResultsModel = StepRunResultsModel{
-		Status:   StepRunStatusAbortedWithNoOutputTimeout,
-		StepInfo: info,
-		ExitCode: 6,
-		ErrorStr: "This won't be used.",
+		Status:          StepRunStatusAbortedWithNoOutputTimeout,
+		StepInfo:        info,
+		ExitCode:        6,
+		ErrorStr:        "This won't be used.",
+		NoOutputTimeout: noOutputTimeout,
 	}
 	expectedStatusReason := ""
 	expectedStepErrors := []StepError{{Code: 6, Message: "This Step failed, because it has not sent any output for 32s."}}
@@ -151,16 +150,16 @@ func TestStatusReasonDefault(t *testing.T) {
 }
 
 func TestFormatStatusReasonTimeInterval(t *testing.T) {
-	expected := map[int]string{
-		10:   "10s",
-		60:   "1m",
-		61:   "1m 1s",
-		3600: "1h",
-		3601: "1h 1s",
-		3661: "1h 1m 1s",
+	expected := map[time.Duration]string{
+		10 * time.Second:   "10s",
+		60 * time.Second:   "1m",
+		61 * time.Second:   "1m 1s",
+		3600 * time.Second: "1h",
+		3601 * time.Second: "1h 1s",
+		3661 * time.Second: "1h 1m 1s",
 	}
 
-	actual := make(map[int]string)
+	actual := make(map[time.Duration]string)
 
 	for key := range expected {
 		actual[key] = formatStatusReasonTimeInterval(key)


### PR DESCRIPTION
### Checklist

- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-io/bitrise/blob/master/.github/CONTRIBUTING.md)
- [x] `README.md` is updated with the changes (if needed)

### Version

Requires a *PATCH* [version update](https://semver.org/)

### Context

This PR fixes a crash in the Bitrise CLI, which happens when no-output-timeout is defined through secrets (and NOT as a step property) and a step meets the timeout.

The bug can be reproduced by using this workflow:

```
  no_output_timeout_test:
    steps:
    - script:
        inputs:
        - content: |-
            sleep 10
```

and specifying 5s timeout as a secret (`.bitrise.secrets.yml`):

```
envs:
- BITRISE_NO_OUTPUT_TIMEOUT: 5
```

`bitrise run no_output_timeout_test` will panic:

```
[15:29:13] No output received for a while. Bitrise CLI is still active.
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x1027ca36c]

goroutine 1 [running]:
github.com/bitrise-io/bitrise/models.StepRunResultsModel.error({{{0x140001cf980, 0x31}, {0x140001adc96, 0x6}, {0x140038149b8, 0x5}, {0x0, 0x0}, {0x140017f6320, 0x5}, ...}, ...})
        $HOME/go/bitrise/models/models.go:213 +0x8c
github.com/bitrise-io/bitrise/models.StepRunResultsModel.StatusReasonAndErrors({{{0x140001cf980, 0x31}, {0x140001adc96, 0x6}, {0x140038149b8, 0x5}, {0x0, 0x0}, {0x140017f6320, 0x5}, ...}, ...})
        $HOME/go/go/bitrise/models/models.go:172 +0x23c
...
```

<!-- Please link the issue that the PR fixes.
Resolves: #GITHUB_ISSUE_ID or https://link_to_the_issue_on_discuss.bitrise.io.
-->

### Changes

- Storing Timeout and NoOutputTimeout on the StepRunResultsModel. 
  - `buildRunResultCollector` specifies the timeouts, based on the step run error.
  - `configs` package's `NoOutputTimeout` variable is removed, to avoid missusages in the future. To determine the value of the actual NoOutputTimeout, use the WorkflowRunner.config.Modes.NoOutputTimeout (step specific NoOutputTimeout overrides the global config).
- Intorudce WorkflowRunner and assign workflow run related functions to this model. Storing the RunConfig on the WorkflowRunner helps sharing the workflow run modes with all the functions involved (like `createWorkflowRunPlan` and `executeStep`) in running a workflow.

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->