### PR TITLE
Step run func

### DIFF
--- a/_tests/integration/log_format_test.go
+++ b/_tests/integration/log_format_test.go
@@ -40,9 +40,17 @@ func TestConsoleLogCanBeRestoredFromJSONLog(t *testing.T) {
 }
 
 func createConsoleLog(t *testing.T, workflow string) (string, error) {
-	execCmd := exec.Command(binPath(), "setup")
-	outBytes, err := execCmd.CombinedOutput()
-	require.NoError(t, err, string(outBytes))
+	{
+		cmd := exec.Command(binPath(), "setup")
+		outBytes, err := cmd.CombinedOutput()
+		require.NoError(t, err, string(outBytes))
+	}
+
+	{
+		cmd := exec.Command(binPath(), ":analytics", "off")
+		outBytes, err := cmd.CombinedOutput()
+		require.NoError(t, err, string(outBytes))
+	}
 
 	cmd := exec.Command(binPath(), "run", workflow, "--config", "log_format_test_bitrise.yml")
 	out, err := cmd.CombinedOutput()
@@ -50,9 +58,17 @@ func createConsoleLog(t *testing.T, workflow string) (string, error) {
 }
 
 func createJSONLog(t *testing.T, workflow string) ([]byte, error) {
-	execCmd := exec.Command(binPath(), "setup")
-	outBytes, err := execCmd.CombinedOutput()
-	require.NoError(t, err, string(outBytes))
+	{
+		cmd := exec.Command(binPath(), "setup")
+		outBytes, err := cmd.CombinedOutput()
+		require.NoError(t, err, string(outBytes))
+	}
+
+	{
+		cmd := exec.Command(binPath(), ":analytics", "off")
+		outBytes, err := cmd.CombinedOutput()
+		require.NoError(t, err, string(outBytes))
+	}
 
 	cmd := exec.Command(binPath(), "run", workflow, "--config", "log_format_test_bitrise.yml", "--output-format", "json")
 	return cmd.CombinedOutput()
@@ -165,7 +181,7 @@ func convertStepFinishedEventLog(line []byte) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	
+
 	var buf bytes.Buffer
 	logger := log.NewLogger(log.LoggerOpts{LoggerType: log.ConsoleLogger, Writer: &buf})
 	logger.PrintStepFinishedEvent(eventLog.Content)

--- a/plugins/run.go
+++ b/plugins/run.go
@@ -40,7 +40,7 @@ func strip(str string) string {
 
 		hasNewlineSuffix := false
 		if strings.HasSuffix(strippedStr, "\n") {
-			hasNewlinePrefix = true
+			hasNewlineSuffix = true
 			strippedStr = strings.TrimSuffix(strippedStr, "\n")
 		}
 

--- a/plugins/run.go
+++ b/plugins/run.go
@@ -129,6 +129,9 @@ func runPlugin(plugin Plugin, args []string, envKeyValues PluginConfig, input []
 		envs = append(envs, key+"="+value)
 	}
 
+	// envs are not expanded when running a plugin,
+	// this means if you pass (ENV_1=value, ENV_2=$ENV_1) and echo $ENV_2,
+	// $ENV_1 will be printed (and not value).
 	cmd.AppendEnvs(envs...)
 
 	logger := log.NewLogger(log.GetGlobalLoggerOpts())

--- a/stepoutput/stepoutputwriter_test.go
+++ b/stepoutput/stepoutputwriter_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/bitrise-io/bitrise/log"
+	"github.com/bitrise-io/bitrise/tools/filterwriter"
 	"github.com/stretchr/testify/require"
 )
 
@@ -209,4 +210,10 @@ func Test_GivenWriter_WhenJSONLoggingAndSecretFiltering_ThenReturnsError(t *test
 			require.Equal(t, tt.want, errors)
 		})
 	}
+}
+
+func Test_WhenSecretsProvided_ThenRootWriterIsFilterWriter(t *testing.T) {
+	w := NewWriter([]string{"secret"}, log.LoggerOpts{})
+	_, isFilterWriter := w.writer.(*filterwriter.Writer)
+	require.True(t, isFilterWriter)
 }


### PR DESCRIPTION
### Checklist

- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-io/bitrise/blob/master/.github/CONTRIBUTING.md)
- [x] `README.md` is updated with the changes (if needed)

### Version

Requires a *NO* [version update](https://semver.org/)

### Context

The goal of this PR is to leave less room for engineers to accidentally break the secret redaction on the step run logs.

One change is discarding the usage of (and removing) `tools.EnvmanRun`, as the rest of its features are only used when running a step, but at the same time the `tools.EnvmanRun` seemed to be a generic function, which is open for many configurations.

Another change is testing if the root writer of the `stepoutput.Writer` is a secret redactor when secrets are provided.

Resolves: https://bitrise.atlassian.net/browse/CI-1102

### Changes

- Remove EnvmanRun and move it's logic to `WorkflowRunner.executeStep`
- Use go-utils command for running plugins
- Move `activateStepLibStep` from run_utils.go to step_activator.go (as it is used only from this file)
- Test if the root writer of the `stepoutput.Writer` is a secret redactor when secrets are provided
