### PR TITLE
Remove log lines

### DIFF
--- a/cli/run_util.go
+++ b/cli/run_util.go
@@ -220,10 +220,10 @@ func CreateBitriseConfigFromCLIParams(bitriseConfigBase64Data, bitriseConfigPath
 
 	isConfigVersionOK, err := versions.IsVersionGreaterOrEqual(models.FormatVersion, bitriseConfig.FormatVersion)
 	if err != nil {
-		return models.BitriseDataModel{}, warnings, fmt.Errorf("Failed to compare bitrise CLI models's version (%s) with the bitrise.yml FormatVersion (%s): %s", models.FormatVersion, bitriseConfig.FormatVersion, err)
+		return models.BitriseDataModel{}, warnings, fmt.Errorf("Failed to compare bitrise CLI supported format version (%s) with the bitrise.yml format version (%s): %s", models.FormatVersion, bitriseConfig.FormatVersion, err)
 	}
 	if !isConfigVersionOK {
-		return models.BitriseDataModel{}, warnings, fmt.Errorf("The bitrise.yml has a higher Format Version (%s) than the bitrise CLI model's version (%s), please upgrade your bitrise CLI to use this bitrise.yml", bitriseConfig.FormatVersion, models.FormatVersion)
+		return models.BitriseDataModel{}, warnings, fmt.Errorf("The bitrise.yml has a higher format version (%s) than the bitrise CLI supported format version (%s), please upgrade your bitrise CLI to use this bitrise.yml", bitriseConfig.FormatVersion, models.FormatVersion)
 	}
 
 	return bitriseConfig, warnings, nil

--- a/cli/run_util.go
+++ b/cli/run_util.go
@@ -220,13 +220,10 @@ func CreateBitriseConfigFromCLIParams(bitriseConfigBase64Data, bitriseConfigPath
 
 	isConfigVersionOK, err := versions.IsVersionGreaterOrEqual(models.FormatVersion, bitriseConfig.FormatVersion)
 	if err != nil {
-		log.Warn("bitrise CLI model version: ", models.FormatVersion)
-		log.Warn("bitrise.yml Format Version: ", bitriseConfig.FormatVersion)
-		return models.BitriseDataModel{}, warnings, fmt.Errorf("Failed to compare bitrise CLI models's version with the bitrise.yml FormatVersion: %s", err)
+		return models.BitriseDataModel{}, warnings, fmt.Errorf("Failed to compare bitrise CLI models's version (%s) with the bitrise.yml FormatVersion (%s): %s", models.FormatVersion, bitriseConfig.FormatVersion, err)
 	}
 	if !isConfigVersionOK {
-		log.Warnf("The bitrise.yml has a higher Format Version (%s) than the bitrise CLI model's version (%s).", bitriseConfig.FormatVersion, models.FormatVersion)
-		return models.BitriseDataModel{}, warnings, errors.New("This bitrise.yml was created with and for a newer version of bitrise CLI, please upgrade your bitrise CLI to use this bitrise.yml")
+		return models.BitriseDataModel{}, warnings, fmt.Errorf("The bitrise.yml has a higher Format Version (%s) than the bitrise CLI model's version (%s), please upgrade your bitrise CLI to use this bitrise.yml", bitriseConfig.FormatVersion, models.FormatVersion)
 	}
 
 	return bitriseConfig, warnings, nil


### PR DESCRIPTION
<!--
  Thanks for contributing to the Bitrise CLI!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [ ] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-io/bitrise/blob/master/.github/CONTRIBUTING.md)
- [ ] `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *PATCH* [version update](https://semver.org/)

### Context

The validation command prints raw log statements when the `-format json` parameter is used. 
This blocks https://github.com/bitrise-io/bitrise/pull/844

### Changes

Three unnecessary log lines are removed. They are not needed because the `CreateBitriseConfigFromCLIParams` function was returning with the same information as an error as what was printed as a warning before the return statement. The warning level was already incorrect because an error is returned and also following all of the code paths using `CreateBitriseConfigFromCLIParams` revealed that the returned error is an execution stopper and the cli was killed. 

So by removing them we can quickly fix the raw logs appearing in the output without losing anything important.