### PR TITLE
Added RunIf field on stage workflow for validation

### DIFF
--- a/models/models.go
+++ b/models/models.go
@@ -29,6 +29,7 @@ type StageListItemModel map[string]StageModel
 type StageModel struct {
 	ShouldAlwaysRun bool                    `json:"should_always_run,omitempty" yaml:"should_always_run,omitempty"`
 	AbortOnFail     bool                    `json:"abort_on_fail,omitempty" yaml:"abort_on_fail,omitempty"`
+	RunIf           string                  `json:"run_if,omitempty" yaml:"run_if,omitempty"`
 	Workflows       []WorkflowListItemModel `json:"workflows,omitempty" yaml:"workflows,omitempty"`
 }
 


### PR DESCRIPTION
<!--
  Thanks for contributing to the Bitrise CLI!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-io/bitrise/blob/master/.github/CONTRIBUTING.md)
- [x] `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *PATCH* [version update](https://semver.org/)

### Context

<!--- 
  One sentence summary on why the change is needed.
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->

<!-- Please link the issue that the PR fixes.
Resolves: #GITHUB_ISSUE_ID or https://link_to_the_issue_on_discuss.bitrise.io.
-->

[[CI-1429](https://bitrise.atlassian.net/browse/CI-1429)] The validate subcommand does not validate the `run_if` field on stages.

### Changes

<!-- 
  Details are important, and help maintainers processing your PR.
  Please list additional details, for example:
  - Update dependencies
  - Make `foo` optional in `main.go`
  - `foo` now returns an `error` for better error handling
-->

* Added the missing property to the stage model

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

I think this is not needed for a couple reasons:

  1. The property is not currently added to the models in the CLI -- this tells me it's fine for it to be missing from the CLI models
    1. Although we can add it for the sake of completeness
  2. The CLI is not the one that will process this condition, that happens at whatever level is executing the stage (DEN?)
  3. We can’t really do pre-runtime validation on this because the condition may contain env vars
  4. If we follow the example of the existing step model's `run_if` then I noticed:
    1. It is a string type so its value can be anything
    2. The expression is evaluated at runtime

### Decisions

<!-- Please list decisions that were made for this change. -->

* Added the field for the sake of completeness

[CI-1429]: https://bitrise.atlassian.net/browse/CI-1429?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ