### PR TITLE
[CI-1546] Detect alternative installation

### DIFF
--- a/_tests/integration/gomodmigrate.yml
+++ b/_tests/integration/gomodmigrate.yml
@@ -32,7 +32,7 @@ workflows:
               end
             end
             " > $TMP_DIR/fastlane/Fastfile
-    - fastlane@3.2.0:
+    - fastlane@3.4.3:
         inputs:
         - lane: test_fastlane
         - work_dir: $TMP_DIR

--- a/_tests/integration/version_test.go
+++ b/_tests/integration/version_test.go
@@ -22,7 +22,7 @@ format version: 12
 os: %s
 go: %s
 build number: 
-commit:`, version.VERSION, expectedOSVersion, runtime.Version())
+commit: (devel)`, version.VERSION, expectedOSVersion, runtime.Version())
 
 		require.Equal(t, expectedVersionOut, out)
 	}

--- a/cli/run.go
+++ b/cli/run.go
@@ -403,8 +403,13 @@ func createWorkflowRunPlan(modes models.WorkflowRunModes, targetWorkflow string,
 		})
 	}
 
+	cliVersion := version.VERSION
+	if version.IsAlternativeInstallation {
+		cliVersion = fmt.Sprintf("%s (%s)", cliVersion, version.Commit)
+	}
+
 	return models.WorkflowRunPlan{
-		Version:                 version.VERSION,
+		Version:                 cliVersion,
 		LogFormatVersion:        "1",
 		CIMode:                  modes.CIMode,
 		PRMode:                  modes.PRMode,

--- a/version/init.go
+++ b/version/init.go
@@ -1,0 +1,26 @@
+package version
+
+import (
+	"runtime/debug"
+	"strings"
+)
+
+// IsAlternativeInstallation tracks if the current cli was installed via `go install` or not.
+var IsAlternativeInstallation = false
+
+func init() {
+	if Commit != "" {
+		return
+	}
+
+	info, available := debug.ReadBuildInfo()
+	if available && info.Main.Version != "" {
+		IsAlternativeInstallation = true
+
+		components := strings.Split(info.Main.Version, "-")
+		count := len(components)
+		if count != 0 {
+			Commit = components[count-1]
+		}
+	}
+}


### PR DESCRIPTION
<!--
  Thanks for contributing to the Bitrise CLI!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [ ] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-io/bitrise/blob/master/.github/CONTRIBUTING.md)
- [ ] `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *PATCH* [version update](https://semver.org/)

### Context

The cli can installed two ways in our stack:
- Preinstalled
- Installed by the den agent with `go install`

The problem we had is that we currently cannot differentiate the two and this caused some problems during the last cli incident. 

This PR will change the cli's behaviour to print extra information into the build log if it was installed by `go install`. This extra information is the git hash which was used to install it. If the cli was preinstalled from a binary release then it will print no extra information.

Tested it with our system:
![Screenshot 2023-05-05 at 13 58 37](https://user-images.githubusercontent.com/54896607/236467842-bec23a09-b629-4851-818d-cd05bab41ea1.png)

![Screenshot 2023-05-05 at 14 02 35](https://user-images.githubusercontent.com/54896607/236467856-3d22e1c4-9d2b-4fbc-97ae-b428718c9c5b.png)

### Changes

The cli reads the build information and if it exists (it will for `go install` based installations) then it will populate the `Commit` variable from there. 
