### PR TITLE
Bump models format version to 13 and version number to 2.3.0

### DIFF
--- a/_tests/integration/version_test.go
+++ b/_tests/integration/version_test.go
@@ -18,7 +18,7 @@ func Test_VersionOutput(t *testing.T) {
 
 		expectedOSVersion := fmt.Sprintf("%s (%s)", runtime.GOOS, runtime.GOARCH)
 		expectedVersionOut := fmt.Sprintf(`version: %s
-format version: 12
+format version: 13
 os: %s
 go: %s
 build number: 

--- a/models/models.go
+++ b/models/models.go
@@ -11,7 +11,7 @@ import (
 
 const (
 	// FormatVersion ...
-	FormatVersion = "12"
+	FormatVersion = "13"
 )
 
 // StepListItemModel ...
@@ -113,6 +113,7 @@ type BitriseDataModel struct {
 
 // StepIDData ...
 // structured representation of a composite-step-id
+//
 //	a composite step id is: step-lib-source::step-id@1.0.0
 type StepIDData struct {
 	// SteplibSource : steplib source uri, or in case of local path just "path", and in case of direct git url just "git"

--- a/version/build.go
+++ b/version/build.go
@@ -1,7 +1,7 @@
 package version
 
 // VERSION is the main CLI version number. It's defined at build time using -ldflags
-var VERSION = "2.2.7"
+var VERSION = "2.3.0"
 
 // BuildNumber is the CI build number that creates the release. It's defined at build time using -ldflags
 var BuildNumber = ""


### PR DESCRIPTION
### Checklist

- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-io/bitrise/blob/master/.github/CONTRIBUTING.md)
- [x] `README.md` is updated with the changes (if needed)

### Context

bitrise.yml data model got new fields in this PR: https://github.com/bitrise-io/bitrise/pull/876.

This PR bumps the bitrise.yml data model format version to `13` and Bitrise CLI version number to `2.3.0`.

Resolves: https://bitrise.atlassian.net/browse/BIVS-1995

### Changes

- bump `FormatVersion` to 13
- bump `VERSION` to 2.3.0
