### PR TITLE
[CI-1803] Secret env sharing

### DIFF
--- a/_tests/integration/secret_keys_sharing_test.go
+++ b/_tests/integration/secret_keys_sharing_test.go
@@ -1,0 +1,13 @@
+package integration
+
+import (
+	"github.com/bitrise-io/go-utils/command"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestSecretSharing(t *testing.T) {
+	cmd := command.New(binPath(), "run", "secret-sharing", "--config", "secret_keys_sharing_test_bitrise.yml", "--inventory", "secret_keys_sharing_test_secrets.yml")
+	out, err := cmd.RunAndReturnTrimmedCombinedOutput()
+	require.NoError(t, err, out)
+}

--- a/_tests/integration/secret_keys_sharing_test_bitrise.yml
+++ b/_tests/integration/secret_keys_sharing_test_bitrise.yml
@@ -1,0 +1,24 @@
+format_version: "11"
+default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
+
+workflows:
+  secret-sharing:
+    steps:
+    - script:
+        title: This does not receive the secret keys
+        inputs:
+        - content: |-
+            #!/bin/env bash
+            set -x # Do not set -e as bitrise command is expected to fail
+            set +v
+
+            # Add an extra secret so we have two from the secrets file and one dynamically created
+            envman add --key MY_SECRET_ENV --value 'this is a secret value' --sensitive
+    - script:
+        inputs:
+        - content: |-
+            #!/bin/env bash
+            set -x # Do not set -e as bitrise command is expected to fail
+            set +v
+
+            if [[ "$BITRISE_SECRET_ENV_KEY_LIST" != "SECRET_ENV_ONE,SECRET_ENV_TWO,MY_SECRET_ENV" ]] ; then exit 1; fi

--- a/_tests/integration/secret_keys_sharing_test_bitrise.yml
+++ b/_tests/integration/secret_keys_sharing_test_bitrise.yml
@@ -9,8 +9,7 @@ workflows:
         inputs:
         - content: |-
             #!/bin/env bash
-            set -x # Do not set -e as bitrise command is expected to fail
-            set +v
+            set -e
 
             # Add an extra secret so we have two from the secrets file and one dynamically created
             envman add --key MY_SECRET_ENV --value 'this is a secret value' --sensitive
@@ -18,7 +17,6 @@ workflows:
         inputs:
         - content: |-
             #!/bin/env bash
-            set -x # Do not set -e as bitrise command is expected to fail
-            set +v
+            set -e
 
             if [[ "$BITRISE_SECRET_ENV_KEY_LIST" != "SECRET_ENV_ONE,SECRET_ENV_TWO,MY_SECRET_ENV" ]] ; then exit 1; fi

--- a/_tests/integration/secret_keys_sharing_test_secrets.yml
+++ b/_tests/integration/secret_keys_sharing_test_secrets.yml
@@ -1,0 +1,3 @@
+envs:
+- SECRET_ENV_ONE: first secret value
+- SECRET_ENV_TWO: second secret value

--- a/cli/run_util.go
+++ b/cli/run_util.go
@@ -441,11 +441,9 @@ func (r WorkflowRunner) runStep(
 	stepUUID string,
 	step stepmanModels.StepModel,
 	stepIDData models.StepIDData,
-	officialStep bool,
 	stepDir string,
 	environments []envmanModels.EnvironmentItemModel,
-	secretKeys []string,
-	secretValues []string) (int, []envmanModels.EnvironmentItemModel, error) {
+	secrets []string) (int, []envmanModels.EnvironmentItemModel, error) {
 	log.Debugf("[BITRISE_CLI] - Try running step: %s (%s)", stepIDData.IDorURI, stepIDData.Version)
 
 	// Check & Install Step Dependencies
@@ -473,10 +471,6 @@ func (r WorkflowRunner) runStep(
 		return 1, []envmanModels.EnvironmentItemModel{}, err
 	}
 
-	if err := exportEnvKeyList(secretKeys); err != nil {
-		log.Debugf("[BITRISE_CLI] - Failed to add Bitrise env key list")
-	}
-
 	// Run step
 	bitriseSourceDir, err := getCurrentBitriseSourceDir(environments)
 	if err != nil {
@@ -486,7 +480,7 @@ func (r WorkflowRunner) runStep(
 		bitriseSourceDir = configs.CurrentDir
 	}
 
-	if exit, err := r.executeStep(stepUUID, step, stepIDData, stepDir, bitriseSourceDir, secretValues); err != nil {
+	if exit, err := r.executeStep(stepUUID, step, stepIDData, stepDir, bitriseSourceDir, secrets); err != nil {
 		stepOutputs, envErr := bitrise.CollectEnvironmentsFromFile(configs.OutputEnvstorePath)
 		if envErr != nil {
 			return 1, []envmanModels.EnvironmentItemModel{}, envErr
@@ -531,11 +525,6 @@ func (r WorkflowRunner) runStep(
 	log.Debugf("[BITRISE_CLI] - Step executed: %s (%s)", stepIDData.IDorURI, stepIDData.Version)
 
 	return 0, updatedStepOutputs, nil
-}
-
-func exportEnvKeyList(keys []string) error {
-	concatenatedKeys := secretkeys.NewManager().Format(keys)
-	return tools.EnvmanAdd(configs.InputEnvstorePath, secretkeys.EnvKey, concatenatedKeys, false, true, true)
 }
 
 func (r WorkflowRunner) activateAndRunSteps(
@@ -807,10 +796,12 @@ func (r WorkflowRunner) activateAndRunSteps(
 				}
 			}
 
+			secretKeysEnv := secretEnvKeysEnvironment(stepSecretKeys)
+			stepDeclaredEnvironments = append(stepDeclaredEnvironments, secretKeysEnv)
+
 			tracker.SendStepStartedEvent(stepStartedProperties, prepareAnalyticsStepInfo(mergedStep, stepInfoPtr), redactedInputsWithType, redactedOriginalInputs)
 
-			isOfficialStep := stepInfoPtr.GroupInfo.Maintainer == "bitrise"
-			exit, outEnvironments, err := r.runStep(stepExecutionID, mergedStep, stepIDData, isOfficialStep, stepDir, stepDeclaredEnvironments, stepSecretKeys, stepSecretValues)
+			exit, outEnvironments, err := r.runStep(stepExecutionID, mergedStep, stepIDData, stepDir, stepDeclaredEnvironments, stepSecretValues)
 
 			if testDirPath != "" {
 				if err := addTestMetadata(testDirPath, models.TestResultStepInfo{Number: idx, Title: *mergedStep.Title, ID: stepIDData.IDorURI, Version: stepIDData.Version}); err != nil {
@@ -909,4 +900,9 @@ func addTestMetadata(testDirPath string, testResultStepInfo models.TestResultSte
 		}
 	}
 	return nil
+}
+
+func secretEnvKeysEnvironment(keys []string) envmanModels.EnvironmentItemModel {
+	value := secretkeys.NewManager().Format(keys)
+	return envmanModels.EnvironmentItemModel{secretkeys.EnvKey: value}
 }

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.17
 
 require (
 	github.com/bitrise-io/envman v0.0.0-20221010094751-a03ce30a5316
+	github.com/bitrise-io/go-steputils/v2 v2.0.0-alpha.19
 	github.com/bitrise-io/go-utils v1.0.8
 	github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.16
 	github.com/bitrise-io/goinp v0.0.0-20211005113137-305e91b481f4

--- a/go.sum
+++ b/go.sum
@@ -3,11 +3,15 @@ github.com/bitrise-io/colorstring v0.0.0-20180614154802-a8cd70115192 h1:vSHYT6kC
 github.com/bitrise-io/colorstring v0.0.0-20180614154802-a8cd70115192/go.mod h1:CIHVcxZUvsG99XUJV6JlR7okNsMMGY81jMvPC20W+O0=
 github.com/bitrise-io/envman v0.0.0-20221010094751-a03ce30a5316 h1:gRQReCvmNxUVvm71SJYpx8d6wz4ln6ChapNkDStco58=
 github.com/bitrise-io/envman v0.0.0-20221010094751-a03ce30a5316/go.mod h1:L4WQyg88d87Z4dxNwrYEa0Cwd9/W0gSfXsibw30r8Vw=
+github.com/bitrise-io/go-steputils/v2 v2.0.0-alpha.19 h1:zP9oZRZA9JGPELjBcWSzo/nd8g7apc7EBd7KZHHFdvs=
+github.com/bitrise-io/go-steputils/v2 v2.0.0-alpha.19/go.mod h1:/ueNOKnsjcUrlt8Ck75WRNspL7E6nAAylvl9oGJtYio=
 github.com/bitrise-io/go-utils v0.0.0-20200224122728-e212188d99b4/go.mod h1:tTEsKvbz1LbzuN/KpVFHXnLtcAPdEgIdM41s0lL407s=
 github.com/bitrise-io/go-utils v0.0.0-20210505121718-07411d72e36e/go.mod h1:nhdaDQFvaMny1CugVV6KjK92/q97ENo0RuKSW5I4fbA=
+github.com/bitrise-io/go-utils v1.0.1/go.mod h1:ZY1DI+fEpZuFpO9szgDeICM4QbqoWVt0RSY3tRI1heY=
 github.com/bitrise-io/go-utils v1.0.3/go.mod h1:ZY1DI+fEpZuFpO9szgDeICM4QbqoWVt0RSY3tRI1heY=
 github.com/bitrise-io/go-utils v1.0.8 h1:ekXH6FK5V8UxkyHm2FsQL8yk9Wqd5fjg1NGlD7jK2kc=
 github.com/bitrise-io/go-utils v1.0.8/go.mod h1:ZY1DI+fEpZuFpO9szgDeICM4QbqoWVt0RSY3tRI1heY=
+github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.13/go.mod h1:gZWtM7PLn1VOroa4gN1La/24aRVc0jg5R701jTsPaO8=
 github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.16 h1:y+Yo0d8pYIjZiKhQuPM/Z5FY9/mu+wrWkyQlch8f9Po=
 github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.16/go.mod h1:Laih4ji980SQkRgdnMCH0g4u2GZI/5nnbqmYT9UfKFQ=
 github.com/bitrise-io/goinp v0.0.0-20210504152833-8559b0680ab1/go.mod h1:iRbd8zAXLeNy+0gic0eqNCxXvDGe8ZEY/uYX2CCeAoo=
@@ -17,12 +21,15 @@ github.com/bitrise-io/gows v0.0.0-20211005113107-14f65e686b88 h1:HObzyO+BJrTSLqx
 github.com/bitrise-io/gows v0.0.0-20211005113107-14f65e686b88/go.mod h1:3Cp9ceJ8wHl1Av6oEE2ff1iWaYLliQuD+oaNdyM0NWQ=
 github.com/bitrise-io/stepman v0.0.0-20221010110437-a88e9a915b58 h1:xrEcHh9p9ZD/tEJLxv3dc/x4gS+GUsr/c1rVnkW8A6w=
 github.com/bitrise-io/stepman v0.0.0-20221010110437-a88e9a915b58/go.mod h1:4BBUXFxB5UlF/tZHXrNFjAy9yNvjZ7Lf/TeIpMwjsow=
+github.com/bmatcuk/doublestar/v4 v4.2.0/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.1 h1:r/myEWzV9lfsM1tFLgDyu0atFtJ1fXn261LKYj/3DxU=
 github.com/cpuguy83/go-md2man/v2 v2.0.1/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
+github.com/gofrs/uuid v4.2.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/gofrs/uuid v4.3.1+incompatible h1:0/KbAdpx3UXAx1kEOWHJeOkpbgRFGHVgv+CFIY7dBJI=
 github.com/gofrs/uuid v4.3.1+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
@@ -40,6 +47,7 @@ github.com/hashicorp/go-version v1.4.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
+github.com/mitchellh/mapstructure v1.4.3/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -98,6 +106,7 @@ golang.org/x/sys v0.0.0-20210503173754-0981d6026fa6/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211205182925-97ca703d548d/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220712014510-0a85c31ab51e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.2.0 h1:ljd4t30dBnAvMZaQCevtY0xLLD0A+bRZXbgLMLU1F/A=
 golang.org/x/sys v0.2.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -268,8 +268,9 @@ func EnvmanClear(envStorePth string) error {
 // ------------------
 // --- Utility
 
-// GetSecretValues filters out built in configuration parameters from the secret envs
-func GetSecretValues(secrets []envmanModels.EnvironmentItemModel) []string {
+// GetSecretKeysAndValues filters out built in configuration parameters from the secret envs
+func GetSecretKeysAndValues(secrets []envmanModels.EnvironmentItemModel) ([]string, []string) {
+	var secretKeys []string
 	var secretValues []string
 	for _, secret := range secrets {
 		key, value, err := secret.GetKeyValuePair()
@@ -279,10 +280,11 @@ func GetSecretValues(secrets []envmanModels.EnvironmentItemModel) []string {
 			}
 			continue
 		}
+		secretKeys = append(secretKeys, key)
 		secretValues = append(secretValues, value)
 	}
 
-	return secretValues
+	return secretKeys, secretValues
 }
 
 // MoveFile ...

--- a/vendor/github.com/bitrise-io/go-steputils/v2/secretkeys/secretkeys.go
+++ b/vendor/github.com/bitrise-io/go-steputils/v2/secretkeys/secretkeys.go
@@ -1,0 +1,39 @@
+package secretkeys
+
+import (
+	"strings"
+
+	"github.com/bitrise-io/go-utils/v2/env"
+)
+
+const (
+	// EnvKey ...
+	EnvKey    = "BITRISE_SECRET_ENV_KEY_LIST"
+	separator = ","
+)
+
+// Manager ...
+type Manager interface {
+	Load(envRepository env.Repository) []string
+	Format(keys []string) string
+}
+
+type manager struct {
+}
+
+// NewManager ...
+func NewManager() Manager {
+	return manager{}
+}
+
+// Load ...
+func (manager) Load(envRepository env.Repository) []string {
+	value := envRepository.Get(EnvKey)
+	keys := strings.Split(value, separator)
+	return keys
+}
+
+// Format ...
+func (manager) Format(keys []string) string {
+	return strings.Join(keys, separator)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -9,6 +9,9 @@ github.com/bitrise-io/envman/envman
 github.com/bitrise-io/envman/models
 github.com/bitrise-io/envman/output
 github.com/bitrise-io/envman/version
+# github.com/bitrise-io/go-steputils/v2 v2.0.0-alpha.19
+## explicit; go 1.17
+github.com/bitrise-io/go-steputils/v2/secretkeys
 # github.com/bitrise-io/go-utils v1.0.8
 ## explicit; go 1.13
 github.com/bitrise-io/go-utils/colorstring


### PR DESCRIPTION
<!--
  Thanks for contributing to the Bitrise CLI!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [ ] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-io/bitrise/blob/master/.github/CONTRIBUTING.md)
- [ ] `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *MINOR* [version update](https://semver.org/)

### Context

The deploy to bitrise io and the share pipeline env var steps will need to know about the available secrets so they can provide extra functionality. This PR introduces the necessary changes on the CLI side.

### Changes

The core of the logic is in the go-utils lib because it will be shared between 3 items. 

Other than that the CLI only used the secret values for redaction but now it also needs the keys so I modified a few functions to also accept the keys too.
