### PR TITLE
Update go-utils/command package

### DIFF
--- a/cli/step_activator.go
+++ b/cli/step_activator.go
@@ -44,7 +44,7 @@ func (a stepActivator) activateStep(
 		if err != nil {
 			return "", "", fmt.Errorf("failed to activate local step: failed to check if a directory exists at %s: %w", stepAbsLocalPth, err)
 		} else if !exist {
-			return "", "", fmt.Errorf("failed to activate local step: the provided directory (%s) doesn't exist", stepAbsLocalPth)
+			return "", "", fmt.Errorf("failed to activate local step: the provided directory doesn't exist: %s", stepAbsLocalPth)
 		}
 
 		log.Debug("stepAbsLocalPth:", stepAbsLocalPth, "|stepDir:", stepDir)

--- a/cli/step_activator.go
+++ b/cli/step_activator.go
@@ -40,9 +40,23 @@ func (a stepActivator) activateStep(
 			return "", "", err
 		}
 
+		exist, err := pathutil.IsDirExists(stepAbsLocalPth)
+		if err != nil {
+			return "", "", fmt.Errorf("failed to activate local step: failed to check if a directory exists at %s: %w", stepAbsLocalPth, err)
+		} else if !exist {
+			return "", "", fmt.Errorf("failed to activate local step: the provided directory (%s) doesn't exist", stepAbsLocalPth)
+		}
+
 		log.Debug("stepAbsLocalPth:", stepAbsLocalPth, "|stepDir:", stepDir)
 
 		origStepYMLPth = filepath.Join(stepAbsLocalPth, "step.yml")
+		exist, err = pathutil.IsPathExists(origStepYMLPth)
+		if err != nil {
+			return "", "", fmt.Errorf("failed to activate local step: failed to check if step.yml exists at %s: %w", origStepYMLPth, err)
+		} else if !exist {
+			return "", "", fmt.Errorf("failed to activate local step: step.yml doesn't exist at %s", origStepYMLPth)
+		}
+
 		if err := command.CopyFile(origStepYMLPth, stepYMLPth); err != nil {
 			return "", "", err
 		}

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/bitrise-io/envman v0.0.0-20221010094751-a03ce30a5316
-	github.com/bitrise-io/go-utils v1.0.5-0.20230130121219-67e373f3f9b2
+	github.com/bitrise-io/go-utils v1.0.5
 	github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.12.0.20221010132402-33be72261ded
 	github.com/bitrise-io/goinp v0.0.0-20211005113137-305e91b481f4
 	github.com/bitrise-io/gows v0.0.0-20211005113107-14f65e686b88

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/bitrise-io/envman v0.0.0-20221010094751-a03ce30a5316
-	github.com/bitrise-io/go-utils v1.0.4
+	github.com/bitrise-io/go-utils v1.0.5-0.20230130121219-67e373f3f9b2
 	github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.12.0.20221010132402-33be72261ded
 	github.com/bitrise-io/goinp v0.0.0-20211005113137-305e91b481f4
 	github.com/bitrise-io/gows v0.0.0-20211005113107-14f65e686b88

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/bitrise-io/envman v0.0.0-20221010094751-a03ce30a5316/go.mod h1:L4WQyg
 github.com/bitrise-io/go-utils v0.0.0-20200224122728-e212188d99b4/go.mod h1:tTEsKvbz1LbzuN/KpVFHXnLtcAPdEgIdM41s0lL407s=
 github.com/bitrise-io/go-utils v0.0.0-20210505121718-07411d72e36e/go.mod h1:nhdaDQFvaMny1CugVV6KjK92/q97ENo0RuKSW5I4fbA=
 github.com/bitrise-io/go-utils v1.0.3/go.mod h1:ZY1DI+fEpZuFpO9szgDeICM4QbqoWVt0RSY3tRI1heY=
-github.com/bitrise-io/go-utils v1.0.5-0.20230130121219-67e373f3f9b2 h1:EZg959PDApD9BtTI33WjTZSlNOpeF/+LwqQjZQTtBtU=
-github.com/bitrise-io/go-utils v1.0.5-0.20230130121219-67e373f3f9b2/go.mod h1:ZY1DI+fEpZuFpO9szgDeICM4QbqoWVt0RSY3tRI1heY=
+github.com/bitrise-io/go-utils v1.0.5 h1:RgLAvyK5m+CGAXeoogGUnz9apShWwbN4B2lBkJkU89c=
+github.com/bitrise-io/go-utils v1.0.5/go.mod h1:ZY1DI+fEpZuFpO9szgDeICM4QbqoWVt0RSY3tRI1heY=
 github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.12.0.20221010132402-33be72261ded h1:KOnT1jCD1hMMFsEd4Ll0Njd/PU7HcdAX2I+jNxypFqU=
 github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.12.0.20221010132402-33be72261ded/go.mod h1:gZWtM7PLn1VOroa4gN1La/24aRVc0jg5R701jTsPaO8=
 github.com/bitrise-io/goinp v0.0.0-20210504152833-8559b0680ab1/go.mod h1:iRbd8zAXLeNy+0gic0eqNCxXvDGe8ZEY/uYX2CCeAoo=

--- a/go.sum
+++ b/go.sum
@@ -5,12 +5,9 @@ github.com/bitrise-io/envman v0.0.0-20221010094751-a03ce30a5316 h1:gRQReCvmNxUVv
 github.com/bitrise-io/envman v0.0.0-20221010094751-a03ce30a5316/go.mod h1:L4WQyg88d87Z4dxNwrYEa0Cwd9/W0gSfXsibw30r8Vw=
 github.com/bitrise-io/go-utils v0.0.0-20200224122728-e212188d99b4/go.mod h1:tTEsKvbz1LbzuN/KpVFHXnLtcAPdEgIdM41s0lL407s=
 github.com/bitrise-io/go-utils v0.0.0-20210505121718-07411d72e36e/go.mod h1:nhdaDQFvaMny1CugVV6KjK92/q97ENo0RuKSW5I4fbA=
-github.com/bitrise-io/go-utils v1.0.3 h1:xKy0WyiJtRPqeKl/HrwQJ0QdjNOOUhiVHs81RMDwD94=
 github.com/bitrise-io/go-utils v1.0.3/go.mod h1:ZY1DI+fEpZuFpO9szgDeICM4QbqoWVt0RSY3tRI1heY=
-github.com/bitrise-io/go-utils v1.0.4-0.20221229083519-3e15e6ea1f2d h1:VqpOidX1xNDf6YJCslL7wG6ynvuCjp9fzPmN6VZ4Gy0=
-github.com/bitrise-io/go-utils v1.0.4-0.20221229083519-3e15e6ea1f2d/go.mod h1:ZY1DI+fEpZuFpO9szgDeICM4QbqoWVt0RSY3tRI1heY=
-github.com/bitrise-io/go-utils v1.0.4 h1:uF94AXYmTk2aNkDqpebmklGVd2wGFOCfmke6LdOqs2Q=
-github.com/bitrise-io/go-utils v1.0.4/go.mod h1:ZY1DI+fEpZuFpO9szgDeICM4QbqoWVt0RSY3tRI1heY=
+github.com/bitrise-io/go-utils v1.0.5-0.20230130121219-67e373f3f9b2 h1:EZg959PDApD9BtTI33WjTZSlNOpeF/+LwqQjZQTtBtU=
+github.com/bitrise-io/go-utils v1.0.5-0.20230130121219-67e373f3f9b2/go.mod h1:ZY1DI+fEpZuFpO9szgDeICM4QbqoWVt0RSY3tRI1heY=
 github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.12.0.20221010132402-33be72261ded h1:KOnT1jCD1hMMFsEd4Ll0Njd/PU7HcdAX2I+jNxypFqU=
 github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.12.0.20221010132402-33be72261ded/go.mod h1:gZWtM7PLn1VOroa4gN1La/24aRVc0jg5R701jTsPaO8=
 github.com/bitrise-io/goinp v0.0.0-20210504152833-8559b0680ab1/go.mod h1:iRbd8zAXLeNy+0gic0eqNCxXvDGe8ZEY/uYX2CCeAoo=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -8,7 +8,7 @@ github.com/bitrise-io/envman/envman
 github.com/bitrise-io/envman/models
 github.com/bitrise-io/envman/output
 github.com/bitrise-io/envman/version
-# github.com/bitrise-io/go-utils v1.0.5-0.20230130121219-67e373f3f9b2
+# github.com/bitrise-io/go-utils v1.0.5
 ## explicit
 github.com/bitrise-io/go-utils/colorstring
 github.com/bitrise-io/go-utils/command

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -8,7 +8,7 @@ github.com/bitrise-io/envman/envman
 github.com/bitrise-io/envman/models
 github.com/bitrise-io/envman/output
 github.com/bitrise-io/envman/version
-# github.com/bitrise-io/go-utils v1.0.4
+# github.com/bitrise-io/go-utils v1.0.5-0.20230130121219-67e373f3f9b2
 ## explicit
 github.com/bitrise-io/go-utils/colorstring
 github.com/bitrise-io/go-utils/command


### PR DESCRIPTION
### Checklist

- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-io/bitrise/blob/master/.github/CONTRIBUTING.md)
- [x] `README.md` is updated with the changes (if needed)

### Version

Requires a */PATCH* [version update](https://semver.org/)

### Context

This PR solves the issue of rsync directly writing to the stdout, when the CLI [activates a local Step](https://github.com/bitrise-io/bitrise/blob/master/cli/step_activator.go#L36-L53) and the provided directory path is invalid.
When structured logging is enabled, the rsync log messes up the structured logging.

### Changes

- Update go-utils/command package to pull the [rsync fix](https://github.com/bitrise-io/go-utils/pull/178)
- Validate if the provided local step directory and step.yml exist

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->