### PR TITLE
Add envcontain to template string evaluation

### DIFF
--- a/bitrise/template_util.go
+++ b/bitrise/template_util.go
@@ -62,6 +62,9 @@ func EvaluateTemplateToString(expStr string, isCI, isPR bool, buildResults model
 		"enveq": func(key, expectedValue string) bool {
 			return (getEnv(key, envList) == expectedValue)
 		},
+		"envcontain": func(key, subString string) bool {
+			return strings.Contains(getEnv(key, envList), subString)
+		},
 	}
 
 	tmpl := template.New("EvaluateTemplateToBool").Funcs(templateFuncMap)

--- a/bitrise/template_utils_test.go
+++ b/bitrise/template_utils_test.go
@@ -91,6 +91,16 @@ func TestRegisteredFunctions(t *testing.T) {
 			envValue:     "enveq value",
 			expected:     false,
 		},
+		{
+			propTempCont: `{{envcontain "TEST_KEY" "val"}}`,
+			envValue:     "enveq value",
+			expected:     true,
+		},
+		{
+			propTempCont: `{{envcontain "TEST_KEY" "different"}}`,
+			envValue:     "enveq value",
+			expected:     false,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.propTempCont, func(t *testing.T) {


### PR DESCRIPTION
### Checklist
- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-io/bitrise/blob/master/.github/CONTRIBUTING.md)
- [x] `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *MAJOR/MINOR/PATCH* [version update](https://semver.org/)

### Context

This PR extends the functionality in condition template evaluation. `envcontain` checks if an environment variable contains a  substring or not.

### Changes

<!-- 
  Details are important, and help maintainers processing your PR.
  Please list additional details, for example:
  - Update dependencies
  - Make `foo` optional in `main.go`
  - `foo` now returns an `error` for better error handling
-->

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->