### PR TITLE
Agent hooks

### DIFF
--- a/_tests/integration/agent-config.yml
+++ b/_tests/integration/agent-config.yml
@@ -10,3 +10,6 @@ hooks:
 
   cleanup_on_workflow_end:
   - $BITRISE_TEST_DEPLOY_DIR
+
+  do_on_build_start: agent_hook_build_start.sh
+  do_on_build_end: agent_hook_build_end.sh

--- a/_tests/integration/agent_config_test.go
+++ b/_tests/integration/agent_config_test.go
@@ -1,10 +1,12 @@
 package integration
 
 import (
+	"log"
 	"os"
 	"path/filepath"
 	"testing"
 
+	"github.com/bitrise-io/bitrise/analytics"
 	"github.com/bitrise-io/go-utils/command"
 	"github.com/bitrise-io/go-utils/pathutil"
 	"github.com/stretchr/testify/require"
@@ -65,6 +67,10 @@ func setupAgentConfig(t *testing.T) func() {
 
 	t.Setenv("BITRISE_APP_SLUG", "ef7a9665e8b6408b")
 	t.Setenv("BITRISE_BUILD_SLUG", "80b66786-d011-430f-9c68-00e9416a7325")
+
+	// Clear the execution ID env var as we are already running inside a Bitrise CLI execution.
+	// This would confuse the logic that prevents running agent hooks in nested executions.
+	t.Setenv(analytics.StepExecutionIDEnvKey, "")
 
 	return cleanupFn
 }

--- a/_tests/integration/agent_config_test.go
+++ b/_tests/integration/agent_config_test.go
@@ -9,23 +9,37 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func Test_AgentConfigTest(t *testing.T) {
+func Test_AgentConfigBitriseDirs(t *testing.T) {
+	cleanupFn := setupAgentConfig(t)
+	defer cleanupFn()
+
+	cmd := command.New(binPath(), "run", "test_bitrise_dirs", "--config", "agent_config_test_bitrise.yml")
+	out, err := cmd.RunAndReturnTrimmedCombinedOutput()
+	require.NoError(t, err, out)
+}
+
+func Test_AgentConfigBuildHooks(t *testing.T) {
+	cleanupFn := setupAgentConfig(t)
+	defer cleanupFn()
+
+	cmd := command.New(binPath(), "run", "test_build_hooks", "--config", "agent_config_test_bitrise.yml")
+	out, err := cmd.RunAndReturnTrimmedCombinedOutput()
+	require.NoError(t, err, out)
+}
+
+func setupAgentConfig(t *testing.T) func() {
 	cfg, err := os.ReadFile("agent-config.yml")
 	require.NoError(t, err)
-	
+
 	absPath, err := pathutil.AbsPath("$HOME/.bitrise/agent-config.yml")
 	require.NoError(t, err)
 
 	err = os.WriteFile(absPath, cfg, 0644)
 	require.NoError(t, err)
-	defer func ()  {
-		os.Remove(absPath)
-	}()
+	cleanupFn := func() { os.Remove(absPath) }
 
 	t.Setenv("BITRISE_APP_SLUG", "ef7a9665e8b6408b")
 	t.Setenv("BITRISE_BUILD_SLUG", "80b66786-d011-430f-9c68-00e9416a7325")
 
-	cmd := command.New(binPath(), "run", "test", "--config", "agent_config_test_bitrise.yml")
-	out, err := cmd.RunAndReturnTrimmedCombinedOutput()
-	require.NoError(t, err, out)
+	return cleanupFn
 }

--- a/_tests/integration/agent_config_test.go
+++ b/_tests/integration/agent_config_test.go
@@ -2,6 +2,7 @@ package integration
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/bitrise-io/go-utils/command"
@@ -18,13 +19,37 @@ func Test_AgentConfigBitriseDirs(t *testing.T) {
 	require.NoError(t, err, out)
 }
 
-func Test_AgentConfigBuildHooks(t *testing.T) {
+func Test_AgentConfigBuildHooksSuccess(t *testing.T) {
 	cleanupFn := setupAgentConfig(t)
 	defer cleanupFn()
 
-	cmd := command.New(binPath(), "run", "test_build_hooks", "--config", "agent_config_test_bitrise.yml")
+	cmd := command.New(binPath(), "run", "test_build_hooks_success", "--config", "agent_config_test_bitrise.yml")
 	out, err := cmd.RunAndReturnTrimmedCombinedOutput()
 	require.NoError(t, err, out)
+
+	hookDataDir := filepath.Join(binPath(), "..", "hooks")
+
+	_, err = os.Stat(filepath.Join(hookDataDir, "build_start"))
+	require.NoError(t, err)
+
+	_, err = os.Stat(filepath.Join(hookDataDir, "build_end"))
+	require.NoError(t, err)
+}
+
+func Test_AgentConfigBuildHooksFailure(t *testing.T) {
+	cleanupFn := setupAgentConfig(t)
+	defer cleanupFn()
+
+	cmd := command.New(binPath(), "run", "test_build_hooks_failure", "--config", "agent_config_test_bitrise.yml")
+	_, _ = cmd.RunAndReturnTrimmedCombinedOutput()
+
+	hookDataDir := filepath.Join(binPath(), "..", "hooks")
+
+	_, err := os.Stat(filepath.Join(hookDataDir, "build_start"))
+	require.NoError(t, err)
+
+	_, err = os.Stat(filepath.Join(hookDataDir, "build_end"))
+	require.NoError(t, err)
 }
 
 func setupAgentConfig(t *testing.T) func() {

--- a/_tests/integration/agent_config_test.go
+++ b/_tests/integration/agent_config_test.go
@@ -1,7 +1,6 @@
 package integration
 
 import (
-	"log"
 	"os"
 	"path/filepath"
 	"testing"

--- a/_tests/integration/agent_config_test_bitrise.yml
+++ b/_tests/integration/agent_config_test_bitrise.yml
@@ -2,7 +2,7 @@ format_version: 13
 default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
 
 workflows:
-  test:
+  test_bitrise_dirs:
     steps:
     - script:
         inputs:
@@ -35,3 +35,20 @@ workflows:
             fi
 
             ls $BITRISE_TEST_DEPLOY_DIR
+  test_build_hooks:
+    steps:
+    - script:
+        inputs:
+        - content: |-
+            set -ex
+            HOOK_DIR=$(dirname "$INTEGRATION_TEST_BINARY_PATH")/hooks
+
+            if [[ ! -f $HOOK_DIR/build_start ]]; then
+              echo "$HOOK_DIR/build_start does not exist"
+              exit 1
+            fi
+
+            if [[ ! -f $HOOK_DIR/build_end ]]; then
+              echo "$HOOK_DIR/build_end does not exist"
+              exit 1
+            fi

--- a/_tests/integration/agent_config_test_bitrise.yml
+++ b/_tests/integration/agent_config_test_bitrise.yml
@@ -35,20 +35,19 @@ workflows:
             fi
 
             ls $BITRISE_TEST_DEPLOY_DIR
-  test_build_hooks:
+  test_build_hooks_success:
     steps:
     - script:
         inputs:
         - content: |-
             set -ex
-            HOOK_DIR=$(dirname "$INTEGRATION_TEST_BINARY_PATH")/hooks
-
-            if [[ ! -f $HOOK_DIR/build_start ]]; then
-              echo "$HOOK_DIR/build_start does not exist"
-              exit 1
-            fi
-
-            if [[ ! -f $HOOK_DIR/build_end ]]; then
-              echo "$HOOK_DIR/build_end does not exist"
-              exit 1
-            fi
+            echo "Let's see what happens after a successful workflow"
+            exit 0
+  test_build_hooks_failure:
+    steps:
+    - script:
+        inputs:
+        - content: |-
+            set -ex
+            echo "Let's see what happens after a failed workflow"
+            exit 42

--- a/_tests/integration/agent_hook_build_end.sh
+++ b/_tests/integration/agent_hook_build_end.sh
@@ -1,0 +1,6 @@
+#! /bin/bash
+
+HOOK_DIR=$(dirname "$INTEGRATION_TEST_BINARY_PATH")/hooks
+mkdir -p "$HOOK_DIR"
+
+touch "$HOOK_DIR"/build_end

--- a/_tests/integration/agent_hook_build_start.sh
+++ b/_tests/integration/agent_hook_build_start.sh
@@ -1,0 +1,6 @@
+#! /bin/bash
+
+HOOK_DIR=$(dirname "$INTEGRATION_TEST_BINARY_PATH")/hooks
+mkdir -p "$HOOK_DIR"
+
+touch "$HOOK_DIR"/build_start

--- a/analytics/tracker.go
+++ b/analytics/tracker.go
@@ -66,7 +66,6 @@ const (
 
 	buildSlugEnvKey = "BITRISE_BUILD_SLUG"
 	appSlugEnvKey   = "BITRISE_APP_SLUG"
-	// StepExecutionIDEnvKey ...
 	StepExecutionIDEnvKey = "BITRISE_STEP_EXECUTION_ID"
 
 	bitriseVersionKey = "bitrise"

--- a/cli/agent.go
+++ b/cli/agent.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 
+	"github.com/bitrise-io/bitrise/analytics"
 	"github.com/bitrise-io/bitrise/configs"
 	"github.com/bitrise-io/bitrise/log"
 	"github.com/bitrise-io/go-utils/pathutil"
@@ -51,6 +52,12 @@ func runBuildStartHooks(hooks configs.AgentHooks) error {
 		return nil
 	}
 
+	if os.Getenv(analytics.StepExecutionIDEnvKey) != "" {
+		// Edge case: this Bitrise process was started by a script step running `bitrise run x`.
+		// In that case, we don't want to run the hooks because they would be executed twice.
+		return nil
+	}
+
 	log.Print()
 	log.Infof("Run build start hook")
 	log.Print(hooks.DoOnBuildStart)
@@ -64,6 +71,12 @@ func runBuildStartHooks(hooks configs.AgentHooks) error {
 
 func runBuildEndHooks(hooks configs.AgentHooks) error {
 	if hooks.DoOnBuildEnd == "" {
+		return nil
+	}
+
+	if os.Getenv(analytics.StepExecutionIDEnvKey) != "" {
+		// Edge case: this Bitrise process was started by a script step running `bitrise run x`.
+		// In that case, we don't want to run the hooks because they would be executed twice.
 		return nil
 	}
 

--- a/cli/agent.go
+++ b/cli/agent.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 
 	"github.com/bitrise-io/bitrise/configs"
+	"github.com/bitrise-io/bitrise/log"
 	"github.com/bitrise-io/go-utils/pathutil"
 )
 
@@ -46,20 +47,33 @@ func registerAgentOverrides(dirs configs.BitriseDirs) error {
 }
 
 func runBuildStartHooks(hooks configs.AgentHooks) error {
-	if hooks.DoOnWorkflowStart == "" {
+	if hooks.DoOnBuildStart == "" {
 		return nil
 	}
 
 	log.Print()
-	log.Info("Run build start hook")
+	log.Infof("Run build start hook")
+	log.Print(hooks.DoOnBuildStart)
+	log.Print()
 
-	cmd := exec.Command(hooks.DoOnWorkflowStart)
-
-
-
-	return nil
+	cmd := exec.Command(hooks.DoOnBuildStart)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
 }
 
 func runBuildEndHooks(hooks configs.AgentHooks) error {
-	return nil
+	if hooks.DoOnBuildEnd == "" {
+		return nil
+	}
+
+	log.Print()
+	log.Infof("Run build end hook")
+	log.Print(hooks.DoOnBuildEnd)
+	log.Print()
+
+	cmd := exec.Command(hooks.DoOnBuildEnd)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
 }

--- a/cli/agent.go
+++ b/cli/agent.go
@@ -8,6 +8,7 @@ import (
 	"github.com/bitrise-io/bitrise/analytics"
 	"github.com/bitrise-io/bitrise/configs"
 	"github.com/bitrise-io/bitrise/log"
+	"github.com/bitrise-io/bitrise/log/logwriter"
 	"github.com/bitrise-io/go-utils/pathutil"
 )
 
@@ -64,8 +65,10 @@ func runBuildStartHooks(hooks configs.AgentHooks) error {
 	log.Print()
 
 	cmd := exec.Command(hooks.DoOnBuildStart)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
+	logger := log.NewLogger(log.GetGlobalLoggerOpts())
+	logWriter := logwriter.NewLogWriter(logger)
+	cmd.Stdout = logWriter
+	cmd.Stderr = logWriter
 	return cmd.Run()
 }
 
@@ -86,7 +89,9 @@ func runBuildEndHooks(hooks configs.AgentHooks) error {
 	log.Print()
 
 	cmd := exec.Command(hooks.DoOnBuildEnd)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
+	logger := log.NewLogger(log.GetGlobalLoggerOpts())
+	logWriter := logwriter.NewLogWriter(logger)
+	cmd.Stdout = logWriter
+	cmd.Stderr = logWriter
 	return cmd.Run()
 }

--- a/cli/agent.go
+++ b/cli/agent.go
@@ -1,0 +1,65 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+
+	"github.com/bitrise-io/bitrise/configs"
+	"github.com/bitrise-io/go-utils/pathutil"
+)
+
+func registerAgentOverrides(dirs configs.BitriseDirs) error {
+	params := []struct {
+		dir    string
+		envKey string
+	}{
+		{
+			dir:    dirs.BitriseDataHomeDir,
+			envKey: configs.BitriseDataHomeDirEnvKey,
+		},
+		{
+			dir:    dirs.SourceDir,
+			envKey: configs.BitriseSourceDirEnvKey,
+		},
+		{
+			dir:    dirs.DeployDir,
+			envKey: configs.BitriseDeployDirEnvKey,
+		},
+		{
+			dir:    dirs.TestDeployDir,
+			envKey: configs.BitriseTestDeployDirEnvKey,
+		},
+	}
+	for _, param := range params {
+		err := pathutil.EnsureDirExist(param.dir)
+		if err != nil {
+			return fmt.Errorf("can't create %s: %w", param.envKey, err)
+		}
+		err = os.Setenv(param.envKey, param.dir)
+		if err != nil {
+			return fmt.Errorf("set %s: %w", param.envKey, err)
+		}
+	}
+
+	return nil
+}
+
+func runBuildStartHooks(hooks configs.AgentHooks) error {
+	if hooks.DoOnWorkflowStart == "" {
+		return nil
+	}
+
+	log.Print()
+	log.Info("Run build start hook")
+
+	cmd := exec.Command(hooks.DoOnWorkflowStart)
+
+
+
+	return nil
+}
+
+func runBuildEndHooks(hooks configs.AgentHooks) error {
+	return nil
+}

--- a/cli/run.go
+++ b/cli/run.go
@@ -135,6 +135,8 @@ func setupAgentConfig() (*configs.AgentConfig, error) {
 
 type WorkflowRunner struct {
 	config      RunConfig
+	
+	// agentConfig is only non-nil if the CLI is configured to run in agent mode
 	agentConfig *configs.AgentConfig
 }
 

--- a/cli/run.go
+++ b/cli/run.go
@@ -225,10 +225,11 @@ func (r WorkflowRunner) runWorkflows(tracker analytics.Tracker) (models.BuildRun
 	var agentConfig *configs.AgentConfig
 	if configs.HasAgentConfig() {
 		configFile := configs.GetAgentConfigPath()
-		agentConfig, err := configs.ReadAgentConfig(configFile)
+		config, err := configs.ReadAgentConfig(configFile)
 		if err != nil {
 			return models.BuildRunResultsModel{}, fmt.Errorf("agent config file: %w", err)
 		}
+		agentConfig = &config
 
 		log.Print()
 		log.Info("Running in agent mode")
@@ -258,7 +259,6 @@ func (r WorkflowRunner) runWorkflows(tracker analytics.Tracker) (models.BuildRun
 	bitrise.PrintSummary(buildRunResults)
 
 	if agentConfig != nil {
-		log.Warn("hello")
 		if err := runBuildEndHooks(agentConfig.Hooks); err != nil {
 			return models.BuildRunResultsModel{}, fmt.Errorf("build end hooks: %s", err)
 		}

--- a/cli/run.go
+++ b/cli/run.go
@@ -85,7 +85,12 @@ func run(c *cli.Context) error {
 		failf("Failed to process arguments: %s", err)
 	}
 
-	runner := NewWorkflowRunner(*config)
+	agentConfig, err := setupAgentConfig()
+	if err != nil {
+		failf("Failed to process agent config: %w", err)
+	}
+
+	runner := NewWorkflowRunner(*config, agentConfig)
 	exitCode, err := runner.RunWorkflowsWithSetupAndCheckForUpdate()
 	if err != nil {
 		if err == workflowRunFailedErr {
@@ -106,12 +111,38 @@ func run(c *cli.Context) error {
 	return nil
 }
 
-type WorkflowRunner struct {
-	config RunConfig
+func setupAgentConfig() (*configs.AgentConfig, error) {
+	if !configs.HasAgentConfig() {
+		return nil, nil
+	}
+
+	configFile := configs.GetAgentConfigPath()
+	config, err := configs.ReadAgentConfig(configFile)
+	if err != nil {
+		return nil, fmt.Errorf("agent config file: %w", err)
+	}
+
+	log.Print()
+	log.Info("Running in agent mode")
+	log.Printf("Config file: %s", configFile)
+
+	if err := registerAgentOverrides(config.BitriseDirs); err != nil {
+		return nil, fmt.Errorf("apply Bitrise dirs: %s", err)
+	}
+
+	return &config, nil
 }
 
-func NewWorkflowRunner(config RunConfig) WorkflowRunner {
-	return WorkflowRunner{config: config}
+type WorkflowRunner struct {
+	config      RunConfig
+	agentConfig *configs.AgentConfig
+}
+
+func NewWorkflowRunner(config RunConfig, agentConfig *configs.AgentConfig) WorkflowRunner {
+	return WorkflowRunner{
+		config:      config,
+		agentConfig: agentConfig,
+	}
 }
 
 func (r WorkflowRunner) RunWorkflowsWithSetupAndCheckForUpdate() (int, error) {
@@ -132,33 +163,16 @@ func (r WorkflowRunner) RunWorkflowsWithSetupAndCheckForUpdate() (int, error) {
 		return 1, fmt.Errorf("setup failed: %s", err)
 	}
 
-	var agentConfig *configs.AgentConfig
-	if configs.HasAgentConfig() {
-		configFile := configs.GetAgentConfigPath()
-		config, err := configs.ReadAgentConfig(configFile)
-		if err != nil {
-			return 1, fmt.Errorf("agent config file: %w", err)
-		}
-		agentConfig = &config
-
-		log.Print()
-		log.Info("Running in agent mode")
-		log.Printf("Config file: %s", configFile)
-		if err := registerAgentOverrides(agentConfig.BitriseDirs); err != nil {
-			return 1, fmt.Errorf("apply Bitrise dirs: %s", err)
-		}
-
-		if err = runBuildStartHooks(agentConfig.Hooks); err != nil {
+	if r.agentConfig != nil {
+		if err := runBuildStartHooks(r.agentConfig.Hooks); err != nil {
 			return 1, fmt.Errorf("build start hooks: %s", err)
 		}
-	}
-	defer func() {
-		if agentConfig != nil {
-			if err := runBuildEndHooks(agentConfig.Hooks); err != nil {
+		defer func() {
+			if err := runBuildEndHooks(r.agentConfig.Hooks); err != nil {
 				log.Errorf("build end hooks: %s", err)
 			}
-		}
-	}()
+		}()
+	}
 
 	if buildRunResults, err := r.runWorkflows(tracker); err != nil {
 		return 1, fmt.Errorf("failed to run workflow: %s", err)

--- a/cli/run.go
+++ b/cli/run.go
@@ -258,6 +258,7 @@ func (r WorkflowRunner) runWorkflows(tracker analytics.Tracker) (models.BuildRun
 	bitrise.PrintSummary(buildRunResults)
 
 	if agentConfig != nil {
+		log.Warn("hello")
 		if err := runBuildEndHooks(agentConfig.Hooks); err != nil {
 			return models.BuildRunResultsModel{}, fmt.Errorf("build end hooks: %s", err)
 		}

--- a/cli/run_test.go
+++ b/cli/run_test.go
@@ -57,7 +57,7 @@ workflows:
 		require.NoError(t, configs.InitPaths())
 
 		runConfig := RunConfig{Config: config, Workflow: "skip_if_empty"}
-		runner := NewWorkflowRunner(runConfig)
+		runner := NewWorkflowRunner(runConfig, nil)
 		buildRunResults, err := runner.runWorkflows(noOpTracker{})
 		require.NoError(t, err)
 		require.Equal(t, 1, len(buildRunResults.SuccessSteps))
@@ -98,7 +98,7 @@ workflows:
 		require.NoError(t, configs.InitPaths())
 
 		runConfig := RunConfig{Config: config, Workflow: "skip_if_empty"}
-		runner := NewWorkflowRunner(runConfig)
+		runner := NewWorkflowRunner(runConfig, nil)
 		buildRunResults, err := runner.runWorkflows(noOpTracker{})
 		require.NoError(t, err)
 		require.Equal(t, 1, len(buildRunResults.SuccessSteps))
@@ -158,7 +158,7 @@ workflows:
 	require.NoError(t, configs.InitPaths())
 
 	runConfig := RunConfig{Config: config, Workflow: "test"}
-	runner := NewWorkflowRunner(runConfig)
+	runner := NewWorkflowRunner(runConfig, nil)
 	buildRunResults, err := runner.runWorkflows(noOpTracker{})
 	require.NoError(t, err)
 	require.Equal(t, 4, len(buildRunResults.SuccessSteps))
@@ -224,7 +224,7 @@ workflows:
 	require.NoError(t, configs.InitPaths())
 
 	runConfig := RunConfig{Config: config, Workflow: "test", Secrets: inventory.Envs}
-	runner := NewWorkflowRunner(runConfig)
+	runner := NewWorkflowRunner(runConfig, nil)
 	buildRunResults, err := runner.runWorkflows(noOpTracker{})
 	require.NoError(t, err)
 	require.Equal(t, 5, len(buildRunResults.SuccessSteps))
@@ -269,7 +269,7 @@ workflows:
 	require.NoError(t, configs.InitPaths())
 
 	runConfig := RunConfig{Config: config, Workflow: "test"}
-	runner := NewWorkflowRunner(runConfig)
+	runner := NewWorkflowRunner(runConfig, nil)
 	buildRunResults, err := runner.runWorkflows(noOpTracker{})
 	require.NoError(t, err)
 	require.Equal(t, 1, len(buildRunResults.SuccessSteps))
@@ -332,7 +332,7 @@ workflows:
 		require.NoError(t, configs.InitPaths())
 
 		runConfig := RunConfig{Config: config, Workflow: "test", Secrets: inventory.Envs}
-		runner := NewWorkflowRunner(runConfig)
+		runner := NewWorkflowRunner(runConfig, nil)
 		_, err = runner.runWorkflows(noOpTracker{})
 		require.NoError(t, err)
 	}
@@ -375,7 +375,7 @@ workflows:
 		require.NoError(t, configs.InitPaths())
 
 		runConfig := RunConfig{Config: config, Workflow: "test", Secrets: inventory.Envs}
-		runner := NewWorkflowRunner(runConfig)
+		runner := NewWorkflowRunner(runConfig, nil)
 		_, err = runner.runWorkflows(noOpTracker{})
 		require.NoError(t, err)
 	}
@@ -420,7 +420,7 @@ workflows:
 		require.NoError(t, configs.InitPaths())
 
 		runConfig := RunConfig{Config: config, Workflow: "test", Secrets: inventory.Envs}
-		runner := NewWorkflowRunner(runConfig)
+		runner := NewWorkflowRunner(runConfig, nil)
 		_, err = runner.runWorkflows(noOpTracker{})
 		require.NoError(t, err)
 	}
@@ -471,7 +471,7 @@ workflows:
 		require.NoError(t, configs.InitPaths())
 
 		runConfig := RunConfig{Config: config, Workflow: "test", Secrets: inventory.Envs}
-		runner := NewWorkflowRunner(runConfig)
+		runner := NewWorkflowRunner(runConfig, nil)
 		_, err = runner.runWorkflows(noOpTracker{})
 		require.NoError(t, err)
 	}
@@ -513,7 +513,7 @@ workflows:
 		require.NoError(t, configs.InitPaths())
 
 		runConfig := RunConfig{Config: config, Workflow: "test", Secrets: inventory.Envs}
-		runner := NewWorkflowRunner(runConfig)
+		runner := NewWorkflowRunner(runConfig, nil)
 		_, err = runner.runWorkflows(noOpTracker{})
 		require.NoError(t, err)
 	}
@@ -558,7 +558,7 @@ workflows:
 		require.NoError(t, configs.InitPaths())
 
 		runConfig := RunConfig{Config: config, Workflow: "test", Secrets: inventory.Envs}
-		runner := NewWorkflowRunner(runConfig)
+		runner := NewWorkflowRunner(runConfig, nil)
 		_, err = runner.runWorkflows(noOpTracker{})
 		require.NoError(t, err)
 	}
@@ -604,7 +604,7 @@ workflows:
 		require.NoError(t, configs.InitPaths())
 
 		runConfig := RunConfig{Config: config, Workflow: "test", Secrets: inventory.Envs}
-		runner := NewWorkflowRunner(runConfig)
+		runner := NewWorkflowRunner(runConfig, nil)
 		_, err = runner.runWorkflows(noOpTracker{})
 		require.NoError(t, err)
 	}
@@ -653,7 +653,7 @@ workflows:
 		require.NoError(t, configs.InitPaths())
 
 		runConfig := RunConfig{Config: config, Workflow: "test", Secrets: inventory.Envs}
-		runner := NewWorkflowRunner(runConfig)
+		runner := NewWorkflowRunner(runConfig, nil)
 		_, err = runner.runWorkflows(noOpTracker{})
 		require.NoError(t, err)
 	}
@@ -685,7 +685,7 @@ func Test0Steps1Workflows(t *testing.T) {
 	require.NoError(t, configs.InitPaths())
 
 	runConfig := RunConfig{Config: config, Workflow: "zero_steps"}
-	runner := NewWorkflowRunner(runConfig)
+	runner := NewWorkflowRunner(runConfig, nil)
 	buildRunResults, err = runner.runWorkflows(noOpTracker{})
 	require.NoError(t, err)
 	require.Equal(t, 0, len(buildRunResults.SuccessSteps))
@@ -731,7 +731,7 @@ func Test0Steps3WorkflowsBeforeAfter(t *testing.T) {
 	require.NoError(t, configs.InitPaths())
 
 	runConfig := RunConfig{Config: config, Workflow: "target"}
-	runner := NewWorkflowRunner(runConfig)
+	runner := NewWorkflowRunner(runConfig, nil)
 	buildRunResults, err = runner.runWorkflows(noOpTracker{})
 
 	require.NoError(t, err)
@@ -790,7 +790,7 @@ workflows:
 	require.NoError(t, configs.InitPaths())
 
 	runConfig := RunConfig{Config: config, Workflow: "trivial_fail"}
-	runner := NewWorkflowRunner(runConfig)
+	runner := NewWorkflowRunner(runConfig, nil)
 	buildRunResults, err = runner.runWorkflows(noOpTracker{})
 
 	require.NoError(t, err)
@@ -873,7 +873,7 @@ workflows:
 	require.NoError(t, configs.InitPaths())
 
 	runConfig := RunConfig{Config: config, Workflow: "target"}
-	runner := NewWorkflowRunner(runConfig)
+	runner := NewWorkflowRunner(runConfig, nil)
 	buildRunResults, err := runner.runWorkflows(noOpTracker{})
 	require.NoError(t, err)
 	require.Equal(t, 3, len(buildRunResults.SuccessSteps))
@@ -981,7 +981,7 @@ workflows:
 	require.NoError(t, configs.InitPaths())
 
 	runConfig := RunConfig{Config: config, Workflow: "target"}
-	runner := NewWorkflowRunner(runConfig)
+	runner := NewWorkflowRunner(runConfig, nil)
 	buildRunResults, err := runner.runWorkflows(noOpTracker{})
 	require.NoError(t, err)
 	require.Equal(t, 3, len(buildRunResults.SuccessSteps))
@@ -1038,7 +1038,7 @@ workflows:
 	require.NoError(t, configs.InitPaths())
 
 	runConfig := RunConfig{Config: config, Workflow: "target"}
-	runner := NewWorkflowRunner(runConfig)
+	runner := NewWorkflowRunner(runConfig, nil)
 	buildRunResults, err := runner.runWorkflows(noOpTracker{})
 	require.NoError(t, err)
 	require.Equal(t, 3, len(buildRunResults.SuccessSteps))
@@ -1073,7 +1073,7 @@ workflows:
 	require.NoError(t, configs.InitPaths())
 
 	runConfig := RunConfig{Config: config, Workflow: "target"}
-	runner := NewWorkflowRunner(runConfig)
+	runner := NewWorkflowRunner(runConfig, nil)
 	buildRunResults, err := runner.runWorkflows(noOpTracker{})
 	require.NoError(t, err)
 	require.Equal(t, 1, len(buildRunResults.SuccessSteps))
@@ -1131,7 +1131,7 @@ workflows:
 	require.NoError(t, configs.InitPaths())
 
 	runConfig := RunConfig{Config: config, Workflow: "target"}
-	runner := NewWorkflowRunner(runConfig)
+	runner := NewWorkflowRunner(runConfig, nil)
 	buildRunResults, err := runner.runWorkflows(noOpTracker{})
 	require.NoError(t, err)
 	require.Equal(t, 1, len(buildRunResults.SuccessSteps))
@@ -1192,7 +1192,7 @@ workflows:
 	require.NoError(t, configs.InitPaths())
 
 	runConfig := RunConfig{Config: config, Workflow: "target"}
-	runner := NewWorkflowRunner(runConfig)
+	runner := NewWorkflowRunner(runConfig, nil)
 	buildRunResults, err := runner.runWorkflows(noOpTracker{})
 	require.NoError(t, err)
 	require.Equal(t, 2, len(buildRunResults.SuccessSteps))
@@ -1253,7 +1253,7 @@ workflows:
 	require.NoError(t, configs.InitPaths())
 
 	runConfig := RunConfig{Config: config, Workflow: "target"}
-	runner := NewWorkflowRunner(runConfig)
+	runner := NewWorkflowRunner(runConfig, nil)
 	buildRunResults, err := runner.runWorkflows(noOpTracker{})
 	require.NoError(t, err)
 	require.Equal(t, 2, len(buildRunResults.SuccessSteps))
@@ -1302,7 +1302,7 @@ workflows:
 	require.NoError(t, configs.InitPaths())
 
 	runConfig := RunConfig{Config: config, Workflow: "target"}
-	runner := NewWorkflowRunner(runConfig)
+	runner := NewWorkflowRunner(runConfig, nil)
 	buildRunResults, err := runner.runWorkflows(noOpTracker{})
 	require.NoError(t, err)
 	require.Equal(t, 1, len(buildRunResults.SuccessSteps))
@@ -1359,7 +1359,7 @@ workflows:
 	require.NoError(t, configs.InitPaths())
 
 	runConfig := RunConfig{Config: config, Workflow: "target"}
-	runner := NewWorkflowRunner(runConfig)
+	runner := NewWorkflowRunner(runConfig, nil)
 	buildRunResults, err := runner.runWorkflows(noOpTracker{})
 	require.NoError(t, err)
 	require.Equal(t, 2, len(buildRunResults.SuccessSteps))
@@ -1420,7 +1420,7 @@ workflows:
 	require.NoError(t, configs.InitPaths())
 
 	runConfig := RunConfig{Config: config, Workflow: "out-test"}
-	runner := NewWorkflowRunner(runConfig)
+	runner := NewWorkflowRunner(runConfig, nil)
 	buildRunResults, err := runner.runWorkflows(noOpTracker{})
 	require.Equal(t, 0, len(buildRunResults.SkippedSteps))
 	require.Equal(t, 3, len(buildRunResults.SuccessSteps))
@@ -1470,7 +1470,7 @@ workflows:
 	require.NoError(t, configs.InitPaths())
 
 	runConfig := RunConfig{Config: config, Workflow: "test"}
-	runner := NewWorkflowRunner(runConfig)
+	runner := NewWorkflowRunner(runConfig, nil)
 	buildRunResults, err := runner.runWorkflows(noOpTracker{})
 	require.NoError(t, err)
 	require.Equal(t, 2, len(buildRunResults.SuccessSteps))
@@ -1524,7 +1524,7 @@ workflows:
 	require.NoError(t, configs.InitPaths())
 
 	runConfig := RunConfig{Config: config, Workflow: "test"}
-	runner := NewWorkflowRunner(runConfig)
+	runner := NewWorkflowRunner(runConfig, nil)
 	buildRunResults, err := runner.runWorkflows(noOpTracker{})
 	require.Equal(t, nil, err)
 	require.Equal(t, 0, len(buildRunResults.SkippedSteps))
@@ -1554,7 +1554,7 @@ workflows:
 	require.NoError(t, configs.InitPaths())
 
 	runConfig := RunConfig{Config: config, Workflow: "target"}
-	runner := NewWorkflowRunner(runConfig)
+	runner := NewWorkflowRunner(runConfig, nil)
 	results, err := runner.runWorkflows(noOpTracker{})
 	require.Equal(t, 1, len(results.StepmanUpdates))
 }
@@ -1647,7 +1647,7 @@ route_map:
 			log.InitGlobalLogger(opts)
 
 			runConfig := RunConfig{Config: config, Workflow: "test"}
-			runner := NewWorkflowRunner(runConfig)
+			runner := NewWorkflowRunner(runConfig, nil)
 			_, err := runner.runWorkflows(noOpTracker{})
 			opts.Writer = origWiter
 

--- a/cli/trigger.go
+++ b/cli/trigger.go
@@ -188,8 +188,12 @@ func trigger(c *cli.Context) error {
 		Workflow: workflowToRunID,
 		Secrets:  inventoryEnvironments,
 	}
+	agentConfig, err := setupAgentConfig()
+	if err != nil {
+		failf("Failed to process agent config: %w", err)
+	}
 
-	runner := NewWorkflowRunner(runConfig)
+	runner := NewWorkflowRunner(runConfig, agentConfig)
 	exitCode, err := runner.RunWorkflowsWithSetupAndCheckForUpdate()
 	if err != nil {
 		if err == workflowRunFailedErr {

--- a/configs/agent_config.go
+++ b/configs/agent_config.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/bitrise-io/bitrise/log"
 	"github.com/bitrise-io/go-utils/pathutil"
 	"gopkg.in/yaml.v2"
 )
@@ -52,66 +51,19 @@ type AgentHooks struct {
 	DoOnWorkflowStart string `yaml:"do_on_workflow_start"`
 
 	// DoOnWorkflowEnd is an optional executable to run when the workflow ends.
-	DoOnWorkflowEnd   string `yaml:"do_on_workflow_end"`
+	DoOnWorkflowEnd string `yaml:"do_on_workflow_end"`
 }
 
-func RegisterAgentOverrides() error {
-	if !hasAgentConfigFile() {
-		return nil
-	}
-
-	file := filepath.Join(GetBitriseHomeDirPath(), agentConfigFileName)
-
-	log.Print("")
-	log.Info("Running in agent mode")
-	log.Printf("Config file: %s", file)
-
-	config, err := readAgentConfig(file)
-	if err != nil {
-		return fmt.Errorf("agent config file: %w", err)
-	}
-
-	params := []struct {
-		dir    string
-		envKey string
-	}{
-		{
-			dir:    config.BitriseDirs.BitriseDataHomeDir,
-			envKey: BitriseDataHomeDirEnvKey,
-		},
-		{
-			dir:    config.BitriseDirs.SourceDir,
-			envKey: BitriseSourceDirEnvKey,
-		},
-		{
-			dir:    config.BitriseDirs.DeployDir,
-			envKey: BitriseDeployDirEnvKey,
-		},
-		{
-			dir:    config.BitriseDirs.TestDeployDir,
-			envKey: BitriseTestDeployDirEnvKey,
-		},
-	}
-	for _, param := range params {
-		err = pathutil.EnsureDirExist(param.dir)
-		if err != nil {
-			return fmt.Errorf("can't create %s: %w", param.envKey, err)
-		}
-		err = os.Setenv(param.envKey, param.dir)
-		if err != nil {
-			return fmt.Errorf("set %s: %w", param.envKey, err)
-		}
-	}
-
-	return nil
+func GetAgentConfigPath() string {
+	return filepath.Join(GetBitriseHomeDirPath(), agentConfigFileName)
 }
 
-func hasAgentConfigFile() bool {
-	exists, _ := pathutil.IsPathExists(filepath.Join(GetBitriseHomeDirPath(), agentConfigFileName))
+func HasAgentConfig() bool {
+	exists, _ := pathutil.IsPathExists(GetAgentConfigPath())
 	return exists
 }
 
-func readAgentConfig(configFile string) (AgentConfig, error) {
+func ReadAgentConfig(configFile string) (AgentConfig, error) {
 	fileContent, err := os.ReadFile(configFile)
 	if err != nil {
 		return AgentConfig{}, err

--- a/configs/agent_config.go
+++ b/configs/agent_config.go
@@ -47,11 +47,11 @@ type AgentHooks struct {
 	// Bitrise dirs defined in this config file are correctly expanded.
 	CleanupOnWorkflowEnd []string `yaml:"cleanup_on_workflow_end"`
 
-	// DoOnWorkflowStart is an optional executable to run when the workflow starts.
-	DoOnWorkflowStart string `yaml:"do_on_workflow_start"`
+	// DoOnBuildStart is an optional executable to run when the workflow starts.
+	DoOnBuildStart string `yaml:"do_on_build_start"`
 
-	// DoOnWorkflowEnd is an optional executable to run when the workflow ends.
-	DoOnWorkflowEnd string `yaml:"do_on_workflow_end"`
+	// DoOnBuildEnd is an optional executable to run when the workflow ends.
+	DoOnBuildEnd string `yaml:"do_on_build_end"`
 }
 
 func GetAgentConfigPath() string {
@@ -112,34 +112,34 @@ func ReadAgentConfig(configFile string) (AgentConfig, error) {
 	config.BitriseDirs.TestDeployDir = testDeployDir
 
 	// Hooks
-	if config.Hooks.DoOnWorkflowStart != "" {
-		doOnWorkflowStart, err := normalizePath(config.Hooks.DoOnWorkflowStart)
+	if config.Hooks.DoOnBuildStart != "" {
+		doOnBuildStart, err := normalizePath(config.Hooks.DoOnBuildStart)
 		if err != nil {
-			return AgentConfig{}, fmt.Errorf("expand do_on_workflow_start value: %s", err)
+			return AgentConfig{}, fmt.Errorf("expand do_on_build_start value: %s", err)
 		}
-		doOnWorkflowStartExists, err := pathutil.IsPathExists(doOnWorkflowStart)
+		doOnBuildStartExists, err := pathutil.IsPathExists(doOnBuildStart)
 		if err != nil {
 			return AgentConfig{}, err
 		}
-		if !doOnWorkflowStartExists {
-			return AgentConfig{}, fmt.Errorf("do_on_workflow_start path does not exist: %s", doOnWorkflowStart)
+		if !doOnBuildStartExists {
+			return AgentConfig{}, fmt.Errorf("do_on_build_start path does not exist: %s", doOnBuildStart)
 		}
-		config.Hooks.DoOnWorkflowStart = doOnWorkflowStart
+		config.Hooks.DoOnBuildStart = doOnBuildStart
 	}
 
-	if config.Hooks.DoOnWorkflowEnd != "" {
-		doOnWorkflowEnd, err := normalizePath(config.Hooks.DoOnWorkflowEnd)
+	if config.Hooks.DoOnBuildEnd != "" {
+		doOnBuildEnd, err := normalizePath(config.Hooks.DoOnBuildEnd)
 		if err != nil {
-			return AgentConfig{}, fmt.Errorf("expand do_on_workflow_end value: %s", err)
+			return AgentConfig{}, fmt.Errorf("expand do_on_build_end value: %s", err)
 		}
-		doOnWorkflowEndExists, err := pathutil.IsPathExists(doOnWorkflowEnd)
+		doOnBuildEndExists, err := pathutil.IsPathExists(doOnBuildEnd)
 		if err != nil {
 			return AgentConfig{}, err
 		}
-		if !doOnWorkflowEndExists {
-			return AgentConfig{}, fmt.Errorf("do_on_workflow_end path does not exist: %s", doOnWorkflowEnd)
+		if !doOnBuildEndExists {
+			return AgentConfig{}, fmt.Errorf("do_on_build_end path does not exist: %s", doOnBuildEnd)
 		}
-		config.Hooks.DoOnWorkflowEnd = doOnWorkflowEnd
+		config.Hooks.DoOnBuildEnd = doOnBuildEnd
 	}
 
 	return config, nil

--- a/configs/agent_config_test.go
+++ b/configs/agent_config_test.go
@@ -71,7 +71,7 @@ func TestReadAgentConfig(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			config, err := readAgentConfig(tc.configFile)
+			config, err := ReadAgentConfig(tc.configFile)
 			if (err != nil) != tc.expectedErr {
 				t.Errorf("Unexpected error: %v", err)
 			}

--- a/configs/agent_config_test.go
+++ b/configs/agent_config_test.go
@@ -35,8 +35,8 @@ func TestReadAgentConfig(t *testing.T) {
 				AgentHooks{
 					CleanupOnWorkflowStart: []string{"$BITRISE_DEPLOY_DIR"},
 					CleanupOnWorkflowEnd:   []string{"$BITRISE_TEST_DEPLOY_DIR"},
-					DoOnWorkflowStart:      filepath.Join(tempDir, "cleanup.sh"),
-					DoOnWorkflowEnd:        filepath.Join(tempDir, "cleanup.sh"),
+					DoOnBuildStart:         filepath.Join(tempDir, "cleanup.sh"),
+					DoOnBuildEnd:           filepath.Join(tempDir, "cleanup.sh"),
 				},
 			},
 			expectedErr: false,

--- a/configs/testdata/full-agent-config.yml
+++ b/configs/testdata/full-agent-config.yml
@@ -11,5 +11,5 @@ hooks:
   cleanup_on_workflow_end:
   - $BITRISE_TEST_DEPLOY_DIR
 
-  do_on_workflow_start: $HOOKS_DIR/cleanup.sh
-  do_on_workflow_end: $HOOKS_DIR/cleanup.sh
+  do_on_build_start: $HOOKS_DIR/cleanup.sh
+  do_on_build_end: $HOOKS_DIR/cleanup.sh


### PR DESCRIPTION
<!--
  Thanks for contributing to the Bitrise CLI!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [ ] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-io/bitrise/blob/master/.github/CONTRIBUTING.md)
- [ ] `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *MINOR* [version update](https://semver.org/)

### Context

Same theme as #894, but this PR is about running arbitrary commands before and after the CLI picks up a build in agent mode.

### Changes

- Rename some config fields from `workflow` to `build` as these actions are meant to be run in the context of a build, i.e. when an agent picks up a build to execute. One such CLI invocation can result in multiple workflows executed, such as `run_before`, `run_after` and inner `bitrise run workflow` calls.
- Move dir override handling to `cli/agent.go`
- Run build start/end hooks at the right time. Output is streamed to stdout and a non-zero exit code results in a failed execution.

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->