### PR TITLE
Handle color reset in the middle of the message

### DIFF
--- a/log/logwriter/writer_test.go
+++ b/log/logwriter/writer_test.go
@@ -143,6 +143,11 @@ func Test_GivenWriter_WhenJSONLogging_ThenDetectsLogLevel(t *testing.T) {
 			messages:         []string{"\u001B[31;1mAnother error\n"},
 			expectedMessages: []string{`{"timestamp":"0001-01-01T00:00:00Z","type":"log","producer":"","level":"normal","message":"\u001b[31;1mAnother error\n"}` + "\n"},
 		},
+		{
+			name:             "Message with a colored part (not a message with log level)",
+			messages:         []string{"\u001B[32;1mWho are you / who's the author?\u001B[0m [Bitrise bot]"},
+			expectedMessages: []string{`{"timestamp":"0001-01-01T00:00:00Z","type":"log","producer":"","level":"normal","message":"\u001b[32;1mWho are you / who's the author?\u001b[0m [Bitrise bot]"}` + "\n"},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
### Checklist

- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-io/bitrise/blob/master/.github/CONTRIBUTING.md)
- [x] `README.md` is updated with the changes (if needed)

### Version

Requires a *PATCH* [version update](https://semver.org/)

### Context

When LogWriter receives a message that seems to be a message with log-level (the message starts with one of the know ANSI color codes), but the message has a color reset character in the middle, it was not handled properly and LogWriter was waiting for the end of the log-leveled message.

If the executed command was waiting for a user input after such a message, the CLI ended up not writing anything to the output.

This can be reproduced by running the step plugin's create command (`bitrise :step create`) using this CLI revision: b8b3e796f118359e91faad5c984b870946249634.

This PR fixes this issue, by not treating a message with log-level if the message contains a color reset sequence in the middle of the content.

<!-- Please link the issue that the PR fixes.
Resolves: #GITHUB_ISSUE_ID or https://link_to_the_issue_on_discuss.bitrise.io.
-->

### Changes

- Update `LogWriter.processLog` to not consider a message with log-level if the message contains a color reset sequence in the middle of the content
