### PR TITLE
[CI-857] Handle step level debug logs

### DIFF
--- a/_tests/integration/log_format_test_bitrise.yml
+++ b/_tests/integration/log_format_test_bitrise.yml
@@ -3,6 +3,16 @@ default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
 project_type: other
 
 workflows:
+  debug_log:
+    steps:
+    - script:
+        title: Success
+        inputs:
+        - content: |-
+            set -e
+            DEBUG_COLOUR='\x1b[35;1m'
+            NO_COLOUR='\x1b[0m'
+            echo -e "${DEBUG_COLOUR}This is a debug message${NO_COLOUR}"
   fail_test:
     title: Fails
     description: Workflow will fail

--- a/cli/run_util.go
+++ b/cli/run_util.go
@@ -408,6 +408,7 @@ func (r WorkflowRunner) executeStep(
 	opts := log.GetGlobalLoggerOpts()
 	opts.Producer = log.Step
 	opts.ProducerID = stepUUID
+	opts.DebugLogEnabled = true
 	logWriter := logwriter.NewLogWriter(log.NewLogger(opts))
 
 	return tools.EnvmanRun(


### PR DESCRIPTION
<!--
  Thanks for contributing to the Bitrise CLI!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [ ] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-io/bitrise/blob/master/.github/CONTRIBUTING.md)
- [ ] `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *PATCH* [version update](https://semver.org/)

### Context

With the structured logging we were using the cli debug flag to show or hide the step level debug logs. This is not correct because it can happen that the user want to only see a specific step's debug logs. This change will make the cli always print put the debug logs if they are coming from a step.

### Changes

The steps have their own input field for indicating the debug level. That means that the steps are responsible for handling their own debug logs. So the cli can safely always print out the debug logs received from the step. 
