### PR TITLE
Remove long-deprecated --path flag

### DIFF
--- a/_tests/brew_publish.yml
+++ b/_tests/brew_publish.yml
@@ -6,16 +6,16 @@ description: |-
   It might be a good idea to call `brew doctor` as well and
   fix the listed issues if any.
 
-  After this you can call `bitrise run -p brew_publish.yml edit-formula`.
+  After this you can call `bitrise run -c brew_publish.yml edit-formula`.
   This'll open the `bitrise` brew formula in the specified Editor.
 
   Update the tool versions (bitrise, stepman, envman) and save the file.
 
-  Run `bitrise run -p brew_publish.yml reinstall` to make sure the specified
+  Run `bitrise run -c brew_publish.yml reinstall` to make sure the specified
   versions do work.
 
   Last but not least, to run a brew audit and issue checking on the Formula
-  you should call: `bitrise run -p brew_publish.yml check`.
+  you should call: `bitrise run -c brew_publish.yml check`.
 
   *NOTE*: you might have to temporarily remove the GOPATH/bin from your
   PATH while calling `brew test`, as it might conflict with how

--- a/_tests/integration/validate_test.go
+++ b/_tests/integration/validate_test.go
@@ -63,19 +63,6 @@ func Test_ValidateTest(t *testing.T) {
 		require.Equal(t, true, elapsed < runtimeLimit, runningTimeMsg, elapsed, elapsed-runtimeLimit)
 	}
 
-	t.Log("valid - warning test - `-p` flag is deprecated")
-	{
-		var out string
-		var err error
-		elapsed := withRunningTimeCheck(func() {
-			cmd := command.New(binPath(), "validate", "-p", "trigger_params_test_bitrise.yml")
-			out, err = cmd.RunAndReturnTrimmedCombinedOutput()
-		}, runtimeLimit)
-		require.NoError(t, err)
-		require.Equal(t, "Config is valid: \x1b[32;1mtrue\x1b[0m\nWarning(s):\n- 'path' key is deprecated, use 'config' instead!", out)
-		require.Equal(t, true, elapsed < runtimeLimit, runningTimeMsg, elapsed, elapsed-runtimeLimit)
-	}
-
 	t.Log("valid - invalid pipeline id")
 	{
 		configPth := filepath.Join(tmpDir, "bitrise.yml")
@@ -145,19 +132,6 @@ func Test_ValidateTestJSON(t *testing.T) {
 		}, runtimeLimit)
 		require.NoError(t, err)
 		require.Equal(t, "{\"data\":{\"config\":{\"is_valid\":true}}}", out)
-		require.Equal(t, true, elapsed < runtimeLimit, runningTimeMsg, elapsed, elapsed-runtimeLimit)
-	}
-
-	t.Log("valid - warning test - `-p` flag is deprecated")
-	{
-		var out string
-		var err error
-		elapsed := withRunningTimeCheck(func() {
-			cmd := command.New(binPath(), "validate", "-p", "trigger_params_test_bitrise.yml", "--format", "json")
-			out, err = cmd.RunAndReturnTrimmedCombinedOutput()
-		}, runtimeLimit)
-		require.NoError(t, err)
-		require.Equal(t, "{\"data\":{\"config\":{\"is_valid\":true}},\"warnings\":[\"'path' key is deprecated, use 'config' instead!\"]}", out)
 		require.Equal(t, true, elapsed < runtimeLimit, runningTimeMsg, elapsed, elapsed-runtimeLimit)
 	}
 

--- a/bitrise/setup.go
+++ b/bitrise/setup.go
@@ -170,7 +170,7 @@ func doSetupBitriseCoreTools() error {
 
 func doSetupOnOSX(isMinimalSetupMode bool) error {
 	log.Print()
-	log.Infof("Doing OS X specific setup")
+	log.Infof("Doing macOS-specific setup")
 	log.Printf("Checking required tools...")
 
 	if err := CheckIsHomebrewInstalled(isMinimalSetupMode); err != nil {

--- a/cli/commands.go
+++ b/cli/commands.go
@@ -38,7 +38,6 @@ var (
 			Usage:  "Validates a specified bitrise config.",
 			Action: validate,
 			Flags: []cli.Flag{
-				flPath,
 				flConfig,
 				flConfigBase64,
 				flInventory,
@@ -69,8 +68,6 @@ var (
 				cli.StringFlag{Name: JSONParamsKey, Usage: "Specify command flags with json string-string hash."},
 				cli.StringFlag{Name: JSONParamsBase64Key, Usage: "Specify command flags with base64 encoded json string-string hash."},
 
-				// deprecated
-				flPath,
 
 				// should deprecate
 				cli.StringFlag{Name: ConfigBase64Key, Usage: "base64 encoded config data."},
@@ -83,7 +80,6 @@ var (
 			Usage:  "Export the bitrise configuration.",
 			Action: export,
 			Flags: []cli.Flag{
-				flPath,
 				flConfig,
 				flConfigBase64,
 				flFormat,
@@ -96,7 +92,6 @@ var (
 			Usage:  "Normalize the bitrise configuration.",
 			Action: normalize,
 			Flags: []cli.Flag{
-				flPath,
 				flConfig,
 				flConfigBase64,
 			},

--- a/cli/export.go
+++ b/cli/export.go
@@ -15,11 +15,6 @@ func export(c *cli.Context) error {
 	bitriseConfigBase64Data := c.String(ConfigBase64Key)
 
 	bitriseConfigPath := c.String(ConfigKey)
-	deprecatedBitriseConfigPath := c.String(PathKey)
-	if bitriseConfigPath == "" && deprecatedBitriseConfigPath != "" {
-		log.Warn("'path' key is deprecated, use 'config' instead!")
-		bitriseConfigPath = deprecatedBitriseConfigPath
-	}
 
 	outfilePth := c.String(OuputPathKey)
 	outFormat := c.String(OuputFormatKey)

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -6,69 +6,46 @@ import (
 )
 
 const (
-	// CollectionPathEnvKey ...
 	CollectionPathEnvKey = "STEPMAN_COLLECTION"
-	// CIKey ...
 	CIKey = "ci"
-	// PRKey ...
 	PRKey = "pr"
-	// DebugModeKey ...
 	DebugModeKey = "debug"
 
-	// VersionKey ...
 	VersionKey      = "version"
 	versionKeyShort = "v"
 
-	// PathKey ...
-	PathKey      = "path"
-	pathKeyShort = "p"
-
-	// CollectionKey ...
 	CollectionKey      = "collection"
 	collectionKeyShort = "c"
 
 	inventoryShortKey = "i"
 
-	// InventoryBase64Key ...
 	InventoryBase64Key = "inventory-base64"
 
 	configShortKey = "c"
 
-	// ConfigBase64Key ...
 	ConfigBase64Key = "config-base64"
 
-	// HelpKey ...
 	HelpKey      = "help"
 	helpKeyShort = "h"
 
-	// MinimalModeKey ...
 	MinimalModeKey = "minimal"
-	// FullModeKey ...
 	FullModeKey = "full"
 
 	ouputFormatKeyShort = "f"
-	// OuputPathKey ...
 	OuputPathKey = "outpath"
-	// PrettyFormatKey ...
 	PrettyFormatKey = "pretty"
 
-	// IDKey ...
 	IDKey      = "id"
 	idKeyShort = "i"
-	// ShortKey ...
 	ShortKey = "short"
 
-	// StepYMLKey ...
 	StepYMLKey = "step-yml"
 
 	//
 	// Stepman share
 
-	// TagKey ...
 	TagKey = "tag"
-	// GitKey ...
 	GitKey = "git"
-	// StepIDKey ...
 	StepIDKey = "stepid"
 )
 
@@ -97,10 +74,6 @@ var (
 	flOutputFormat = cli.StringFlag{
 		Name:  OuputFormatKey + ", " + ouputFormatKeyShort,
 		Usage: "Output format. Accepted: raw (default), json, yml",
-	}
-	flPath = cli.StringFlag{
-		Name:  PathKey + ", " + pathKeyShort,
-		Usage: "[Deprecated!!! Use 'config'] Path where the workflow config file is located.",
 	}
 	flCollection = cli.StringFlag{
 		Name:   CollectionKey + ", " + collectionKeyShort,

--- a/cli/normalize.go
+++ b/cli/normalize.go
@@ -11,11 +11,6 @@ func normalize(c *cli.Context) error {
 	bitriseConfigBase64Data := c.String(ConfigBase64Key)
 
 	bitriseConfigPath := c.String(ConfigKey)
-	deprecatedBitriseConfigPath := c.String(PathKey)
-	if bitriseConfigPath == "" && deprecatedBitriseConfigPath != "" {
-		log.Warn("'path' key is deprecated, use 'config' instead!")
-		bitriseConfigPath = deprecatedBitriseConfigPath
-	}
 	//
 
 	// Input validation

--- a/cli/run.go
+++ b/cli/run.go
@@ -64,9 +64,6 @@ var runCommand = cli.Command{
 		cli.StringFlag{Name: JSONParamsBase64Key, Usage: "Specify command flags with base64 encoded json string-string hash."},
 		cli.StringFlag{Name: OutputFormatKey, Usage: "Log format. Available values: json, console"},
 
-		// deprecated
-		flPath,
-
 		// should deprecate
 		cli.StringFlag{Name: ConfigBase64Key, Usage: "base64 encoded config data."},
 		cli.StringFlag{Name: InventoryBase64Key, Usage: "base64 encoded inventory data."},
@@ -283,11 +280,6 @@ func processArgs(c *cli.Context) (*RunConfig, error) {
 
 	bitriseConfigBase64Data := c.String(ConfigBase64Key)
 	bitriseConfigPath := c.String(ConfigKey)
-	deprecatedBitriseConfigPath := c.String(PathKey)
-	if bitriseConfigPath == "" && deprecatedBitriseConfigPath != "" {
-		log.Warn("'path' key is deprecated, use 'config' instead!")
-		bitriseConfigPath = deprecatedBitriseConfigPath
-	}
 
 	inventoryBase64Data := c.String(InventoryBase64Key)
 	inventoryPath := c.String(InventoryKey)

--- a/cli/step_info.go
+++ b/cli/step_info.go
@@ -37,11 +37,6 @@ func stepInfo(c *cli.Context) error {
 	bitriseConfigBase64Data := c.String(ConfigBase64Key)
 
 	bitriseConfigPath := c.String(ConfigKey)
-	deprecatedBitriseConfigPath := c.String(PathKey)
-	if bitriseConfigPath == "" && deprecatedBitriseConfigPath != "" {
-		warnings = append(warnings, "'path' key is deprecated, use 'config' instead!")
-		bitriseConfigPath = deprecatedBitriseConfigPath
-	}
 
 	format := c.String(OuputFormatKey)
 

--- a/cli/step_list.go
+++ b/cli/step_list.go
@@ -16,11 +16,6 @@ func stepList(c *cli.Context) error {
 	bitriseConfigBase64Data := c.String(ConfigBase64Key)
 
 	bitriseConfigPath := c.String(ConfigKey)
-	deprecatedBitriseConfigPath := c.String(PathKey)
-	if bitriseConfigPath == "" && deprecatedBitriseConfigPath != "" {
-		warnings = append(warnings, "'path' key is deprecated, use 'config' instead!")
-		bitriseConfigPath = deprecatedBitriseConfigPath
-	}
 
 	format := c.String(OuputFormatKey)
 

--- a/cli/trigger.go
+++ b/cli/trigger.go
@@ -34,9 +34,6 @@ var triggerCommand = cli.Command{
 		cli.StringFlag{Name: JSONParamsKey, Usage: "Specify command flags with json string-string hash."},
 		cli.StringFlag{Name: JSONParamsBase64Key, Usage: "Specify command flags with base64 encoded json string-string hash."},
 
-		// deprecated
-		flPath,
-
 		// should deprecate
 		cli.StringFlag{Name: ConfigBase64Key, Usage: "base64 encoded config data."},
 		cli.StringFlag{Name: InventoryBase64Key, Usage: "base64 encoded inventory data."},
@@ -107,11 +104,6 @@ func trigger(c *cli.Context) error {
 
 	bitriseConfigBase64Data := c.String(ConfigBase64Key)
 	bitriseConfigPath := c.String(ConfigKey)
-	deprecatedBitriseConfigPath := c.String(PathKey)
-	if bitriseConfigPath == "" && deprecatedBitriseConfigPath != "" {
-		log.Warn("'path' key is deprecated, use 'config' instead!")
-		bitriseConfigPath = deprecatedBitriseConfigPath
-	}
 
 	inventoryBase64Data := c.String(InventoryBase64Key)
 	inventoryPath := c.String(InventoryKey)

--- a/cli/trigger_check.go
+++ b/cli/trigger_check.go
@@ -108,11 +108,6 @@ func triggerCheck(c *cli.Context) error {
 
 	bitriseConfigBase64Data := c.String(ConfigBase64Key)
 	bitriseConfigPath := c.String(ConfigKey)
-	deprecatedBitriseConfigPath := c.String(PathKey)
-	if bitriseConfigPath == "" && deprecatedBitriseConfigPath != "" {
-		warnings = append(warnings, "'path' key is deprecated, use 'config' instead!")
-		bitriseConfigPath = deprecatedBitriseConfigPath
-	}
 
 	inventoryBase64Data := c.String(InventoryBase64Key)
 	inventoryPath := c.String(InventoryKey)

--- a/cli/validate.go
+++ b/cli/validate.go
@@ -193,13 +193,8 @@ func validateInventory(inventoryPath string, inventoryBase64Data string) (*Valid
 	return nil, nil
 }
 
-func runValidate(bitriseConfigPath string, deprecatedBitriseConfigPath string, bitriseConfigBase64Data string, inventoryPath string, inventoryBase64Data string) (*ValidationModel, []string, error) {
+func runValidate(bitriseConfigPath string, bitriseConfigBase64Data string, inventoryPath string, inventoryBase64Data string) (*ValidationModel, []string, error) {
 	warnings := []string{}
-
-	if bitriseConfigPath == "" && deprecatedBitriseConfigPath != "" {
-		warnings = append(warnings, "'path' key is deprecated, use 'config' instead!")
-		bitriseConfigPath = deprecatedBitriseConfigPath
-	}
 
 	validation := ValidationModel{}
 
@@ -226,7 +221,6 @@ func validate(c *cli.Context) error {
 	// Expand cli.Context
 	bitriseConfigBase64Data := c.String(ConfigBase64Key)
 	bitriseConfigPath := c.String(ConfigKey)
-	deprecatedBitriseConfigPath := c.String(PathKey)
 
 	inventoryBase64Data := c.String(InventoryBase64Key)
 	inventoryPath := c.String(InventoryKey)
@@ -247,7 +241,7 @@ func validate(c *cli.Context) error {
 		os.Exit(1)
 	}
 
-	validation, warnings, err := runValidate(bitriseConfigPath, deprecatedBitriseConfigPath, bitriseConfigBase64Data, inventoryPath, inventoryBase64Data)
+	validation, warnings, err := runValidate(bitriseConfigPath, bitriseConfigBase64Data, inventoryPath, inventoryBase64Data)
 	if err != nil {
 		log.Print(NewValidationError(err.Error(), warnings...))
 		os.Exit(1)

--- a/cli/workflow_list.go
+++ b/cli/workflow_list.go
@@ -24,7 +24,6 @@ var workflowListCommand = cli.Command{
 		return nil
 	},
 	Flags: []cli.Flag{
-		flPath,
 		flConfig,
 		flConfigBase64,
 		cli.StringFlag{


### PR DESCRIPTION
<!--
  Thanks for contributing to the Bitrise CLI!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [ ] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-io/bitrise/blob/master/.github/CONTRIBUTING.md)
- [ ] `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *MAJOR/MINOR/PATCH* [version update](https://semver.org/)

### Context

According to git blame, this has been deprecated 8 years ago 😵‍💫 

### Changes

Clean up the `--path` flag from the various subcommands.

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->