### PR TITLE
test: use `t.Setenv` to set env vars in tests

### DIFF
--- a/_tests/integration/global_flag_test.go
+++ b/_tests/integration/global_flag_test.go
@@ -1,7 +1,6 @@
 package integration
 
 import (
-	"os"
 	"testing"
 
 	"github.com/bitrise-io/bitrise/configs"
@@ -39,125 +38,90 @@ func Test_GlobalFlagPRTriggerCheck(t *testing.T) {
 	configPth := "global_flag_test_bitrise.yml"
 	secretsPth := "global_flag_test_secrets.yml"
 
-	prModeEnv := os.Getenv(configs.PRModeEnvKey)
-	prIDEnv := os.Getenv(configs.PullRequestIDEnvKey)
-
-	// cleanup Envs after these tests
-	defer func() {
-		require.NoError(t, os.Setenv(configs.PRModeEnvKey, prModeEnv))
-		require.NoError(t, os.Setenv(configs.PullRequestIDEnvKey, prIDEnv))
-	}()
-
-	t.Log("global flag sets pr mode")
-	{
-		require.NoError(t, os.Setenv(configs.PRModeEnvKey, "false"))
-		require.NoError(t, os.Setenv(configs.PullRequestIDEnvKey, ""))
+	t.Run("global flag sets pr mode", func(t *testing.T) {
+		t.Setenv(configs.PRModeEnvKey, "false")
+		t.Setenv(configs.PullRequestIDEnvKey, "")
 
 		cmd := command.New(binPath(), "--pr", "trigger-check", "deprecated_pr", "--config", configPth, "--inventory", secretsPth)
 		out, err := cmd.RunAndReturnTrimmedCombinedOutput()
 		require.Error(t, err, out)
-	}
+	})
 
-	t.Log("global flag sets pr mode")
-	{
-
-		require.NoError(t, os.Setenv("PR", "false"))
-		require.NoError(t, os.Setenv("PULL_REQUEST_ID", ""))
+	t.Run("global flag sets pr mode", func(t *testing.T) {
+		t.Setenv(configs.PRModeEnvKey, "false")
+		t.Setenv(configs.PullRequestIDEnvKey, "")
 
 		cmd := command.New(binPath(), "--pr=true", "trigger-check", "deprecated_pr", "--config", configPth, "--inventory", secretsPth)
 		out, err := cmd.RunAndReturnTrimmedCombinedOutput()
 		require.Error(t, err, out)
-	}
+	})
 
-	t.Log("global flag sets NOT pr mode")
-	{
-		require.NoError(t, os.Setenv("PR", "true"))
-		require.NoError(t, os.Setenv("PULL_REQUEST_ID", "ID"))
+	t.Run("global flag sets NOT pr mode", func(t *testing.T) {
+		t.Setenv(configs.PRModeEnvKey, "true")
+		t.Setenv(configs.PullRequestIDEnvKey, "ID")
 
 		cmd := command.New(binPath(), "--pr=true", "trigger-check", "master", "--config", configPth, "--format", "json")
 		out, err := cmd.RunAndReturnTrimmedCombinedOutput()
 		require.NoError(t, err, out)
 		require.Equal(t, `{"pattern":"master","workflow":"deprecated_pr"}`, out)
-	}
+	})
 
-	t.Log("global flag sets NOT pr mode")
-	{
-		require.NoError(t, os.Setenv("PR", "true"))
-		require.NoError(t, os.Setenv("PULL_REQUEST_ID", "ID"))
+	t.Run("global flag sets NOT pr mode", func(t *testing.T) {
+		t.Setenv(configs.PRModeEnvKey, "true")
+		t.Setenv(configs.PullRequestIDEnvKey, "ID")
 
 		cmd := command.New(binPath(), "--pr=false", "trigger-check", "master", "--config", configPth, "--format", "json")
 		out, err := cmd.RunAndReturnTrimmedCombinedOutput()
 		require.NoError(t, err, out)
 		require.Equal(t, `{"pattern":"master","workflow":"deprecated_code_push"}`, out)
-	}
+	})
 }
 
 func Test_GlobalFlagPRTrigger(t *testing.T) {
 	configPth := "global_flag_test_bitrise.yml"
 	secretsPth := "global_flag_test_secrets.yml"
 
-	prModeEnv := os.Getenv(configs.PRModeEnvKey)
-	prIDEnv := os.Getenv(configs.PullRequestIDEnvKey)
+	t.Setenv(configs.PRModeEnvKey, "false")
+	t.Setenv(configs.PullRequestIDEnvKey, "")
 
-	// cleanup Envs after these tests
-	defer func() {
-		require.NoError(t, os.Setenv(configs.PRModeEnvKey, prModeEnv))
-		require.NoError(t, os.Setenv(configs.PullRequestIDEnvKey, prIDEnv))
-	}()
-
-	require.NoError(t, os.Setenv(configs.PRModeEnvKey, "false"))
-	require.NoError(t, os.Setenv(configs.PullRequestIDEnvKey, ""))
-
-	t.Log("global flag sets pr mode")
-	{
+	t.Run("global flag sets pr mode", func(t *testing.T) {
 		cmd := command.New(binPath(), "--pr", "trigger", "deprecated_pr", "--config", configPth, "--inventory", secretsPth)
 		out, err := cmd.RunAndReturnTrimmedCombinedOutput()
 		require.Error(t, err, out)
-	}
+	})
 
-	t.Log("global flag sets pr mode")
-	{
+	t.Run("global flag sets pr mode", func(t *testing.T) {
 		cmd := command.New(binPath(), "--pr=true", "trigger", "deprecated_pr", "--config", configPth, "--inventory", secretsPth)
 		out, err := cmd.RunAndReturnTrimmedCombinedOutput()
 		require.Error(t, err, out)
-	}
+	})
 }
 
 func Test_GlobalFlagCI(t *testing.T) {
 	configPth := "global_flag_test_bitrise.yml"
 	secretsPth := "global_flag_test_secrets.yml"
 
-	ciModeEnv := os.Getenv(configs.CIModeEnvKey)
-
-	// cleanup Envs after these tests
-	defer func() {
-		require.NoError(t, os.Setenv(configs.CIModeEnvKey, ciModeEnv))
-	}()
-
-	t.Log("Should run in ci mode")
-	{
-		require.NoError(t, os.Setenv(configs.CIModeEnvKey, "false"))
+	t.Run("Should run in ci mode", func(t *testing.T) {
+		t.Setenv(configs.CIModeEnvKey, "false")
 
 		cmd := command.New(binPath(), "--ci", "run", "fail_in_not_ci_mode", "--config", configPth, "--inventory", secretsPth)
 		out, err := cmd.RunAndReturnTrimmedCombinedOutput()
 		require.NoError(t, err, out)
-	}
+	})
 
-	t.Log("Should run in ci mode")
-	{
-		require.NoError(t, os.Setenv(configs.CIModeEnvKey, "false"))
+	t.Run("Should run in ci mode", func(t *testing.T) {
+		t.Setenv(configs.CIModeEnvKey, "false")
 
 		cmd := command.New(binPath(), "--ci=true", "run", "fail_in_not_ci_mode", "--config", configPth, "--inventory", secretsPth)
 		out, err := cmd.RunAndReturnTrimmedCombinedOutput()
 		require.NoError(t, err, out)
-	}
+	})
 
-	t.Log("Should run in ci mode")
-	{
-		require.NoError(t, os.Setenv(configs.CIModeEnvKey, "true"))
+	t.Run("Should run in ci mode", func(t *testing.T) {
+		t.Setenv(configs.CIModeEnvKey, "true")
 
 		cmd := command.New(binPath(), "--ci=false", "run", "fail_in_ci_mode", "--config", configPth)
 		out, err := cmd.RunAndReturnTrimmedCombinedOutput()
 		require.NoError(t, err, out)
-	}
+	})
 }

--- a/cli/run_test.go
+++ b/cli/run_test.go
@@ -663,11 +663,8 @@ workflows:
 func Test0Steps1Workflows(t *testing.T) {
 	workflow := models.WorkflowModel{}
 
-	require.NoError(t, os.Setenv("BITRISE_BUILD_STATUS", "0"))
-	defer func() { require.NoError(t, os.Unsetenv("BITRISE_BUILD_STATUS")) }()
-
-	require.NoError(t, os.Setenv("STEPLIB_BUILD_STATUS", "0"))
-	defer func() { require.NoError(t, os.Unsetenv("STEPLIB_BUILD_STATUS")) }()
+	t.Setenv("BITRISE_BUILD_STATUS", "0")
+	t.Setenv("STEPLIB_BUILD_STATUS", "0")
 
 	config := models.BitriseDataModel{
 		FormatVersion:        "1.0.0",
@@ -702,11 +699,8 @@ func Test0Steps1Workflows(t *testing.T) {
 
 // Workflow contains before and after workflow, and no one contains steps
 func Test0Steps3WorkflowsBeforeAfter(t *testing.T) {
-	require.NoError(t, os.Setenv("BITRISE_BUILD_STATUS", "0"))
-	defer func() { require.NoError(t, os.Unsetenv("BITRISE_BUILD_STATUS")) }()
-
-	require.NoError(t, os.Setenv("STEPLIB_BUILD_STATUS", "0"))
-	defer func() { require.NoError(t, os.Unsetenv("STEPLIB_BUILD_STATUS")) }()
+	t.Setenv("BITRISE_BUILD_STATUS", "0")
+	t.Setenv("STEPLIB_BUILD_STATUS", "0")
 
 	beforeWorkflow := models.WorkflowModel{}
 	afterWorkflow := models.WorkflowModel{}

--- a/cli/run_util_test.go
+++ b/cli/run_util_test.go
@@ -71,27 +71,25 @@ func TestIsSecretFiltering(t *testing.T) {
 }
 
 func TestIsPRMode(t *testing.T) {
-	prModeEnv := os.Getenv(configs.PRModeEnvKey)
-	prIDEnv := os.Getenv(configs.PullRequestIDEnvKey)
-
-	// cleanup Envs after these tests
-	defer func() {
-		require.NoError(t, os.Setenv(configs.PRModeEnvKey, prModeEnv))
-		require.NoError(t, os.Setenv(configs.PullRequestIDEnvKey, prIDEnv))
-	}()
-
-	t.Log("Should be false for: prGlobalFlag: nil, prModeEnv: '', prIDEnv: ''")
-	{
-		require.NoError(t, os.Setenv(configs.PRModeEnvKey, ""))
-		require.NoError(t, os.Setenv(configs.PullRequestIDEnvKey, ""))
+	t.Run("Should be false for: prGlobalFlag: nil, prModeEnv: '', prIDEnv: ''", func(t *testing.T) {
+		t.Setenv(configs.PRModeEnvKey, "")
+		t.Setenv(configs.PullRequestIDEnvKey, "")
 
 		pr, err := isPRMode(nil, []envmanModels.EnvironmentItemModel{})
 		require.NoError(t, err)
 		require.Equal(t, false, pr)
-	}
+	})
 
-	t.Log("Should be false for: prGlobalFlag: nil, prModeEnv: '', prIDEnv: '', secrets: false")
-	{
+	t.Run("Should be true for: prGlobalFlag: true, prModeEnv: '', prIDEnv: ''", func(t *testing.T) {
+		t.Setenv(configs.PRModeEnvKey, "")
+		t.Setenv(configs.PullRequestIDEnvKey, "")
+
+		pr, err := isPRMode(pointers.NewBoolPtr(true), []envmanModels.EnvironmentItemModel{})
+		require.NoError(t, err)
+		require.Equal(t, true, pr)
+	})
+
+	t.Run("Should be false for: prGlobalFlag: nil, prModeEnv: '', prIDEnv: '', secrets: false", func(t *testing.T) {
 		inventoryStr := `
 envs:
 - PR: "false"
@@ -100,16 +98,15 @@ envs:
 		inventory, err := bitrise.InventoryModelFromYAMLBytes([]byte(inventoryStr))
 		require.NoError(t, err)
 
-		require.NoError(t, os.Setenv(configs.PRModeEnvKey, ""))
-		require.NoError(t, os.Setenv(configs.PullRequestIDEnvKey, ""))
+		t.Setenv(configs.PRModeEnvKey, "")
+		t.Setenv(configs.PullRequestIDEnvKey, "")
 
 		pr, err := isPRMode(nil, inventory.Envs)
 		require.NoError(t, err)
 		require.Equal(t, false, pr)
-	}
+	})
 
-	t.Log("Should be false for: prGlobalFlag: nil, prModeEnv: 'false', prIDEnv: '', secrets: ''")
-	{
+	t.Run("Should be false for: prGlobalFlag: nil, prModeEnv: 'false', prIDEnv: '', secrets: ''", func(t *testing.T) {
 		inventoryStr := `
 envs:
 - PR: ""
@@ -118,16 +115,15 @@ envs:
 		inventory, err := bitrise.InventoryModelFromYAMLBytes([]byte(inventoryStr))
 		require.NoError(t, err)
 
-		require.NoError(t, os.Setenv(configs.PRModeEnvKey, "false"))
-		require.NoError(t, os.Setenv(configs.PullRequestIDEnvKey, ""))
+		t.Setenv(configs.PRModeEnvKey, "false")
+		t.Setenv(configs.PullRequestIDEnvKey, "")
 
 		pr, err := isPRMode(nil, inventory.Envs)
 		require.NoError(t, err)
 		require.Equal(t, false, pr)
-	}
+	})
 
-	t.Log("Should be false for: prGlobalFlag: false, prModeEnv: 'true', prIDEnv: 'ID', secrets: 'true'")
-	{
+	t.Run("Should be false for: prGlobalFlag: false, prModeEnv: 'true', prIDEnv: 'ID', secrets: 'true'", func(t *testing.T) {
 		inventoryStr := `
 envs:
 - PR: "true"
@@ -136,26 +132,15 @@ envs:
 		inventory, err := bitrise.InventoryModelFromYAMLBytes([]byte(inventoryStr))
 		require.NoError(t, err)
 
-		require.NoError(t, os.Setenv(configs.PRModeEnvKey, "true"))
-		require.NoError(t, os.Setenv(configs.PullRequestIDEnvKey, "ID"))
+		t.Setenv(configs.PRModeEnvKey, "true")
+		t.Setenv(configs.PullRequestIDEnvKey, "ID")
 
 		pr, err := isPRMode(pointers.NewBoolPtr(false), inventory.Envs)
 		require.NoError(t, err)
 		require.Equal(t, false, pr)
-	}
+	})
 
-	t.Log("Should be true for: prGlobalFlag: true, prModeEnv: '', prIDEnv: ''")
-	{
-		require.NoError(t, os.Setenv(configs.PRModeEnvKey, ""))
-		require.NoError(t, os.Setenv(configs.PullRequestIDEnvKey, ""))
-
-		pr, err := isPRMode(pointers.NewBoolPtr(true), []envmanModels.EnvironmentItemModel{})
-		require.NoError(t, err)
-		require.Equal(t, true, pr)
-	}
-
-	t.Log("Should be true for: prGlobalFlag: true, prModeEnv: '', prIDEnv: '', secrets: false")
-	{
+	t.Run("Should be true for: prGlobalFlag: true, prModeEnv: '', prIDEnv: '', secrets: false", func(t *testing.T) {
 		inventoryStr := `
 envs:
 - PR: "false"
@@ -164,16 +149,15 @@ envs:
 		inventory, err := bitrise.InventoryModelFromYAMLBytes([]byte(inventoryStr))
 		require.NoError(t, err)
 
-		require.NoError(t, os.Setenv(configs.PRModeEnvKey, ""))
-		require.NoError(t, os.Setenv(configs.PullRequestIDEnvKey, ""))
+		t.Setenv(configs.PRModeEnvKey, "")
+		t.Setenv(configs.PullRequestIDEnvKey, "")
 
 		pr, err := isPRMode(pointers.NewBoolPtr(true), inventory.Envs)
 		require.NoError(t, err)
 		require.Equal(t, true, pr)
-	}
+	})
 
-	t.Log("Should be true for: prGlobalFlag: nil, prModeEnv: 'true', prIDEnv: '', secrets: false")
-	{
+	t.Run("Should be true for: prGlobalFlag: nil, prModeEnv: 'true', prIDEnv: '', secrets: false", func(t *testing.T) {
 		inventoryStr := `
 envs:
 - PR: "false"
@@ -182,16 +166,15 @@ envs:
 		inventory, err := bitrise.InventoryModelFromYAMLBytes([]byte(inventoryStr))
 		require.NoError(t, err)
 
-		require.NoError(t, os.Setenv(configs.PRModeEnvKey, "true"))
-		require.NoError(t, os.Setenv(configs.PullRequestIDEnvKey, ""))
+		t.Setenv(configs.PRModeEnvKey, "true")
+		t.Setenv(configs.PullRequestIDEnvKey, "")
 
 		pr, err := isPRMode(nil, inventory.Envs)
 		require.NoError(t, err)
 		require.Equal(t, true, pr)
-	}
+	})
 
-	t.Log("Should be true for: prGlobalFlag: nil, prModeEnv: 'false', prIDEnv: 'some', secrets: false")
-	{
+	t.Run("Should be true for: prGlobalFlag: nil, prModeEnv: 'false', prIDEnv: 'some', secrets: false", func(t *testing.T) {
 		inventoryStr := `
 envs:
 - PR: "false"
@@ -200,16 +183,15 @@ envs:
 		inventory, err := bitrise.InventoryModelFromYAMLBytes([]byte(inventoryStr))
 		require.NoError(t, err)
 
-		require.NoError(t, os.Setenv(configs.PRModeEnvKey, "false"))
-		require.NoError(t, os.Setenv(configs.PullRequestIDEnvKey, "some"))
+		t.Setenv(configs.PRModeEnvKey, "false")
+		t.Setenv(configs.PullRequestIDEnvKey, "some")
 
 		pr, err := isPRMode(nil, inventory.Envs)
 		require.NoError(t, err)
 		require.Equal(t, true, pr)
-	}
+	})
 
-	t.Log("Should be true for: prGlobalFlag: nil, prModeEnv: '', prIDEnv: '', secrets: true")
-	{
+	t.Run("Should be true for: prGlobalFlag: nil, prModeEnv: '', prIDEnv: '', secrets: true", func(t *testing.T) {
 		inventoryStr := `
 envs:
 - PR: "true"
@@ -218,16 +200,15 @@ envs:
 		inventory, err := bitrise.InventoryModelFromYAMLBytes([]byte(inventoryStr))
 		require.NoError(t, err)
 
-		require.NoError(t, os.Setenv(configs.PRModeEnvKey, ""))
-		require.NoError(t, os.Setenv(configs.PullRequestIDEnvKey, ""))
+		t.Setenv(configs.PRModeEnvKey, "")
+		t.Setenv(configs.PullRequestIDEnvKey, "")
 
 		pr, err := isPRMode(nil, inventory.Envs)
 		require.NoError(t, err)
 		require.Equal(t, true, pr)
-	}
+	})
 
-	t.Log("Should be true for: prGlobalFlag: nil, prModeEnv: 'false', prIDEnv: '', secrets: true")
-	{
+	t.Run("Should be true for: prGlobalFlag: nil, prModeEnv: 'false', prIDEnv: '', secrets: true", func(t *testing.T) {
 		inventoryStr := `
 envs:
 - PR: ""
@@ -236,16 +217,15 @@ envs:
 		inventory, err := bitrise.InventoryModelFromYAMLBytes([]byte(inventoryStr))
 		require.NoError(t, err)
 
-		require.NoError(t, os.Setenv(configs.PRModeEnvKey, "false"))
-		require.NoError(t, os.Setenv(configs.PullRequestIDEnvKey, ""))
+		t.Setenv(configs.PRModeEnvKey, "false")
+		t.Setenv(configs.PullRequestIDEnvKey, "")
 
 		pr, err := isPRMode(nil, inventory.Envs)
 		require.NoError(t, err)
 		require.Equal(t, true, pr)
-	}
+	})
 
-	t.Log("Should be true for: prGlobalFlag: true, prModeEnv: 'false', prIDEnv: '', secrets: false")
-	{
+	t.Run("Should be true for: prGlobalFlag: true, prModeEnv: 'false', prIDEnv: '', secrets: false", func(t *testing.T) {
 		inventoryStr := `
 envs:
 - PR: "false"
@@ -254,58 +234,33 @@ envs:
 		inventory, err := bitrise.InventoryModelFromYAMLBytes([]byte(inventoryStr))
 		require.NoError(t, err)
 
-		require.NoError(t, os.Setenv(configs.PRModeEnvKey, "false"))
-		require.NoError(t, os.Setenv(configs.PullRequestIDEnvKey, ""))
+		t.Setenv(configs.PRModeEnvKey, "false")
+		t.Setenv(configs.PullRequestIDEnvKey, "")
 
 		pr, err := isPRMode(pointers.NewBoolPtr(true), inventory.Envs)
 		require.NoError(t, err)
 		require.Equal(t, true, pr)
-	}
+	})
 }
 
 func TestIsCIMode(t *testing.T) {
-	ciModeEnv := os.Getenv(configs.CIModeEnvKey)
-
-	defer func() {
-		require.NoError(t, os.Setenv(configs.CIModeEnvKey, ciModeEnv))
-	}()
-
-	t.Log("Should be false for: ciGlobalFlag: nil, ciModeEnv: 'false'")
-	{
-		require.NoError(t, os.Setenv(configs.CIModeEnvKey, "false"))
+	t.Run("Should be false for: ciGlobalFlag: nil, ciModeEnv: 'false'", func(t *testing.T) {
+		t.Setenv(configs.CIModeEnvKey, "false")
 
 		ci, err := isCIMode(nil, []envmanModels.EnvironmentItemModel{})
 		require.NoError(t, err)
 		require.Equal(t, false, ci)
-	}
+	})
 
-	t.Log("Should be false for: ciGlobalFlag: false, ciModeEnv: 'false' secrets: false")
-	{
-		inventoryStr := `
-envs:
-- CI: "false"
-`
-		inventory, err := bitrise.InventoryModelFromYAMLBytes([]byte(inventoryStr))
-		require.NoError(t, err)
-
-		require.NoError(t, os.Setenv(configs.CIModeEnvKey, "false"))
-
-		ci, err := isCIMode(pointers.NewBoolPtr(false), inventory.Envs)
-		require.NoError(t, err)
-		require.Equal(t, false, ci)
-	}
-
-	t.Log("Should be true for: ciGlobalFlag: true, ciModeEnv: 'false'")
-	{
-		require.NoError(t, os.Setenv(configs.CIModeEnvKey, ""))
+	t.Run("Should be true for: ciGlobalFlag: true, ciModeEnv: 'false'", func(t *testing.T) {
+		t.Setenv(configs.CIModeEnvKey, "")
 
 		ci, err := isCIMode(pointers.NewBoolPtr(true), []envmanModels.EnvironmentItemModel{})
 		require.NoError(t, err)
 		require.Equal(t, true, ci)
-	}
+	})
 
-	t.Log("Should be true for: ciGlobalFlag: true, ciModeEnv: '' secrets: false")
-	{
+	t.Run("Should be false for: ciGlobalFlag: false, ciModeEnv: 'false' secrets: false", func(t *testing.T) {
 		inventoryStr := `
 envs:
 - CI: "false"
@@ -313,15 +268,29 @@ envs:
 		inventory, err := bitrise.InventoryModelFromYAMLBytes([]byte(inventoryStr))
 		require.NoError(t, err)
 
-		require.NoError(t, os.Setenv(configs.CIModeEnvKey, ""))
+		t.Setenv(configs.CIModeEnvKey, "false")
+
+		ci, err := isCIMode(pointers.NewBoolPtr(false), inventory.Envs)
+		require.NoError(t, err)
+		require.Equal(t, false, ci)
+	})
+
+	t.Run("Should be true for: ciGlobalFlag: true, ciModeEnv: '' secrets: false", func(t *testing.T) {
+		inventoryStr := `
+envs:
+- CI: "false"
+`
+		inventory, err := bitrise.InventoryModelFromYAMLBytes([]byte(inventoryStr))
+		require.NoError(t, err)
+
+		t.Setenv(configs.CIModeEnvKey, "")
 
 		ci, err := isCIMode(pointers.NewBoolPtr(true), inventory.Envs)
 		require.NoError(t, err)
 		require.Equal(t, true, ci)
-	}
+	})
 
-	t.Log("Should be true for: ciGlobalFlag: nil, ciModeEnv: 'true' secrets: false")
-	{
+	t.Run("Should be true for: ciGlobalFlag: nil, ciModeEnv: 'true' secrets: false", func(t *testing.T) {
 		inventoryStr := `
 envs:
 - CI: ""
@@ -329,15 +298,14 @@ envs:
 		inventory, err := bitrise.InventoryModelFromYAMLBytes([]byte(inventoryStr))
 		require.NoError(t, err)
 
-		require.NoError(t, os.Setenv(configs.CIModeEnvKey, "true"))
+		t.Setenv(configs.CIModeEnvKey, "true")
 
 		ci, err := isCIMode(nil, inventory.Envs)
 		require.NoError(t, err)
 		require.Equal(t, true, ci)
-	}
+	})
 
-	t.Log("Should be true for: ciGlobalFlag: nil, ciModeEnv: '' secrets: true")
-	{
+	t.Run("Should be true for: ciGlobalFlag: nil, ciModeEnv: '' secrets: true", func(t *testing.T) {
 		inventoryStr := `
 envs:
 - CI: "true"
@@ -345,12 +313,12 @@ envs:
 		inventory, err := bitrise.InventoryModelFromYAMLBytes([]byte(inventoryStr))
 		require.NoError(t, err)
 
-		require.NoError(t, os.Setenv(configs.CIModeEnvKey, ""))
+		t.Setenv(configs.CIModeEnvKey, "")
 
 		ci, err := isCIMode(nil, inventory.Envs)
 		require.NoError(t, err)
 		require.Equal(t, true, ci)
-	}
+	})
 }
 
 func TestGetBitriseConfigFromBase64Data(t *testing.T) {

--- a/configs/configs_test.go
+++ b/configs/configs_test.go
@@ -11,14 +11,12 @@ import (
 func TestSetupForVersionChecks(t *testing.T) {
 	fakeHomePth, err := pathutil.NormalizedOSTempDirPath("_FAKE_HOME")
 	require.Equal(t, nil, err)
-	originalHome := os.Getenv("HOME")
 
 	defer func() {
-		require.Equal(t, nil, os.Setenv("HOME", originalHome))
 		require.Equal(t, nil, os.RemoveAll(fakeHomePth))
 	}()
 
-	require.Equal(t, nil, os.Setenv("HOME", fakeHomePth))
+	t.Setenv("HOME", fakeHomePth)
 
 	require.Equal(t, false, CheckIsSetupWasDoneForVersion("0.9.7"))
 

--- a/configs/paths_test.go
+++ b/configs/paths_test.go
@@ -53,7 +53,7 @@ func TestInitPaths(t *testing.T) {
 	require.Equal(t, CurrentDir, os.Getenv(BitriseSourceDirEnvKey))
 
 	// Set BITRISE_SOURCE_DIR -> after InitPaths BITRISE_SOURCE_DIR should keep content
-	require.Equal(t, nil, os.Setenv(BitriseSourceDirEnvKey, "$HOME/test"))
+	t.Setenv(BitriseSourceDirEnvKey, "$HOME/test")
 	require.Equal(t, nil, InitPaths())
 	require.Equal(t, "$HOME/test", os.Getenv(BitriseSourceDirEnvKey))
 
@@ -68,7 +68,7 @@ func TestInitPaths(t *testing.T) {
 	require.NotEqual(t, "", os.Getenv(BitriseDeployDirEnvKey))
 
 	// Set BITRISE_DEPLOY_DIR -> after InitPaths BITRISE_DEPLOY_DIR should keep content
-	require.Equal(t, nil, os.Setenv(BitriseDeployDirEnvKey, "$HOME/test"))
+	t.Setenv(BitriseDeployDirEnvKey, "$HOME/test")
 	require.Equal(t, nil, InitPaths())
 	require.Equal(t, "$HOME/test", os.Getenv(BitriseDeployDirEnvKey))
 
@@ -83,7 +83,7 @@ func TestInitPaths(t *testing.T) {
 	require.NotEqual(t, "", os.Getenv(BitriseTestDeployDirEnvKey))
 
 	// Set BITRISE_TEST_DEPLOY_DIR -> after InitPaths BITRISE_TEST_DEPLOY_DIR should keep content
-	require.Equal(t, nil, os.Setenv(BitriseTestDeployDirEnvKey, "$HOME/test"))
+	t.Setenv(BitriseTestDeployDirEnvKey, "$HOME/test")
 	require.Equal(t, nil, InitPaths())
 	require.Equal(t, "$HOME/test", os.Getenv(BitriseTestDeployDirEnvKey))
 
@@ -98,7 +98,7 @@ func TestInitPaths(t *testing.T) {
 	require.NotEqual(t, "", os.Getenv(BitriseTmpDirEnvKey))
 
 	// Set BITRISE_TMP_DIR -> after InitPaths BITRISE_TMP_DIR should keep content
-	require.Equal(t, nil, os.Setenv(BitriseTmpDirEnvKey, "$HOME/test"))
+	t.Setenv(BitriseTmpDirEnvKey, "$HOME/test")
 	require.Equal(t, nil, InitPaths())
 	require.Equal(t, "$HOME/test", os.Getenv(BitriseTmpDirEnvKey))
 }

--- a/models/models_methods_test.go
+++ b/models/models_methods_test.go
@@ -1886,11 +1886,8 @@ workflows:
 
 // Workflow contains before and after workflow, and no one contains steps, but circular workflow dependency exist, which should fail
 func TestBitriseDataModelValidateWorkflowsCircularDependency(t *testing.T) {
-	require.NoError(t, os.Setenv("BITRISE_BUILD_STATUS", "0"))
-	defer func() { require.NoError(t, os.Unsetenv("BITRISE_BUILD_STATUS")) }()
-
-	require.NoError(t, os.Setenv("STEPLIB_BUILD_STATUS", "0"))
-	defer func() { require.NoError(t, os.Unsetenv("STEPLIB_BUILD_STATUS")) }()
+	t.Setenv("BITRISE_BUILD_STATUS", "0")
+	t.Setenv("STEPLIB_BUILD_STATUS", "0")
 
 	beforeWorkflow := WorkflowModel{
 		BeforeRun: []string{"target"},

--- a/toolkits/golang_test.go
+++ b/toolkits/golang_test.go
@@ -250,8 +250,7 @@ func Benchmark_goBuildStep(b *testing.B) {
 
 	for _, mode := range []string{"on", "auto"} {
 		b.Run(fmt.Sprintf("Benchmarking GO111MODULE=%s", mode), func(b *testing.B) {
-			err := os.Setenv("GO111MODULE", mode)
-			require.NoError(b, err)
+			b.Setenv("GO111MODULE", mode)
 
 			for i := 0; i < b.N; i++ {
 				stepPerTestDir, err := ioutil.TempDir("", "")


### PR DESCRIPTION
<!--
  Thanks for contributing to the Bitrise CLI!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-io/bitrise/blob/master/.github/CONTRIBUTING.md)
- [x] `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *MAJOR/MINOR/PATCH* [version update](https://semver.org/)

### Context

<!--- 
  One sentence summary on why the change is needed.
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->

<!-- Please link the issue that the PR fixes.
Resolves: #GITHUB_ISSUE_ID or https://link_to_the_issue_on_discuss.bitrise.io.
-->

This PR replaces `os.Setenv` with `t.Setenv` in `*_test.go` files.

### Changes

<!-- 
  Details are important, and help maintainers processing your PR.
  Please list additional details, for example:
  - Update dependencies
  - Make `foo` optional in `main.go`
  - `foo` now returns an `error` for better error handling
-->

- Replaces `os.Setenv` with `t.Setenv`
- Refactor several test functions to table-driven tests so that `t.Setenv` performs the cleanup after each subtest.

Starting from Go 1.17, we can use `t.Setenv` to set environment variable in test. The environment variable is automatically restored to its original value when the test and all its subtests complete. This ensures that each test does not start with leftover environment variables from previous completed tests.

Reference: https://pkg.go.dev/testing#T.Setenv

```go
func TestFoo(t *testing.T) {
	// before
	os.Setenv(key, "new value")
	defer os.Unsetenv(key)
	
	// after
	t.Setenv(key, "new value")
}
```

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->