### PR TITLE
Update version number

### DIFF
--- a/version/build.go
+++ b/version/build.go
@@ -1,7 +1,7 @@
 package version
 
 // VERSION is the main CLI version number. It's defined at build time using -ldflags
-var VERSION = "2.2.5"
+var VERSION = "2.2.7"
 
 // BuildNumber is the CI build number that creates the release. It's defined at build time using -ldflags
 var BuildNumber = ""


### PR DESCRIPTION
### Checklist

- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-io/bitrise/blob/master/.github/CONTRIBUTING.md)
- [x] `README.md` is updated with the changes (if needed)

### Version

Requires a *PATCH* [version update](https://semver.org/)

### Context

This PR bumps the CLI version to 2.2.7.
The latest release is [2.2.6](https://github.com/bitrise-io/bitrise/releases/tag/2.2.6), but for that release updating the version number in the code was forgotten, that's why this PR bumps from 2.2.5 -> 2.2.7.
