### PR TITLE
Step finished runtime

### DIFF
--- a/analytics/tracker.go
+++ b/analytics/tracker.go
@@ -53,6 +53,7 @@ const (
 	stepSourceProperty            = "step_source"
 	skippableProperty             = "skippable"
 	timeoutProperty               = "timeout"
+	totalRuntime                  = "total_runtime"
 
 	failedValue          = "failed"
 	successfulValue      = "successful"
@@ -91,6 +92,7 @@ type StepResult struct {
 	Status                   models.StepRunStatus
 	ErrorMessage             string
 	Timeout, NoOutputTimeout time.Duration
+	TotalRuntime             time.Duration
 }
 
 // Tracker ...
@@ -307,6 +309,8 @@ func mapStepResultToEvent(result StepResult) (string, analytics.Properties, erro
 	default:
 		return "", analytics.Properties{}, fmt.Errorf("Unknown step status code: %d", result.Status)
 	}
+
+	extraProperties[totalRuntime] = int64(result.TotalRuntime.Seconds())
 
 	return eventName, extraProperties, nil
 }

--- a/analytics/tracker_test.go
+++ b/analytics/tracker_test.go
@@ -19,10 +19,11 @@ func Test_mapStepResultToEvent(t *testing.T) {
 		{
 			name: "Step succeeded",
 			result: StepResult{
-				Status: models.StepRunStatusCodeSuccess,
+				Status:       models.StepRunStatusCodeSuccess,
+				TotalRuntime: 30 * time.Second,
 			},
 			expectedEvent:      "step_finished",
-			expectedExtraProps: analytics.Properties{"status": "successful"},
+			expectedExtraProps: analytics.Properties{"status": "successful", "total_runtime": int64(30)},
 		},
 		{
 			name: "Step failed",
@@ -34,6 +35,7 @@ func Test_mapStepResultToEvent(t *testing.T) {
 			expectedExtraProps: analytics.Properties{
 				"status":        "failed",
 				"error_message": "msg",
+				"total_runtime": int64(0),
 			},
 		},
 		{
@@ -42,7 +44,7 @@ func Test_mapStepResultToEvent(t *testing.T) {
 				Status: models.StepRunStatusCodeFailedSkippable,
 			},
 			expectedEvent:      "step_finished",
-			expectedExtraProps: analytics.Properties{"status": "failed"},
+			expectedExtraProps: analytics.Properties{"status": "failed", "total_runtime": int64(0)},
 		},
 		{
 			name: "Step skipped",
@@ -55,9 +57,10 @@ func Test_mapStepResultToEvent(t *testing.T) {
 			},
 			expectedEvent: "step_skipped",
 			expectedExtraProps: analytics.Properties{
-				"reason":    "build_failed",
-				"skippable": true,
-				"step_id":   "ID",
+				"reason":        "build_failed",
+				"skippable":     true,
+				"step_id":       "ID",
+				"total_runtime": int64(0),
 			},
 		},
 		{
@@ -67,8 +70,9 @@ func Test_mapStepResultToEvent(t *testing.T) {
 			},
 			expectedEvent: "step_skipped",
 			expectedExtraProps: analytics.Properties{
-				"reason":    "run_if",
-				"skippable": false,
+				"reason":        "run_if",
+				"skippable":     false,
+				"total_runtime": int64(0),
 			},
 		},
 		{
@@ -81,6 +85,7 @@ func Test_mapStepResultToEvent(t *testing.T) {
 			expectedExtraProps: analytics.Properties{
 				"skippable":     false,
 				"error_message": "msg",
+				"total_runtime": int64(0),
 			},
 		},
 		{
@@ -91,8 +96,9 @@ func Test_mapStepResultToEvent(t *testing.T) {
 			},
 			expectedEvent: "step_aborted",
 			expectedExtraProps: analytics.Properties{
-				"reason":  "timeout",
-				"timeout": int64(1),
+				"reason":        "timeout",
+				"timeout":       int64(1),
+				"total_runtime": int64(0),
 			},
 		},
 		{
@@ -103,8 +109,9 @@ func Test_mapStepResultToEvent(t *testing.T) {
 			},
 			expectedEvent: "step_aborted",
 			expectedExtraProps: analytics.Properties{
-				"reason":  "no_output_timeout",
-				"timeout": int64(1),
+				"reason":        "no_output_timeout",
+				"timeout":       int64(1),
+				"total_runtime": int64(0),
 			},
 		},
 	}

--- a/cli/build_run_result_collector.go
+++ b/cli/build_run_result_collector.go
@@ -40,6 +40,8 @@ func (r buildRunResultCollector) registerStepRunResults(
 	redactedStepInputs map[string]string,
 	properties coreanalytics.Properties) {
 
+	stepTotalRunTime := time.Since(stepStartTime)
+
 	timeout, noOutputTimeout := time.Duration(-1), time.Duration(-1)
 	if status == models.StepRunStatusCodeFailed {
 		// Forward the status of a Step or a wrapped bitrise process.
@@ -93,7 +95,7 @@ func (r buildRunResultCollector) registerStepRunResults(
 		StepInputs: redactedStepInputs,
 		Status:     status,
 		Idx:        buildRunResults.ResultsCount(),
-		RunTime:    time.Since(stepStartTime),
+		RunTime:    stepTotalRunTime,
 		ErrorStr:   errStr,
 		ExitCode:   exitCode,
 		StartTime:  stepStartTime,
@@ -108,6 +110,7 @@ func (r buildRunResultCollector) registerStepRunResults(
 		ErrorMessage:    errStr,
 		Timeout:         timeout,
 		NoOutputTimeout: noOutputTimeout,
+		TotalRuntime:    stepTotalRunTime,
 	})
 
 	switch status {

--- a/cli/build_run_result_collector.go
+++ b/cli/build_run_result_collector.go
@@ -31,7 +31,6 @@ func (r buildRunResultCollector) registerStepRunResults(
 	step stepmanModels.StepModel,
 	stepInfoPtr stepmanModels.StepInfoModel,
 	stepIdxPtr int,
-	runIf string,
 	status models.StepRunStatus,
 	exitCode int,
 	err error,

--- a/cli/run_util.go
+++ b/cli/run_util.go
@@ -618,7 +618,7 @@ func (r WorkflowRunner) activateAndRunSteps(
 
 		if err := bitrise.CleanupStepWorkDir(); err != nil {
 			runResultCollector.registerStepRunResults(&buildRunResults, stepExecutionID, stepStartTime, stepmanModels.StepModel{}, stepInfoPtr, stepIdxPtr,
-				"", models.StepRunStatusCodePreparationFailed, 1, err, isLastStep, true, map[string]string{}, stepStartedProperties)
+				models.StepRunStatusCodePreparationFailed, 1, err, isLastStep, true, map[string]string{}, stepStartedProperties)
 			continue
 		}
 
@@ -626,13 +626,13 @@ func (r WorkflowRunner) activateAndRunSteps(
 		// Preparing the step
 		if err := tools.EnvmanInit(configs.InputEnvstorePath, true); err != nil {
 			runResultCollector.registerStepRunResults(&buildRunResults, stepExecutionID, stepStartTime, stepmanModels.StepModel{}, stepInfoPtr, stepIdxPtr,
-				"", models.StepRunStatusCodePreparationFailed, 1, err, isLastStep, true, map[string]string{}, stepStartedProperties)
+				models.StepRunStatusCodePreparationFailed, 1, err, isLastStep, true, map[string]string{}, stepStartedProperties)
 			continue
 		}
 
 		if err := tools.EnvmanAddEnvs(configs.InputEnvstorePath, *environments); err != nil {
 			runResultCollector.registerStepRunResults(&buildRunResults, stepExecutionID, stepStartTime, stepmanModels.StepModel{}, stepInfoPtr, stepIdxPtr,
-				"", models.StepRunStatusCodePreparationFailed, 1, err, isLastStep, true, map[string]string{}, stepStartedProperties)
+				models.StepRunStatusCodePreparationFailed, 1, err, isLastStep, true, map[string]string{}, stepStartedProperties)
 			continue
 		}
 
@@ -640,7 +640,7 @@ func (r WorkflowRunner) activateAndRunSteps(
 		compositeStepIDStr, workflowStep, err := models.GetStepIDStepDataPair(stepListItm)
 		if err != nil {
 			runResultCollector.registerStepRunResults(&buildRunResults, stepExecutionID, stepStartTime, stepmanModels.StepModel{}, stepInfoPtr, stepIdxPtr,
-				"", models.StepRunStatusCodePreparationFailed, 1, err, isLastStep, true, map[string]string{}, stepStartedProperties)
+				models.StepRunStatusCodePreparationFailed, 1, err, isLastStep, true, map[string]string{}, stepStartedProperties)
 			continue
 		}
 		stepInfoPtr.ID = compositeStepIDStr
@@ -653,7 +653,7 @@ func (r WorkflowRunner) activateAndRunSteps(
 		stepIDData, err := models.CreateStepIDDataFromString(compositeStepIDStr, defaultStepLibSource)
 		if err != nil {
 			runResultCollector.registerStepRunResults(&buildRunResults, stepExecutionID, stepStartTime, stepmanModels.StepModel{}, stepInfoPtr, stepIdxPtr,
-				"", models.StepRunStatusCodePreparationFailed, 1, err, isLastStep, true, map[string]string{}, stepStartedProperties)
+				models.StepRunStatusCodePreparationFailed, 1, err, isLastStep, true, map[string]string{}, stepStartedProperties)
 			continue
 		}
 		stepInfoPtr.ID = stepIDData.IDorURI
@@ -671,7 +671,7 @@ func (r WorkflowRunner) activateAndRunSteps(
 		stepYMLPth, origStepYMLPth, err := activator.activateStep(stepIDData, &buildRunResults, stepDir, configs.BitriseWorkDirPath, &workflowStep, &stepInfoPtr)
 		if err != nil {
 			runResultCollector.registerStepRunResults(&buildRunResults, stepExecutionID, stepStartTime, stepmanModels.StepModel{}, stepInfoPtr, stepIdxPtr,
-				"", models.StepRunStatusCodePreparationFailed, 1, err, isLastStep, true, map[string]string{}, stepStartedProperties)
+				models.StepRunStatusCodePreparationFailed, 1, err, isLastStep, true, map[string]string{}, stepStartedProperties)
 			continue
 		}
 
@@ -688,7 +688,7 @@ func (r WorkflowRunner) activateAndRunSteps(
 					ymlPth = origStepYMLPth
 				}
 				runResultCollector.registerStepRunResults(&buildRunResults, stepExecutionID, stepStartTime, stepmanModels.StepModel{}, stepInfoPtr, stepIdxPtr,
-					"", models.StepRunStatusCodePreparationFailed, 1, fmt.Errorf("failed to parse step definition (%s): %s", ymlPth, err),
+					models.StepRunStatusCodePreparationFailed, 1, fmt.Errorf("failed to parse step definition (%s): %s", ymlPth, err),
 					isLastStep, true, map[string]string{}, stepStartedProperties)
 				continue
 			}
@@ -696,7 +696,7 @@ func (r WorkflowRunner) activateAndRunSteps(
 			mergedStep, err = models.MergeStepWith(specStep, workflowStep)
 			if err != nil {
 				runResultCollector.registerStepRunResults(&buildRunResults, stepExecutionID, stepStartTime, stepmanModels.StepModel{}, stepInfoPtr, stepIdxPtr,
-					"", models.StepRunStatusCodePreparationFailed, 1, err, isLastStep, true, map[string]string{}, stepStartedProperties)
+					models.StepRunStatusCodePreparationFailed, 1, err, isLastStep, true, map[string]string{}, stepStartedProperties)
 				continue
 			}
 		}
@@ -741,7 +741,7 @@ func (r WorkflowRunner) activateAndRunSteps(
 			envList, err := tools.EnvmanReadEnvList(configs.InputEnvstorePath)
 			if err != nil {
 				runResultCollector.registerStepRunResults(&buildRunResults, stepExecutionID, stepStartTime, mergedStep, stepInfoPtr, stepIdxPtr,
-					*mergedStep.RunIf, models.StepRunStatusCodePreparationFailed, 1, fmt.Errorf("EnvmanReadEnvList failed, err: %s", err),
+					models.StepRunStatusCodePreparationFailed, 1, fmt.Errorf("EnvmanReadEnvList failed, err: %s", err),
 					isLastStep, false, map[string]string{}, stepStartedProperties)
 				continue
 			}
@@ -749,12 +749,12 @@ func (r WorkflowRunner) activateAndRunSteps(
 			isRun, err := bitrise.EvaluateTemplateToBool(*mergedStep.RunIf, configs.IsCIMode, configs.IsPullRequestMode, buildRunResults, envList)
 			if err != nil {
 				runResultCollector.registerStepRunResults(&buildRunResults, stepExecutionID, stepStartTime, mergedStep, stepInfoPtr, stepIdxPtr,
-					*mergedStep.RunIf, models.StepRunStatusCodePreparationFailed, 1, err, isLastStep, false, map[string]string{}, stepStartedProperties)
+					models.StepRunStatusCodePreparationFailed, 1, err, isLastStep, false, map[string]string{}, stepStartedProperties)
 				continue
 			}
 			if !isRun {
 				runResultCollector.registerStepRunResults(&buildRunResults, stepExecutionID, stepStartTime, mergedStep, stepInfoPtr, stepIdxPtr,
-					*mergedStep.RunIf, models.StepRunStatusCodeSkippedWithRunIf, 0, err, isLastStep, false, map[string]string{}, stepStartedProperties)
+					models.StepRunStatusCodeSkippedWithRunIf, 0, err, isLastStep, false, map[string]string{}, stepStartedProperties)
 				continue
 			}
 		}
@@ -768,7 +768,7 @@ func (r WorkflowRunner) activateAndRunSteps(
 
 		if buildRunResults.IsBuildFailed() && !isAlwaysRun {
 			runResultCollector.registerStepRunResults(&buildRunResults, stepExecutionID, stepStartTime, mergedStep, stepInfoPtr, stepIdxPtr,
-				*mergedStep.RunIf, models.StepRunStatusCodeSkipped, 0, err, isLastStep, false, map[string]string{}, stepStartedProperties)
+				models.StepRunStatusCodeSkipped, 0, err, isLastStep, false, map[string]string{}, stepStartedProperties)
 		} else {
 			// beside of the envs coming from the current parent process these will be added as an extra
 			var additionalEnvironments []envmanModels.EnvironmentItemModel
@@ -807,7 +807,7 @@ func (r WorkflowRunner) activateAndRunSteps(
 			}, envSource)
 			if err != nil {
 				runResultCollector.registerStepRunResults(&buildRunResults, stepExecutionID, stepStartTime, mergedStep, stepInfoPtr, stepIdxPtr,
-					*mergedStep.RunIf, models.StepRunStatusCodePreparationFailed, 1,
+					models.StepRunStatusCodePreparationFailed, 1,
 					fmt.Errorf("failed to prepare step environment variables: %s", err),
 					isLastStep, false, map[string]string{}, stepStartedProperties)
 				continue
@@ -818,7 +818,7 @@ func (r WorkflowRunner) activateAndRunSteps(
 				sensitiveEnvs, err := getSensitiveEnvs(stepDeclaredEnvironments, expandedStepEnvironment)
 				if err != nil {
 					runResultCollector.registerStepRunResults(&buildRunResults, stepExecutionID, stepStartTime, mergedStep, stepInfoPtr, stepIdxPtr,
-						*mergedStep.RunIf, models.StepRunStatusCodePreparationFailed, 1,
+						models.StepRunStatusCodePreparationFailed, 1,
 						fmt.Errorf("failed to get sensitive inputs: %s", err),
 						isLastStep, false, map[string]string{}, stepStartedProperties)
 					continue
@@ -830,7 +830,7 @@ func (r WorkflowRunner) activateAndRunSteps(
 			redactedStepInputs, redactedOriginalInputs, err := redactStepInputs(expandedStepEnvironment, mergedStep.Inputs, stepSecrets)
 			if err != nil {
 				runResultCollector.registerStepRunResults(&buildRunResults, stepExecutionID, stepStartTime, mergedStep, stepInfoPtr, stepIdxPtr,
-					*mergedStep.RunIf, models.StepRunStatusCodePreparationFailed, 1,
+					models.StepRunStatusCodePreparationFailed, 1,
 					fmt.Errorf("failed to redact step inputs: %s", err),
 					isLastStep, false, map[string]string{}, stepStartedProperties)
 				continue
@@ -860,14 +860,14 @@ func (r WorkflowRunner) activateAndRunSteps(
 			if err != nil {
 				if *mergedStep.IsSkippable {
 					runResultCollector.registerStepRunResults(&buildRunResults, stepExecutionID, stepStartTime, mergedStep, stepInfoPtr, stepIdxPtr,
-						*mergedStep.RunIf, models.StepRunStatusCodeFailedSkippable, exit, err, isLastStep, false, redactedStepInputs, stepIDProperties)
+						models.StepRunStatusCodeFailedSkippable, exit, err, isLastStep, false, redactedStepInputs, stepIDProperties)
 				} else {
 					runResultCollector.registerStepRunResults(&buildRunResults, stepExecutionID, stepStartTime, mergedStep, stepInfoPtr, stepIdxPtr,
-						*mergedStep.RunIf, models.StepRunStatusCodeFailed, exit, err, isLastStep, false, redactedStepInputs, stepIDProperties)
+						models.StepRunStatusCodeFailed, exit, err, isLastStep, false, redactedStepInputs, stepIDProperties)
 				}
 			} else {
 				runResultCollector.registerStepRunResults(&buildRunResults, stepExecutionID, stepStartTime, mergedStep, stepInfoPtr, stepIdxPtr,
-					*mergedStep.RunIf, models.StepRunStatusCodeSuccess, 0, nil, isLastStep, false, redactedStepInputs, stepIDProperties)
+					models.StepRunStatusCodeSuccess, 0, nil, isLastStep, false, redactedStepInputs, stepIDProperties)
 			}
 		}
 	}


### PR DESCRIPTION
<!--
  Thanks for contributing to the Bitrise CLI!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [ ] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-io/bitrise/blob/master/.github/CONTRIBUTING.md)
- [ ] `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *MAJOR/MINOR/PATCH* [version update](https://semver.org/)

### Context

This PR adds `total_runtime` property to the step finished events. 
This was needed because currently the step runtime is calculated based on the step started and step finished events' timestamps. 
In the case of some step run status (`preparation_failed`, `skipped` and `skipped_with_run_if`) we don't send a step started event, so step runtime is unknown.
This is an issue because step runtime was available in all the cases with the legacy analytics.

Resolves: https://bitrise.atlassian.net/browse/BIVS-1907


### Changes

<!-- 
  Details are important, and help maintainers processing your PR.
  Please list additional details, for example:
  - Update dependencies
  - Make `foo` optional in `main.go`
  - `foo` now returns an `error` for better error handling
-->

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->