### PR TITLE
Update default workflow editor plugin version

### DIFF
--- a/bitrise/setup.go
+++ b/bitrise/setup.go
@@ -36,7 +36,7 @@ var PluginDependencyMap = map[string]PluginDependency{
 	},
 	"workflow-editor": {
 		Source:     "https://github.com/bitrise-io/bitrise-workflow-editor.git",
-		MinVersion: "1.3.135",
+		MinVersion: "1.3.234",
 	},
 	"analytics": {
 		Source:     "https://github.com/bitrise-io/bitrise-plugins-analytics.git",


### PR DESCRIPTION
### Checklist

- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-io/bitrise/blob/master/.github/CONTRIBUTING.md)
- [x] `README.md` is updated with the changes (if needed)

### Version

Requires a *MINOR* [version update](https://semver.org/)

### Context

This PR updates the workflow editor plugin version to the latest version ([1.3.234](https://github.com/bitrise-io/bitrise-workflow-editor/releases/tag/1.3.234)).

This workflow editor version [supports Pipeline and Stage title, summary, and description](https://github.com/bitrise-io/bitrise-workflow-editor/pull/793).

Resolves: https://bitrise.atlassian.net/browse/BIVS-1995

### Changes

- Update workflow editor plugin version to 1.3.234
