### PR TITLE
stop gows command printing to the stdout directly

### DIFF
--- a/toolkits/command_runner.go
+++ b/toolkits/command_runner.go
@@ -10,27 +10,11 @@ import (
 
 // commandRunner ...
 type commandRunner interface {
-	run(c *command.Model) error
 	runForOutput(c *command.Model) (string, error)
 }
 
 // defaultRunner ...
 type defaultRunner struct {
-}
-
-// run ...
-func (r *defaultRunner) run(c *command.Model) error {
-	log.Debugf("$ %s", c.PrintableCommandArgs())
-
-	if err := c.Run(); err != nil {
-		if errorutil.IsExitStatusError(err) {
-			return fmt.Errorf("command `%s` failed: %v", c.PrintableCommandArgs(), err)
-		}
-
-		return fmt.Errorf("failed to run command `%s`: %v", c.PrintableCommandArgs(), err)
-	}
-
-	return nil
 }
 
 // runForOutput ...

--- a/toolkits/golang.go
+++ b/toolkits/golang.go
@@ -302,12 +302,15 @@ func goBuildInGoPathMode(cmdRunner commandRunner, goConfig GoConfigurationModel,
 		return fmt.Errorf("Failed to create Project->Workspace symlink, error: %s", err)
 	}
 
-	cmd := gows.CreateCommand(workspaceRootPath, workspaceRootPath,
-		goConfig.GoBinaryPath, "build", "-o", outputBinPath, packageName)
+	cmd := gows.CreateCommand(workspaceRootPath, workspaceRootPath, goConfig.GoBinaryPath, "build", "-o", outputBinPath, packageName)
+	cmd.Stdout = nil
+	cmd.Stderr = nil
+	cmd.Stdin = nil
 	cmd.Env = append(cmd.Env, "GOROOT="+goConfig.GOROOT)
+
 	buildCmd := command.NewWithCmd(cmd)
 
-	if err := cmdRunner.run(buildCmd); err != nil {
+	if _, err := cmdRunner.runForOutput(buildCmd); err != nil {
 		return fmt.Errorf("Failed to install package, error: %s", err)
 	}
 

--- a/toolkits/golang_test.go
+++ b/toolkits/golang_test.go
@@ -99,12 +99,6 @@ type mockRunner struct {
 	cmds    []string
 }
 
-func (m *mockRunner) run(cmd *command.Model) error {
-	m.cmds = append(m.cmds, cmd.PrintableCommandArgs())
-
-	return nil
-}
-
 func (m *mockRunner) runForOutput(cmd *command.Model) (string, error) {
 	m.cmds = append(m.cmds, cmd.PrintableCommandArgs())
 	if val, ok := m.outputs[cmd.PrintableCommandArgs()]; ok {


### PR DESCRIPTION
### Checklist

- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-io/bitrise/blob/master/.github/CONTRIBUTING.md)
- [x] `README.md` is updated with the changes (if needed)

### Version

Requires a *PATCH* [version update](https://semver.org/)

### Context

This PR stops Go toolkit printing directly to the os.Stdout, which messes up structured logging.

### Changes

- Set the gows command's std `out`, `err`, and `in` to nil and execute with `runForOutput`
- Remove `run` from the `commandRunner`, because it allows running commands, which might directly write to the stdout.

### Investigation details

As an alternative solution, I tried to utilize the v2 command package because the [Factory.Create](https://github.com/bitrise-io/go-utils/blob/master/command/command.go#L42) method enforces a code where you allow the client to specify the command std interface.
 
I tried to implement a similar solution that we have in the ruby package for gows: https://github.com/bitrise-io/gows/commit/dbd258a214bc70fe36b14a6dea271351537b80d4

The issue is that not the Bitrise CLI nor gows uses the v2 command library, and I didn't want to migrate them along this bug fix.
