### PR TITLE
Read and parse agent config

### DIFF
--- a/configs/agent_config.go
+++ b/configs/agent_config.go
@@ -3,10 +3,15 @@ package configs
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/bitrise-io/go-utils/pathutil"
 	"gopkg.in/yaml.v2"
 )
+
+const defaultSourceDir = "workspace"
+const defaultDeployDir = "$BITRISE_APP_SLUG/$BITRISE_BUILD_SLUG/artifacts"
+const defaultTestDeployDir = "$BITRISE_APP_SLUG/$BITRISE_BUILD_SLUG/test_results"
 
 type AgentConfig struct {
 	BitriseDirs BitriseDirs `yaml:"bitrise_dirs"`
@@ -14,8 +19,19 @@ type AgentConfig struct {
 }
 
 type BitriseDirs struct {
-	SourceDir     string `yaml:"BITRISE_SOURCE_DIR"`
-	DeployDir     string `yaml:"BITRISE_DEPLOY_DIR"`
+	// BitriseDataHomeDir is the root directory for all Bitrise data produced at runtime
+	BitriseDataHomeDir string `yaml:"BITRISE_DATA_HOME_DIR"`
+
+	// SourceDir is for source code checkouts.
+	// It might be outside of BitriseDataHomeDir if the user has configured it so
+	SourceDir string `yaml:"BITRISE_SOURCE_DIR"`
+
+	// DeployDir is for deployable artifacts.
+	// It might be outside of BitriseDataHomeDir if the user has configured it so
+	DeployDir string `yaml:"BITRISE_DEPLOY_DIR"`
+
+	// TestDeployDir is for deployable test result artifacts.
+	// It might be outside of BitriseDataHomeDir if the user has configured it so
 	TestDeployDir string `yaml:"BITRISE_TEST_DEPLOY_DIR"`
 }
 
@@ -30,7 +46,10 @@ type AgentHooks struct {
 	// Bitrise dirs defined in this config file are correctly expanded.
 	CleanupOnWorkflowEnd []string `yaml:"cleanup_on_workflow_end"`
 
+	// DoOnWorkflowStart is an optional executable to run when the workflow starts.
 	DoOnWorkflowStart string `yaml:"do_on_workflow_start"`
+
+	// DoOnWorkflowEnd is an optional executable to run when the workflow ends.
 	DoOnWorkflowEnd   string `yaml:"do_on_workflow_end"`
 }
 
@@ -46,49 +65,72 @@ func readAgentConfig(configFile string) (AgentConfig, error) {
 		return AgentConfig{}, err
 	}
 
+	expandedBitriseDataHomeDir, err := expandPath(config.BitriseDirs.BitriseDataHomeDir)
+	if err != nil {
+		return AgentConfig{}, fmt.Errorf("expand BITRISE_DATA_HOME_DIR value: %s", err)
+	}
+	config.BitriseDirs.BitriseDataHomeDir = expandedBitriseDataHomeDir
+
+	// BITRISE_SOURCE_DIR
+	if config.BitriseDirs.SourceDir == "" {
+		config.BitriseDirs.SourceDir = filepath.Join(config.BitriseDirs.BitriseDataHomeDir, defaultSourceDir)
+	}
 	expandedSourceDir, err := expandPath(config.BitriseDirs.SourceDir)
 	if err != nil {
 		return AgentConfig{}, fmt.Errorf("expand BITRISE_SOURCE_DIR value: %s", err)
 	}
 	config.BitriseDirs.SourceDir = expandedSourceDir
 
+	// BITRISE_DEPLOY_DIR
+	if config.BitriseDirs.DeployDir == "" {
+		config.BitriseDirs.DeployDir = filepath.Join(config.BitriseDirs.BitriseDataHomeDir, defaultDeployDir)
+	}
 	expandedDeployDir, err := expandPath(config.BitriseDirs.DeployDir)
 	if err != nil {
 		return AgentConfig{}, fmt.Errorf("expand BITRISE_DEPLOY_DIR value: %s", err)
 	}
 	config.BitriseDirs.DeployDir = expandedDeployDir
 
+	// BITRISE_TEST_DEPLOY_DIR
+	if config.BitriseDirs.TestDeployDir == "" {
+		config.BitriseDirs.TestDeployDir = filepath.Join(config.BitriseDirs.BitriseDataHomeDir, defaultTestDeployDir)
+	}
 	expandedTestDeployDir, err := expandPath(config.BitriseDirs.TestDeployDir)
 	if err != nil {
 		return AgentConfig{}, fmt.Errorf("expand BITRISE_TEST_DEPLOY_DIR value: %s", err)
 	}
 	config.BitriseDirs.TestDeployDir = expandedTestDeployDir
 
-	expandedDoOnWorkflowStart, err := expandPath(config.Hooks.DoOnWorkflowStart)
-	if err != nil {
-		return AgentConfig{}, fmt.Errorf("expand do_on_workflow_start value: %s", err)
+	// Hooks
+	if config.Hooks.DoOnWorkflowStart != "" {
+		expandedDoOnWorkflowStart, err := expandPath(config.Hooks.DoOnWorkflowStart)
+		if err != nil {
+			return AgentConfig{}, fmt.Errorf("expand do_on_workflow_start value: %s", err)
+		}
+		doOnWorkflowStartExists, err := pathutil.IsPathExists(expandedDoOnWorkflowStart)
+		if err != nil {
+			return AgentConfig{}, err
+		}
+		if !doOnWorkflowStartExists {
+			return AgentConfig{}, fmt.Errorf("do_on_workflow_start path does not exist: %s", expandedDoOnWorkflowStart)
+		}
+		config.Hooks.DoOnWorkflowStart = expandedDoOnWorkflowStart
 	}
-	doOnWorkflowStartExists, err := pathutil.IsPathExists(expandedDoOnWorkflowStart)
-	if err != nil {
-		return AgentConfig{}, err
-	}
-	if !doOnWorkflowStartExists {
-		return AgentConfig{}, fmt.Errorf("do_on_workflow_start path does not exist: %s", expandedDoOnWorkflowStart)
-	}
-	config.Hooks.DoOnWorkflowStart = expandedDoOnWorkflowStart
 
-	expandedDoOnWorkflowEnd, err := expandPath(config.Hooks.DoOnWorkflowEnd)
-	if err != nil {
-		return AgentConfig{}, fmt.Errorf("expand do_on_workflow_end value: %s", err)
+	if config.Hooks.DoOnWorkflowEnd != "" {
+		expandedDoOnWorkflowEnd, err := expandPath(config.Hooks.DoOnWorkflowEnd)
+		if err != nil {
+			return AgentConfig{}, fmt.Errorf("expand do_on_workflow_end value: %s", err)
+		}
+		doOnWorkflowEndExists, err := pathutil.IsPathExists(expandedDoOnWorkflowEnd)
+		if err != nil {
+			return AgentConfig{}, err
+		}
+		if !doOnWorkflowEndExists {
+			return AgentConfig{}, fmt.Errorf("do_on_workflow_end path does not exist: %s", expandedDoOnWorkflowEnd)
+		}
+		config.Hooks.DoOnWorkflowEnd = expandedDoOnWorkflowEnd
 	}
-	doOnWorkflowEndExists, err := pathutil.IsPathExists(expandedDoOnWorkflowEnd)
-	if err != nil {
-		return AgentConfig{}, err
-	}
-	if !doOnWorkflowEndExists {
-		return AgentConfig{}, fmt.Errorf("do_on_workflow_end path does not exist: %s", expandedDoOnWorkflowStart)
-	}
-	config.Hooks.DoOnWorkflowEnd = expandedDoOnWorkflowEnd
 
 	return config, nil
 }

--- a/configs/agent_config.go
+++ b/configs/agent_config.go
@@ -8,8 +8,6 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-const agentConfigFileName = "agent-config.yml"
-
 type AgentConfig struct {
 	BitriseDirs BitriseDirs `yaml:"bitrise_dirs"`
 	Hooks       AgentHooks  `yaml:"hooks"`
@@ -70,11 +68,25 @@ func readAgentConfig(configFile string) (AgentConfig, error) {
 	if err != nil {
 		return AgentConfig{}, fmt.Errorf("expand do_on_workflow_start value: %s", err)
 	}
+	doOnWorkflowStartExists, err := pathutil.IsPathExists(expandedDoOnWorkflowStart)
+	if err != nil {
+		return AgentConfig{}, err
+	}
+	if !doOnWorkflowStartExists {
+		return AgentConfig{}, fmt.Errorf("do_on_workflow_start path does not exist: %s", expandedDoOnWorkflowStart)
+	}
 	config.Hooks.DoOnWorkflowStart = expandedDoOnWorkflowStart
 
 	expandedDoOnWorkflowEnd, err := expandPath(config.Hooks.DoOnWorkflowEnd)
 	if err != nil {
 		return AgentConfig{}, fmt.Errorf("expand do_on_workflow_end value: %s", err)
+	}
+	doOnWorkflowEndExists, err := pathutil.IsPathExists(expandedDoOnWorkflowEnd)
+	if err != nil {
+		return AgentConfig{}, err
+	}
+	if !doOnWorkflowEndExists {
+		return AgentConfig{}, fmt.Errorf("do_on_workflow_end path does not exist: %s", expandedDoOnWorkflowStart)
 	}
 	config.Hooks.DoOnWorkflowEnd = expandedDoOnWorkflowEnd
 

--- a/configs/agent_config.go
+++ b/configs/agent_config.go
@@ -5,7 +5,7 @@ import (
 	"os"
 
 	"github.com/bitrise-io/go-utils/pathutil"
-	yaml "gopkg.in/yaml.v1"
+	"gopkg.in/yaml.v2"
 )
 
 const agentConfigFileName = "agent-config.yml"

--- a/configs/agent_config.go
+++ b/configs/agent_config.go
@@ -5,7 +5,7 @@ import (
 	"os"
 
 	"github.com/bitrise-io/go-utils/pathutil"
-	"gopkg.in/yaml.v1"
+	yaml "gopkg.in/yaml.v1"
 )
 
 const agentConfigFileName = "agent-config.yml"

--- a/configs/agent_config.go
+++ b/configs/agent_config.go
@@ -1,0 +1,86 @@
+package configs
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/bitrise-io/go-utils/pathutil"
+	"gopkg.in/yaml.v1"
+)
+
+const agentConfigFileName = "agent-config.yml"
+
+type AgentConfig struct {
+	BitriseDirs BitriseDirs `yaml:"bitrise_dirs"`
+	Hooks       AgentHooks  `yaml:"hooks"`
+}
+
+type BitriseDirs struct {
+	SourceDir     string `yaml:"BITRISE_SOURCE_DIR"`
+	DeployDir     string `yaml:"BITRISE_DEPLOY_DIR"`
+	TestDeployDir string `yaml:"BITRISE_TEST_DEPLOY_DIR"`
+}
+
+type AgentHooks struct {
+	// CleanupOnWorkflowStart is the list of UNEXPANDED paths to clean up when the workflow starts.
+	// The actual string value should be expanded at execution time, so that
+	// Bitrise dirs defined in this config file are correctly expanded.
+	CleanupOnWorkflowStart []string `yaml:"cleanup_on_workflow_start"`
+
+	// CleanupOnWorkflowEnd is the list of UNEXPANDED paths to clean up when the workflow end.
+	// The actual string value should be expanded at execution time, so that
+	// Bitrise dirs defined in this config file are correctly expanded.
+	CleanupOnWorkflowEnd []string `yaml:"cleanup_on_workflow_end"`
+
+	DoOnWorkflowStart string `yaml:"do_on_workflow_start"`
+	DoOnWorkflowEnd   string `yaml:"do_on_workflow_end"`
+}
+
+func readAgentConfig(configFile string) (AgentConfig, error) {
+	fileContent, err := os.ReadFile(configFile)
+	if err != nil {
+		return AgentConfig{}, err
+	}
+
+	var config AgentConfig
+	err = yaml.Unmarshal(fileContent, &config)
+	if err != nil {
+		return AgentConfig{}, err
+	}
+
+	expandedSourceDir, err := expandPath(config.BitriseDirs.SourceDir)
+	if err != nil {
+		return AgentConfig{}, fmt.Errorf("expand BITRISE_SOURCE_DIR value: %s", err)
+	}
+	config.BitriseDirs.SourceDir = expandedSourceDir
+
+	expandedDeployDir, err := expandPath(config.BitriseDirs.DeployDir)
+	if err != nil {
+		return AgentConfig{}, fmt.Errorf("expand BITRISE_DEPLOY_DIR value: %s", err)
+	}
+	config.BitriseDirs.DeployDir = expandedDeployDir
+
+	expandedTestDeployDir, err := expandPath(config.BitriseDirs.TestDeployDir)
+	if err != nil {
+		return AgentConfig{}, fmt.Errorf("expand BITRISE_TEST_DEPLOY_DIR value: %s", err)
+	}
+	config.BitriseDirs.TestDeployDir = expandedTestDeployDir
+
+	expandedDoOnWorkflowStart, err := expandPath(config.Hooks.DoOnWorkflowStart)
+	if err != nil {
+		return AgentConfig{}, fmt.Errorf("expand do_on_workflow_start value: %s", err)
+	}
+	config.Hooks.DoOnWorkflowStart = expandedDoOnWorkflowStart
+
+	expandedDoOnWorkflowEnd, err := expandPath(config.Hooks.DoOnWorkflowEnd)
+	if err != nil {
+		return AgentConfig{}, fmt.Errorf("expand do_on_workflow_end value: %s", err)
+	}
+	config.Hooks.DoOnWorkflowEnd = expandedDoOnWorkflowEnd
+
+	return config, nil
+}
+
+func expandPath(path string) (string, error) {
+	return pathutil.ExpandTilde(os.ExpandEnv(path))
+}

--- a/configs/agent_config_test.go
+++ b/configs/agent_config_test.go
@@ -3,7 +3,6 @@ package configs
 import (
 	"io/ioutil"
 	"path/filepath"
-	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -18,40 +17,55 @@ func TestReadAgentConfig(t *testing.T) {
 	require.NoError(t, err)
 
 	testCases := []struct {
-		name          string
+		name           string
 		configFile     string
 		expectedConfig AgentConfig
-		expectedErr   bool
+		expectedErr    bool
 	}{
 		{
-			name:        "Valid config file",
-			configFile:   "testdata/valid-agent-config.yml",
+			name:       "Full config file",
+			configFile: "testdata/full-agent-config.yml",
 			expectedConfig: AgentConfig{
-				BitriseDirs {
-					SourceDir:     "/opt/bitrise/workspace/ef7a9665e8b6408b",
-					DeployDir:     "/opt/bitrise/ef7a9665e8b6408b/80b66786-d011-430f-9c68-00e9416a7325/artifacts",
-					TestDeployDir: "/opt/bitrise/ef7a9665e8b6408b/80b66786-d011-430f-9c68-00e9416a7325/test_results",
+				BitriseDirs{
+					BitriseDataHomeDir: "/opt/bitrise",
+					SourceDir:          "/opt/bitrise/workspace/ef7a9665e8b6408b",
+					DeployDir:          "/opt/bitrise/ef7a9665e8b6408b/80b66786-d011-430f-9c68-00e9416a7325/artifacts",
+					TestDeployDir:      "/opt/bitrise/ef7a9665e8b6408b/80b66786-d011-430f-9c68-00e9416a7325/test_results",
 				},
-				AgentHooks {
-					CleanupOnWorkflowStart: []string { "$BITRISE_DEPLOY_DIR" },
-					CleanupOnWorkflowEnd: []string { "$BITRISE_TEST_DEPLOY_DIR" },
-					DoOnWorkflowStart: filepath.Join(tempDir, "cleanup.sh"),
-					DoOnWorkflowEnd: filepath.Join(tempDir, "cleanup.sh"),
+				AgentHooks{
+					CleanupOnWorkflowStart: []string{"$BITRISE_DEPLOY_DIR"},
+					CleanupOnWorkflowEnd:   []string{"$BITRISE_TEST_DEPLOY_DIR"},
+					DoOnWorkflowStart:      filepath.Join(tempDir, "cleanup.sh"),
+					DoOnWorkflowEnd:        filepath.Join(tempDir, "cleanup.sh"),
 				},
 			},
 			expectedErr: false,
 		},
 		{
-			name:        "Non-existent config file",
-			configFile:   "nonexistent",
-			expectedConfig: AgentConfig{},
-			expectedErr:   true,
+			name:       "Minimal config file",
+			configFile: "testdata/minimal-agent-config.yml",
+			expectedConfig: AgentConfig{
+				BitriseDirs{
+					BitriseDataHomeDir: "/opt/bitrise",
+					SourceDir:          "/opt/bitrise/workspace",
+					DeployDir:          "/opt/bitrise/ef7a9665e8b6408b/80b66786-d011-430f-9c68-00e9416a7325/artifacts",
+					TestDeployDir:      "/opt/bitrise/ef7a9665e8b6408b/80b66786-d011-430f-9c68-00e9416a7325/test_results",
+				},
+				AgentHooks{},
+			},
+			expectedErr: false,
 		},
 		{
-			name:        "Config file with invalid YAML",
-			configFile:   "testdata",
+			name:           "Non-existent config file",
+			configFile:     "nonexistent",
 			expectedConfig: AgentConfig{},
-			expectedErr:   true,
+			expectedErr:    true,
+		},
+		{
+			name:           "Config file with invalid YAML",
+			configFile:     "testdata",
+			expectedConfig: AgentConfig{},
+			expectedErr:    true,
 		},
 	}
 
@@ -61,9 +75,10 @@ func TestReadAgentConfig(t *testing.T) {
 			if (err != nil) != tc.expectedErr {
 				t.Errorf("Unexpected error: %v", err)
 			}
-			if !reflect.DeepEqual(config, tc.expectedConfig) {
-				t.Errorf("Expected config: %v, but got: %v", tc.expectedConfig, config)
-			}
+			// if !reflect.DeepEqual(config, tc.expectedConfig) {
+			// 	t.Errorf("Expected config: %+v, but got: %+v", tc.expectedConfig, config)
+			// }
+			require.Equal(t, tc.expectedConfig, config)
 		})
 	}
 }

--- a/configs/agent_config_test.go
+++ b/configs/agent_config_test.go
@@ -1,0 +1,61 @@
+package configs
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestReadAgentConfig(t *testing.T) {
+	t.Setenv("BITRISE_APP_SLUG", "ef7a9665e8b6408b")
+	t.Setenv("BITRISE_BUILD_SLUG", "80b66786-d011-430f-9c68-00e9416a7325")
+	t.Setenv("HOME", "/Users/bitrise")
+	testCases := []struct {
+		name          string
+		configFile     string
+		expectedConfig AgentConfig
+		expectedErr   bool
+	}{
+		{
+			name:        "Valid config file",
+			configFile:   "testdata/valid-agent-config.yml",
+			expectedConfig: AgentConfig{
+				BitriseDirs {
+					SourceDir:     "/opt/bitrise/workspace/ef7a9665e8b6408b",
+					DeployDir:     "/opt/bitrise/ef7a9665e8b6408b/80b66786-d011-430f-9c68-00e9416a7325/artifacts",
+					TestDeployDir: "/opt/bitrise/ef7a9665e8b6408b/80b66786-d011-430f-9c68-00e9416a7325/test_results",
+				},
+				AgentHooks {
+					CleanupOnWorkflowStart: []string { "$BITRISE_DEPLOY_DIR" },
+					CleanupOnWorkflowEnd: []string { "$BITRISE_TEST_DEPLOY_DIR" },
+					DoOnWorkflowStart: "/Users/bitrise/hooks/pre-build.sh",
+					DoOnWorkflowEnd: "/Users/bitrise/hooks/post-build.sh",
+				},
+			},
+			expectedErr: false,
+		},
+		{
+			name:        "Non-existent config file",
+			configFile:   "nonexistent",
+			expectedConfig: AgentConfig{},
+			expectedErr:   true,
+		},
+		{
+			name:        "Config file with invalid YAML",
+			configFile:   "testdata",
+			expectedConfig: AgentConfig{},
+			expectedErr:   true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			config, err := readAgentConfig(tc.configFile)
+			if (err != nil) != tc.expectedErr {
+				t.Errorf("Unexpected error: %v", err)
+			}
+			if !reflect.DeepEqual(config, tc.expectedConfig) {
+				t.Errorf("Expected config: %v, but got: %v", tc.expectedConfig, config)
+			}
+		})
+	}
+}

--- a/configs/agent_config_test.go
+++ b/configs/agent_config_test.go
@@ -75,9 +75,6 @@ func TestReadAgentConfig(t *testing.T) {
 			if (err != nil) != tc.expectedErr {
 				t.Errorf("Unexpected error: %v", err)
 			}
-			// if !reflect.DeepEqual(config, tc.expectedConfig) {
-			// 	t.Errorf("Expected config: %+v, but got: %+v", tc.expectedConfig, config)
-			// }
 			require.Equal(t, tc.expectedConfig, config)
 		})
 	}

--- a/configs/agent_config_test.go
+++ b/configs/agent_config_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestReadAgentConfig(t *testing.T) {
@@ -12,7 +14,8 @@ func TestReadAgentConfig(t *testing.T) {
 	t.Setenv("BITRISE_BUILD_SLUG", "80b66786-d011-430f-9c68-00e9416a7325")
 	tempDir := t.TempDir()
 	t.Setenv("HOOKS_DIR", tempDir)
-	ioutil.WriteFile(filepath.Join(tempDir, "cleanup.sh"), []byte("echo cleanup.sh"), 0644)
+	err := ioutil.WriteFile(filepath.Join(tempDir, "cleanup.sh"), []byte("echo cleanup.sh"), 0644)
+	require.NoError(t, err)
 
 	testCases := []struct {
 		name          string

--- a/configs/agent_config_test.go
+++ b/configs/agent_config_test.go
@@ -1,6 +1,8 @@
 package configs
 
 import (
+	"io/ioutil"
+	"path/filepath"
 	"reflect"
 	"testing"
 )
@@ -8,7 +10,10 @@ import (
 func TestReadAgentConfig(t *testing.T) {
 	t.Setenv("BITRISE_APP_SLUG", "ef7a9665e8b6408b")
 	t.Setenv("BITRISE_BUILD_SLUG", "80b66786-d011-430f-9c68-00e9416a7325")
-	t.Setenv("HOME", "/Users/bitrise")
+	tempDir := t.TempDir()
+	t.Setenv("HOOKS_DIR", tempDir)
+	ioutil.WriteFile(filepath.Join(tempDir, "cleanup.sh"), []byte("echo cleanup.sh"), 0644)
+
 	testCases := []struct {
 		name          string
 		configFile     string
@@ -27,8 +32,8 @@ func TestReadAgentConfig(t *testing.T) {
 				AgentHooks {
 					CleanupOnWorkflowStart: []string { "$BITRISE_DEPLOY_DIR" },
 					CleanupOnWorkflowEnd: []string { "$BITRISE_TEST_DEPLOY_DIR" },
-					DoOnWorkflowStart: "/Users/bitrise/hooks/pre-build.sh",
-					DoOnWorkflowEnd: "/Users/bitrise/hooks/post-build.sh",
+					DoOnWorkflowStart: filepath.Join(tempDir, "cleanup.sh"),
+					DoOnWorkflowEnd: filepath.Join(tempDir, "cleanup.sh"),
 				},
 			},
 			expectedErr: false,

--- a/configs/testdata/full-agent-config.yml
+++ b/configs/testdata/full-agent-config.yml
@@ -1,4 +1,5 @@
 bitrise_dirs:
+  BITRISE_DATA_HOME_DIR: /opt/bitrise
   BITRISE_SOURCE_DIR: /opt/bitrise/workspace/$BITRISE_APP_SLUG
   BITRISE_DEPLOY_DIR: /opt/bitrise/$BITRISE_APP_SLUG/$BITRISE_BUILD_SLUG/artifacts
   BITRISE_TEST_DEPLOY_DIR: /opt/bitrise/$BITRISE_APP_SLUG/$BITRISE_BUILD_SLUG/test_results

--- a/configs/testdata/minimal-agent-config.yml
+++ b/configs/testdata/minimal-agent-config.yml
@@ -1,0 +1,2 @@
+bitrise_dirs:
+  BITRISE_DATA_HOME_DIR: /opt/bitrise

--- a/configs/testdata/valid-agent-config.yml
+++ b/configs/testdata/valid-agent-config.yml
@@ -10,5 +10,5 @@ hooks:
   cleanup_on_workflow_end:
   - $BITRISE_TEST_DEPLOY_DIR
 
-  do_on_workflow_start: ~/hooks/pre-build.sh
-  do_on_workflow_end: ~/hooks/post-build.sh
+  do_on_workflow_start: $HOOKS_DIR/cleanup.sh
+  do_on_workflow_end: $HOOKS_DIR/cleanup.sh

--- a/configs/testdata/valid-agent-config.yml
+++ b/configs/testdata/valid-agent-config.yml
@@ -5,10 +5,10 @@ bitrise_dirs:
 
 hooks:
   cleanup_on_workflow_start:
-    - $BITRISE_DEPLOY_DIR
-  
+  - $BITRISE_DEPLOY_DIR
+
   cleanup_on_workflow_end:
-    - $BITRISE_TEST_DEPLOY_DIR
-  
+  - $BITRISE_TEST_DEPLOY_DIR
+
   do_on_workflow_start: ~/hooks/pre-build.sh
   do_on_workflow_end: ~/hooks/post-build.sh

--- a/configs/testdata/valid-agent-config.yml
+++ b/configs/testdata/valid-agent-config.yml
@@ -1,0 +1,14 @@
+bitrise_dirs:
+  BITRISE_SOURCE_DIR: /opt/bitrise/workspace/$BITRISE_APP_SLUG
+  BITRISE_DEPLOY_DIR: /opt/bitrise/$BITRISE_APP_SLUG/$BITRISE_BUILD_SLUG/artifacts
+  BITRISE_TEST_DEPLOY_DIR: /opt/bitrise/$BITRISE_APP_SLUG/$BITRISE_BUILD_SLUG/test_results
+
+hooks:
+  cleanup_on_workflow_start:
+    - $BITRISE_DEPLOY_DIR
+  
+  cleanup_on_workflow_end:
+    - $BITRISE_TEST_DEPLOY_DIR
+  
+  do_on_workflow_start: ~/hooks/pre-build.sh
+  do_on_workflow_end: ~/hooks/post-build.sh


### PR DESCRIPTION
<!--
  Thanks for contributing to the Bitrise CLI!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [ ] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-io/bitrise/blob/master/.github/CONTRIBUTING.md)
- [ ] `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *MINOR* [version update](https://semver.org/)

### Context

First PR of a series of changes preparing Bitrise CLI for agent-like persistent behavior. The initial features are:
- override special Bitrise directories for all builds served by the CLI on a given host
- provide hooks for cleaning up Bitrise directories at the start/end of the build

### Changes

- Define the new agent config file
- Read and parse this new file, including env var expansion and shell tilde expansion where it makes sense

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

The config field names are not final, we might rename them later.