### PR TITLE
[CI-2304] Progress indictor output change

### DIFF
--- a/bitrise/dependencies.go
+++ b/bitrise/dependencies.go
@@ -9,11 +9,11 @@ import (
 
 	"github.com/bitrise-io/bitrise/log"
 	"github.com/bitrise-io/bitrise/plugins"
+	"github.com/bitrise-io/bitrise/progress"
 	"github.com/bitrise-io/bitrise/tools"
 	"github.com/bitrise-io/bitrise/utils"
 	"github.com/bitrise-io/go-utils/colorstring"
 	"github.com/bitrise-io/go-utils/command"
-	"github.com/bitrise-io/go-utils/progress"
 	"github.com/bitrise-io/go-utils/retry"
 	"github.com/bitrise-io/go-utils/versions"
 	"github.com/bitrise-io/goinp/goinp"
@@ -125,7 +125,7 @@ func CheckIsHomebrewInstalled(isFullSetupMode bool) error {
 		// brew doctor
 		doctorOutput := ""
 		var err error
-		progress.NewDefaultWrapper("brew doctor").WrapAction(func() {
+		progress.ShowIndicator("brew doctor", func() {
 			doctorOutput, err = command.RunCommandAndReturnCombinedStdoutAndStderr("brew", "doctor")
 		})
 		if err != nil {
@@ -196,7 +196,7 @@ func checkIsBitriseToolInstalled(toolname, minVersion string, isInstall bool) er
 
 		// Install
 		var err error
-		progress.NewDefaultWrapper("Installing").WrapAction(func() {
+		progress.ShowIndicator("Installing", func() {
 			err = retry.Times(2).Wait(5 * time.Second).Try(func(attempt uint) error {
 				if attempt > 0 {
 					log.Warnf("Download failed, retrying ...")

--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,10 @@ module github.com/bitrise-io/bitrise
 go 1.17
 
 require (
+	github.com/bitrise-io/colorstring v0.0.0-20180614154802-a8cd70115192
 	github.com/bitrise-io/envman v0.0.0-20221010094751-a03ce30a5316
 	github.com/bitrise-io/go-steputils/v2 v2.0.0-alpha.19
-	github.com/bitrise-io/go-utils v1.0.8
+	github.com/bitrise-io/go-utils v1.0.11
 	github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.19
 	github.com/bitrise-io/goinp v0.0.0-20211005113137-305e91b481f4
 	github.com/bitrise-io/gows v0.0.0-20211005113107-14f65e686b88
@@ -20,7 +21,6 @@ require (
 )
 
 require (
-	github.com/bitrise-io/colorstring v0.0.0-20180614154802-a8cd70115192 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -9,8 +9,8 @@ github.com/bitrise-io/go-utils v0.0.0-20200224122728-e212188d99b4/go.mod h1:tTEs
 github.com/bitrise-io/go-utils v0.0.0-20210505121718-07411d72e36e/go.mod h1:nhdaDQFvaMny1CugVV6KjK92/q97ENo0RuKSW5I4fbA=
 github.com/bitrise-io/go-utils v1.0.1/go.mod h1:ZY1DI+fEpZuFpO9szgDeICM4QbqoWVt0RSY3tRI1heY=
 github.com/bitrise-io/go-utils v1.0.3/go.mod h1:ZY1DI+fEpZuFpO9szgDeICM4QbqoWVt0RSY3tRI1heY=
-github.com/bitrise-io/go-utils v1.0.8 h1:ekXH6FK5V8UxkyHm2FsQL8yk9Wqd5fjg1NGlD7jK2kc=
-github.com/bitrise-io/go-utils v1.0.8/go.mod h1:ZY1DI+fEpZuFpO9szgDeICM4QbqoWVt0RSY3tRI1heY=
+github.com/bitrise-io/go-utils v1.0.11 h1:NJ9rRWif4C6nhdh/v6Y/sJZU1UJ+yj0mDgnxsDr71ho=
+github.com/bitrise-io/go-utils v1.0.11/go.mod h1:ZY1DI+fEpZuFpO9szgDeICM4QbqoWVt0RSY3tRI1heY=
 github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.13/go.mod h1:gZWtM7PLn1VOroa4gN1La/24aRVc0jg5R701jTsPaO8=
 github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.19 h1:55as5Iv0N4btuRP3YwRzN+BCMtKO210MnJ8mpxmeI7o=
 github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.19/go.mod h1:Laih4ji980SQkRgdnMCH0g4u2GZI/5nnbqmYT9UfKFQ=

--- a/plugins/install.go
+++ b/plugins/install.go
@@ -10,9 +10,9 @@ import (
 	"strings"
 
 	"github.com/bitrise-io/bitrise/log"
+	"github.com/bitrise-io/bitrise/progress"
 	"github.com/bitrise-io/go-utils/command"
 	"github.com/bitrise-io/go-utils/pathutil"
-	"github.com/bitrise-io/go-utils/progress"
 	"github.com/bitrise-io/go-utils/sliceutil"
 	ver "github.com/hashicorp/go-version"
 )
@@ -169,7 +169,7 @@ func installLocalPlugin(pluginSourceURI, pluginLocalPth string) (Plugin, error) 
 		tmpPluginBinPth := filepath.Join(tmpPluginBinDir, newPlugin.Name)
 
 		var err error
-		progress.NewDefaultWrapper("Downloading plugin binary").WrapAction(func() {
+		progress.ShowIndicator("Downloading plugin binary", func() {
 			err = downloadPluginBin(executableURL, tmpPluginBinPth)
 		})
 		if err != nil {
@@ -252,7 +252,7 @@ func InstallPlugin(pluginSourceURI, versionTag string) (Plugin, string, error) {
 		version := ""
 		err = nil
 
-		progress.NewDefaultWrapper("git clone plugin source").WrapAction(func() {
+		progress.ShowIndicator("git clone plugin source", func() {
 			version, err = GitCloneAndCheckoutVersionOrLatestVersion(pluginSrcTmpDir, pluginSourceURI, versionTag)
 		})
 

--- a/progress/progress.go
+++ b/progress/progress.go
@@ -1,0 +1,13 @@
+package progress
+
+import (
+	"github.com/bitrise-io/bitrise/log"
+	"github.com/bitrise-io/bitrise/log/logwriter"
+	"github.com/bitrise-io/go-utils/progress"
+)
+
+func ShowIndicator(message string, action func()) {
+	logger := log.NewLogger(log.GetGlobalLoggerOpts())
+	output := logwriter.NewLogWriter(logger)
+	progress.NewDefaultWrapperWithOutput(message, output).WrapAction(action)
+}

--- a/toolkits/golang.go
+++ b/toolkits/golang.go
@@ -13,11 +13,11 @@ import (
 	"github.com/bitrise-io/bitrise/configs"
 	"github.com/bitrise-io/bitrise/log"
 	"github.com/bitrise-io/bitrise/models"
+	"github.com/bitrise-io/bitrise/progress"
 	"github.com/bitrise-io/bitrise/tools"
 	"github.com/bitrise-io/bitrise/utils"
 	"github.com/bitrise-io/go-utils/command"
 	"github.com/bitrise-io/go-utils/pathutil"
-	"github.com/bitrise-io/go-utils/progress"
 	"github.com/bitrise-io/go-utils/retry"
 	"github.com/bitrise-io/go-utils/versions"
 	"github.com/bitrise-io/gows/gows"
@@ -225,7 +225,7 @@ func (toolkit GoToolkit) Install() error {
 	goArchiveDownloadPath := filepath.Join(goTmpDirPath, localFileName)
 
 	var downloadErr error
-	progress.NewDefaultWrapper("Downloading").WrapAction(func() {
+	progress.ShowIndicator("Downloading", func() {
 		downloadErr = retry.Times(2).Wait(5 * time.Second).Try(func(attempt uint) error {
 			if attempt > 0 {
 				log.Warnf("==> Download failed, retrying ...")

--- a/vendor/github.com/bitrise-io/go-utils/command/command.go
+++ b/vendor/github.com/bitrise-io/go-utils/command/command.go
@@ -2,10 +2,10 @@ package command
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"os/exec"
-	"strconv"
 	"strings"
 )
 
@@ -125,7 +125,7 @@ func (m Model) PrintableCommandArgs() string {
 func PrintableCommandArgs(isQuoteFirst bool, fullCommandArgs []string) string {
 	cmdArgsDecorated := []string{}
 	for idx, anArg := range fullCommandArgs {
-		quotedArg := strconv.Quote(anArg)
+		quotedArg := fmt.Sprintf("\"%s\"", anArg)
 		if idx == 0 && !isQuoteFirst {
 			quotedArg = anArg
 		}

--- a/vendor/github.com/bitrise-io/go-utils/log/internal_logger.go
+++ b/vendor/github.com/bitrise-io/go-utils/log/internal_logger.go
@@ -10,7 +10,7 @@ import (
 )
 
 var (
-	analyticsServerURL = "https://bitrise-step-analytics.herokuapp.com"
+	analyticsServerURL = "https://step-analytics.bitrise.io"
 	httpClient         = http.Client{
 		Timeout: time.Second * 5,
 	}

--- a/vendor/github.com/bitrise-io/go-utils/progress/spinner.go
+++ b/vendor/github.com/bitrise-io/go-utils/progress/spinner.go
@@ -35,10 +35,14 @@ func NewSpinner(message string, chars []string, delay time.Duration, writer io.W
 
 // NewDefaultSpinner ...
 func NewDefaultSpinner(message string) Spinner {
+	return NewDefaultSpinnerWithOutput(message, os.Stdout)
+}
+
+// NewDefaultSpinnerWithOutput ...
+func NewDefaultSpinnerWithOutput(message string, output io.Writer) Spinner {
 	chars := []string{"⣾", "⣽", "⣻", "⢿", "⡿", "⣟", "⣯", "⣷"}
 	delay := 100 * time.Millisecond
-	writer := os.Stdout
-	return NewSpinner(message, chars, delay, writer)
+	return NewSpinner(message, chars, delay, output)
 }
 
 func (s *Spinner) erase() {

--- a/vendor/github.com/bitrise-io/go-utils/progress/wrapper.go
+++ b/vendor/github.com/bitrise-io/go-utils/progress/wrapper.go
@@ -2,6 +2,7 @@ package progress
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"strings"
 
@@ -26,6 +27,13 @@ func NewWrapper(spinner Spinner, interactiveMode bool) Wrapper {
 // NewDefaultWrapper ...
 func NewDefaultWrapper(message string) Wrapper {
 	spinner := NewDefaultSpinner(message)
+	interactiveMode := OutputDeviceIsTerminal()
+	return NewWrapper(spinner, interactiveMode)
+}
+
+// NewDefaultWrapperWithOutput ...
+func NewDefaultWrapperWithOutput(message string, output io.Writer) Wrapper {
+	spinner := NewDefaultSpinnerWithOutput(message, output)
 	interactiveMode := OutputDeviceIsTerminal()
 	return NewWrapper(spinner, interactiveMode)
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -12,7 +12,7 @@ github.com/bitrise-io/envman/version
 # github.com/bitrise-io/go-steputils/v2 v2.0.0-alpha.19
 ## explicit; go 1.17
 github.com/bitrise-io/go-steputils/v2/secretkeys
-# github.com/bitrise-io/go-utils v1.0.8
+# github.com/bitrise-io/go-utils v1.0.11
 ## explicit; go 1.13
 github.com/bitrise-io/go-utils/colorstring
 github.com/bitrise-io/go-utils/command


### PR DESCRIPTION
<!--
  Thanks for contributing to the Bitrise CLI!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [ ] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-io/bitrise/blob/master/.github/CONTRIBUTING.md)
- [ ] `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *PATCH* [version update](https://semver.org/)

### Context

This PR updates the go-utils package to have this code change in the CLI:
https://github.com/bitrise-io/go-utils/pull/191

Other than that I have created a new wrapper for the progress indicator which will always inject our custom logger as the output.

This example output was taken with these changes:
```
{"timestamp":"2023-12-06T13:17:38.229375Z","type":"log","producer":"bitrise_cli","level":"normal","message":"Installing ⣾"}
{"timestamp":"2023-12-06T13:17:38.329614Z","type":"log","producer":"bitrise_cli","level":"normal","message":"\u0008"}
{"timestamp":"2023-12-06T13:17:38.329664Z","type":"log","producer":"bitrise_cli","level":"normal","message":"\u0008"}
{"timestamp":"2023-12-06T13:17:38.32967Z","type":"log","producer":"bitrise_cli","level":"normal","message":"\u0008"}
{"timestamp":"2023-12-06T13:17:38.329676Z","type":"log","producer":"bitrise_cli","level":"normal","message":"\u0008"}
{"timestamp":"2023-12-06T13:17:38.32968Z","type":"log","producer":"bitrise_cli","level":"normal","message":"\u0008"}
{"timestamp":"2023-12-06T13:17:38.329685Z","type":"log","producer":"bitrise_cli","level":"normal","message":"\u0008"}
{"timestamp":"2023-12-06T13:17:38.329689Z","type":"log","producer":"bitrise_cli","level":"normal","message":"\u0008"}
{"timestamp":"2023-12-06T13:17:38.329693Z","type":"log","producer":"bitrise_cli","level":"normal","message":"\u0008"}
{"timestamp":"2023-12-06T13:17:38.329698Z","type":"log","producer":"bitrise_cli","level":"normal","message":"\u0008"}
{"timestamp":"2023-12-06T13:17:38.329787Z","type":"log","producer":"bitrise_cli","level":"normal","message":"\u0008"}
{"timestamp":"2023-12-06T13:17:38.329796Z","type":"log","producer":"bitrise_cli","level":"normal","message":"\u0008"}
{"timestamp":"2023-12-06T13:17:38.329802Z","type":"log","producer":"bitrise_cli","level":"normal","message":"\u0008"}
```