### PR TITLE
Update default plugin versions

### DIFF
--- a/bitrise/setup.go
+++ b/bitrise/setup.go
@@ -32,15 +32,15 @@ var PluginDependencyMap = map[string]PluginDependency{
 	},
 	"step": {
 		Source:     "https://github.com/bitrise-io/bitrise-plugins-step.git",
-		MinVersion: "0.10.3",
+		MinVersion: "0.10.4",
 	},
 	"workflow-editor": {
 		Source:     "https://github.com/bitrise-io/bitrise-workflow-editor.git",
-		MinVersion: "1.3.234",
+		MinVersion: "1.3.241",
 	},
 	"analytics": {
 		Source:     "https://github.com/bitrise-io/bitrise-plugins-analytics.git",
-		MinVersion: "0.13.0",
+		MinVersion: "0.13.1",
 	},
 }
 

--- a/plugins/run.go
+++ b/plugins/run.go
@@ -143,6 +143,7 @@ func runPlugin(plugin Plugin, args []string, envKeyValues PluginConfig, input []
 	logWriter := logwriter.NewLogWriter(logger)
 
 	cmd.SetStdout(logWriter)
+	cmd.SetStderr(logWriter)
 
 	cmdErr := cmd.Run()
 

--- a/plugins/run.go
+++ b/plugins/run.go
@@ -2,6 +2,7 @@ package plugins
 
 import (
 	"bytes"
+	"os"
 	"strings"
 
 	"github.com/bitrise-io/bitrise/configs"
@@ -122,7 +123,11 @@ func runPlugin(plugin Plugin, args []string, envKeyValues PluginConfig, input []
 		cmd = command.New("bash", append([]string{pluginExecutable}, args...)...)
 	}
 
-	cmd.SetStdin(bytes.NewReader(input))
+	if len(input) > 0 {
+		cmd.SetStdin(bytes.NewReader(input))
+	} else {
+		cmd.SetStdin(os.Stdin)
+	}
 
 	var envs []string
 	for key, value := range envKeyValues {


### PR DESCRIPTION
### Checklist

- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-io/bitrise/blob/master/.github/CONTRIBUTING.md)
- [x] `README.md` is updated with the changes (if needed)

### Version

Requires a *NO* [version update](https://semver.org/)

The changes will be released under the unreleased 2.4.0 version.

### Context

This PR updates the default plugins' versions and sets stdin and stderr for the plugin execution command.
The latter fixes the issue of the init plugin not printing relevant error messages to the output and the issue of the step plugin not prompting for user input.

### Changes

- Update analytics plugin version: 0.13.0 -> [0.13.1](https://github.com/bitrise-io/bitrise-plugins-analytics/releases/tag/0.13.1)
- Update step plugin version: 0.10.3 -> [0.10.4](https://github.com/bitrise-io/bitrise-plugins-step/releases/tag/0.10.4)
- Update workflow-editor plugin version: 1.3.234 -> [1.3.241](https://github.com/bitrise-io/bitrise-workflow-editor/releases/tag/1.3.241)
- set stdin and stderr for the plugin execution command.
