### PR TITLE
Control draft pr trigger

### DIFF
--- a/_tests/integration/helper.go
+++ b/_tests/integration/helper.go
@@ -19,7 +19,7 @@ func toBase64(t *testing.T, str string) string {
 	return string(bytes)
 }
 
-func toJSON(t *testing.T, stringStringMap map[string]string) string {
+func toJSON(t *testing.T, stringStringMap map[string]interface{}) string {
 	bytes, err := json.Marshal(stringStringMap)
 	require.NoError(t, err)
 	return string(bytes)

--- a/_tests/integration/json_params_test.go
+++ b/_tests/integration/json_params_test.go
@@ -12,7 +12,7 @@ func Test_JsonParams(t *testing.T) {
 
 	t.Log("run test")
 	{
-		config := map[string]string{
+		config := map[string]interface{}{
 			"config":   configPth,
 			"workflow": "json_params_test_target",
 		}
@@ -24,7 +24,7 @@ func Test_JsonParams(t *testing.T) {
 
 	t.Log("run test - param override")
 	{
-		config := map[string]string{
+		config := map[string]interface{}{
 			"config":   configPth,
 			"workflow": "exit_code_test_fail",
 		}
@@ -36,7 +36,7 @@ func Test_JsonParams(t *testing.T) {
 
 	t.Log("trigger test")
 	{
-		config := map[string]string{
+		config := map[string]interface{}{
 			"config":  configPth,
 			"pattern": "json_params_test_target",
 		}
@@ -48,7 +48,7 @@ func Test_JsonParams(t *testing.T) {
 
 	t.Log("trigger test - param override")
 	{
-		config := map[string]string{
+		config := map[string]interface{}{
 			"config":  configPth,
 			"pattern": "exit_code_test_fail",
 		}
@@ -60,7 +60,7 @@ func Test_JsonParams(t *testing.T) {
 
 	t.Log("run test base64")
 	{
-		config := map[string]string{
+		config := map[string]interface{}{
 			"config":   configPth,
 			"workflow": "json_params_test_target",
 		}
@@ -72,7 +72,7 @@ func Test_JsonParams(t *testing.T) {
 
 	t.Log("trigger test base64")
 	{
-		config := map[string]string{
+		config := map[string]interface{}{
 			"config":  configPth,
 			"pattern": "json_params_test_target",
 		}
@@ -84,7 +84,7 @@ func Test_JsonParams(t *testing.T) {
 
 	t.Log("trigger check test")
 	{
-		config := map[string]string{
+		config := map[string]interface{}{
 			"config":  configPth,
 			"pattern": "json_params_test_target",
 			"format":  "json",
@@ -98,7 +98,7 @@ func Test_JsonParams(t *testing.T) {
 
 	t.Log("trigger check test - param override")
 	{
-		config := map[string]string{
+		config := map[string]interface{}{
 			"config":  configPth,
 			"pattern": "json_params_test_target",
 			"format":  "raw",

--- a/_tests/integration/new_trigger_test.go
+++ b/_tests/integration/new_trigger_test.go
@@ -181,7 +181,6 @@ func Test_NewTrigger(t *testing.T) {
 		require.Equal(t, `{"pr-source-branch":"no_draft_pr","workflow":"no_draft_pr"}`, out)
 	}
 
-	// TODO: this shouldn't find a workflow, because of the draft pr state
 	t.Log("draft pr control test - draft pr disabled - draft pr trigger")
 	{
 		config := map[string]interface{}{

--- a/_tests/integration/new_trigger_test_bitrise.yml
+++ b/_tests/integration/new_trigger_test_bitrise.yml
@@ -23,6 +23,9 @@ trigger_map:
   workflow: pr_target
 - pull_request_source_branch: pr_source_only
   workflow: pr_source
+- pull_request_source_branch: no_draft_pr
+  draft_pull_request_enabled: false
+  workflow: no_draft_pr
 
 pipelines:
   deprecated_pipeline:
@@ -48,3 +51,4 @@ workflows:
   pr_source_and_target:
   pr_target:
   pr_source:
+  no_draft_pr:

--- a/cli/commands.go
+++ b/cli/commands.go
@@ -60,7 +60,7 @@ var (
 				cli.StringFlag{Name: PushBranchKey, Usage: "Git push branch name."},
 				cli.StringFlag{Name: PRSourceBranchKey, Usage: "Git pull request source branch name."},
 				cli.StringFlag{Name: PRTargetBranchKey, Usage: "Git pull request target branch name."},
-				cli.StringFlag{Name: DraftPRKey, Usage: "Is the pull request in draft state?"},
+				cli.BoolFlag{Name: DraftPRKey, Usage: "Is the pull request in draft state?"},
 				cli.StringFlag{Name: TagKey, Usage: "Git tag name."},
 
 				cli.StringFlag{Name: OuputFormatKey, Usage: "Output format. Accepted: json, yml."},

--- a/cli/commands.go
+++ b/cli/commands.go
@@ -13,11 +13,11 @@ const (
 	PushBranchKey     = "push-branch"
 	PRSourceBranchKey = "pr-source-branch"
 	PRTargetBranchKey = "pr-target-branch"
+	DraftPRKey        = "draft-pr"
 
-	IncludeWorkflowMetaKey = "include-workflow-meta"
-	ConfigKey              = "config"
-	InventoryKey           = "inventory"
-	OuputFormatKey         = "format"
+	ConfigKey      = "config"
+	InventoryKey   = "inventory"
+	OuputFormatKey = "format"
 )
 
 var (
@@ -60,6 +60,7 @@ var (
 				cli.StringFlag{Name: PushBranchKey, Usage: "Git push branch name."},
 				cli.StringFlag{Name: PRSourceBranchKey, Usage: "Git pull request source branch name."},
 				cli.StringFlag{Name: PRTargetBranchKey, Usage: "Git pull request target branch name."},
+				cli.StringFlag{Name: DraftPRKey, Usage: "Is the pull request in draft state?"},
 				cli.StringFlag{Name: TagKey, Usage: "Git tag name."},
 
 				cli.StringFlag{Name: OuputFormatKey, Usage: "Output format. Accepted: json, yml."},
@@ -67,7 +68,6 @@ var (
 				// cli params used in CI mode
 				cli.StringFlag{Name: JSONParamsKey, Usage: "Specify command flags with json string-string hash."},
 				cli.StringFlag{Name: JSONParamsBase64Key, Usage: "Specify command flags with base64 encoded json string-string hash."},
-
 
 				// should deprecate
 				cli.StringFlag{Name: ConfigBase64Key, Usage: "base64 encoded config data."},

--- a/cli/run_trigger_params.go
+++ b/cli/run_trigger_params.go
@@ -45,7 +45,7 @@ func parseRunAndTriggerJSONParams(jsonParams string) (RunAndTriggerParamsModel, 
 func parseRunAndTriggerParams(
 	workflowToRunID,
 	triggerPattern,
-	pushBranch, prSourceBranch, prTargetBranch string, isDraftPR bool, tag,
+	pushBranch, prSourceBranch, prTargetBranch string, isDraftPR *bool, tag,
 	format,
 	bitriseConfigPath, bitriseConfigBase64Data,
 	inventoryPath, inventoryBase64Data,
@@ -87,7 +87,9 @@ func parseRunAndTriggerParams(
 	if prTargetBranch != "" {
 		params.PRTargetBranch = prTargetBranch
 	}
-	params.IsDraftPR = isDraftPR
+	if isDraftPR != nil {
+		params.IsDraftPR = *isDraftPR
+	}
 	if tag != "" {
 		params.Tag = tag
 	}
@@ -117,12 +119,12 @@ func parseRunParams(
 	bitriseConfigPath, bitriseConfigBase64Data,
 	inventoryPath, inventoryBase64Data,
 	jsonParams, base64JSONParams string) (RunAndTriggerParamsModel, error) {
-	return parseRunAndTriggerParams(workflowToRunID, "", "", "", "", false, "", "", bitriseConfigPath, bitriseConfigBase64Data, inventoryPath, inventoryBase64Data, jsonParams, base64JSONParams)
+	return parseRunAndTriggerParams(workflowToRunID, "", "", "", "", nil, "", "", bitriseConfigPath, bitriseConfigBase64Data, inventoryPath, inventoryBase64Data, jsonParams, base64JSONParams)
 }
 
 func parseTriggerParams(
 	triggerPattern,
-	pushBranch, prSourceBranch, prTargetBranch string, isDraftPR bool, tag,
+	pushBranch, prSourceBranch, prTargetBranch string, isDraftPR *bool, tag,
 	bitriseConfigPath, bitriseConfigBase64Data,
 	inventoryPath, inventoryBase64Data,
 	jsonParams, base64JSONParams string) (RunAndTriggerParamsModel, error) {
@@ -131,7 +133,7 @@ func parseTriggerParams(
 
 func parseTriggerCheckParams(
 	triggerPattern,
-	pushBranch, prSourceBranch, prTargetBranch string, isDraftPR bool, tag,
+	pushBranch, prSourceBranch, prTargetBranch string, isDraftPR *bool, tag,
 	format,
 	bitriseConfigPath, bitriseConfigBase64Data,
 	inventoryPath, inventoryBase64Data,

--- a/cli/run_trigger_params.go
+++ b/cli/run_trigger_params.go
@@ -20,6 +20,7 @@ type RunAndTriggerParamsModel struct {
 	PushBranch     string `json:"push-branch"`
 	PRSourceBranch string `json:"pr-source-branch"`
 	PRTargetBranch string `json:"pr-target-branch"`
+	IsDraftPR      bool   `json:"draft-pr"`
 	Tag            string `json:"tag"`
 
 	// Trigger Check Params
@@ -44,7 +45,7 @@ func parseRunAndTriggerJSONParams(jsonParams string) (RunAndTriggerParamsModel, 
 func parseRunAndTriggerParams(
 	workflowToRunID,
 	triggerPattern,
-	pushBranch, prSourceBranch, prTargetBranch, tag,
+	pushBranch, prSourceBranch, prTargetBranch string, isDraftPR bool, tag,
 	format,
 	bitriseConfigPath, bitriseConfigBase64Data,
 	inventoryPath, inventoryBase64Data,
@@ -68,7 +69,7 @@ func parseRunAndTriggerParams(
 		}
 	}
 
-	// Owerride params
+	// Override params
 	if workflowToRunID != "" {
 		params.WorkflowToRunID = workflowToRunID
 	}
@@ -86,6 +87,7 @@ func parseRunAndTriggerParams(
 	if prTargetBranch != "" {
 		params.PRTargetBranch = prTargetBranch
 	}
+	params.IsDraftPR = isDraftPR
 	if tag != "" {
 		params.Tag = tag
 	}
@@ -115,24 +117,24 @@ func parseRunParams(
 	bitriseConfigPath, bitriseConfigBase64Data,
 	inventoryPath, inventoryBase64Data,
 	jsonParams, base64JSONParams string) (RunAndTriggerParamsModel, error) {
-	return parseRunAndTriggerParams(workflowToRunID, "", "", "", "", "", "", bitriseConfigPath, bitriseConfigBase64Data, inventoryPath, inventoryBase64Data, jsonParams, base64JSONParams)
+	return parseRunAndTriggerParams(workflowToRunID, "", "", "", "", false, "", "", bitriseConfigPath, bitriseConfigBase64Data, inventoryPath, inventoryBase64Data, jsonParams, base64JSONParams)
 }
 
 func parseTriggerParams(
 	triggerPattern,
-	pushBranch, prSourceBranch, prTargetBranch, tag,
+	pushBranch, prSourceBranch, prTargetBranch string, isDraftPR bool, tag,
 	bitriseConfigPath, bitriseConfigBase64Data,
 	inventoryPath, inventoryBase64Data,
 	jsonParams, base64JSONParams string) (RunAndTriggerParamsModel, error) {
-	return parseRunAndTriggerParams("", triggerPattern, pushBranch, prSourceBranch, prTargetBranch, tag, "", bitriseConfigPath, bitriseConfigBase64Data, inventoryPath, inventoryBase64Data, jsonParams, base64JSONParams)
+	return parseRunAndTriggerParams("", triggerPattern, pushBranch, prSourceBranch, prTargetBranch, isDraftPR, tag, "", bitriseConfigPath, bitriseConfigBase64Data, inventoryPath, inventoryBase64Data, jsonParams, base64JSONParams)
 }
 
 func parseTriggerCheckParams(
 	triggerPattern,
-	pushBranch, prSourceBranch, prTargetBranch, tag,
+	pushBranch, prSourceBranch, prTargetBranch string, isDraftPR bool, tag,
 	format,
 	bitriseConfigPath, bitriseConfigBase64Data,
 	inventoryPath, inventoryBase64Data,
 	jsonParams, base64JSONParams string) (RunAndTriggerParamsModel, error) {
-	return parseRunAndTriggerParams("", triggerPattern, pushBranch, prSourceBranch, prTargetBranch, tag, format, bitriseConfigPath, bitriseConfigBase64Data, inventoryPath, inventoryBase64Data, jsonParams, base64JSONParams)
+	return parseRunAndTriggerParams("", triggerPattern, pushBranch, prSourceBranch, prTargetBranch, isDraftPR, tag, format, bitriseConfigPath, bitriseConfigBase64Data, inventoryPath, inventoryBase64Data, jsonParams, base64JSONParams)
 }

--- a/cli/run_trigger_params_test.go
+++ b/cli/run_trigger_params_test.go
@@ -13,22 +13,24 @@ func toBase64(t *testing.T, str string) string {
 	return string(bytes)
 }
 
-func toJSON(t *testing.T, stringStringMap map[string]string) string {
+func toJSON(t *testing.T, stringStringMap map[string]interface{}) string {
 	bytes, err := json.Marshal(stringStringMap)
 	require.NoError(t, err)
 	return string(bytes)
 }
 
+// TODO: test is Draft PR
 func TestParseRunAndTriggerJSONParams(t *testing.T) {
 	t.Log("it parses cli params")
 	{
-		paramsMap := map[string]string{
+		paramsMap := map[string]interface{}{
 			WorkflowKey: "primary",
 
 			PatternKey:        "master",
 			PushBranchKey:     "deploy",
 			PRSourceBranchKey: "development",
 			PRTargetBranchKey: "release",
+			DraftPRKey:        false,
 			TagKey:            "0.9.0",
 
 			OuputFormatKey: "json",
@@ -81,6 +83,7 @@ func TestParseRunAndTriggerJSONParams(t *testing.T) {
 	}
 }
 
+// TODO: test is Draft PR
 func TestParseRunAndTriggerParams(t *testing.T) {
 	t.Log("it parses cli params")
 	{
@@ -90,6 +93,7 @@ func TestParseRunAndTriggerParams(t *testing.T) {
 		pushBranch := "master"
 		prSourceBranch := "develop"
 		prTargetBranch := "master"
+		isDraftPR := false
 		tag := "0.9.0"
 		format := "json"
 
@@ -105,7 +109,7 @@ func TestParseRunAndTriggerParams(t *testing.T) {
 		params, err := parseRunAndTriggerParams(
 			workflow,
 			pattern,
-			pushBranch, prSourceBranch, prTargetBranch, tag,
+			pushBranch, prSourceBranch, prTargetBranch, isDraftPR, tag,
 			format,
 			bitriseConfigPath, bitriseConfigBase64Data,
 			inventoryPath, inventoryBase64Data,
@@ -138,6 +142,7 @@ func TestParseRunAndTriggerParams(t *testing.T) {
 		pushBranch := "master"
 		prSourceBranch := "develop"
 		prTargetBranch := "master"
+		isDraftPR := false
 		tag := "0.9.0"
 		format := "json"
 
@@ -147,13 +152,14 @@ func TestParseRunAndTriggerParams(t *testing.T) {
 		inventoryPath := ".secrets.bitrise.yml"
 		inventoryBase64Data := toBase64(t, ".secrets.bitrise.yml")
 
-		paramsMap := map[string]string{
+		paramsMap := map[string]interface{}{
 			WorkflowKey: workflow,
 
 			PatternKey:        pattern,
 			PushBranchKey:     pushBranch,
 			PRSourceBranchKey: prSourceBranch,
 			PRTargetBranchKey: prTargetBranch,
+			DraftPRKey:        isDraftPR,
 			TagKey:            tag,
 			OuputFormatKey:    format,
 
@@ -167,7 +173,7 @@ func TestParseRunAndTriggerParams(t *testing.T) {
 		jsonParams := toJSON(t, paramsMap)
 		base64JSONParams := ""
 
-		params, err := parseRunAndTriggerParams("", "", "", "", "", "", "", "", "", "", "", jsonParams, base64JSONParams)
+		params, err := parseRunAndTriggerParams("", "", "", "", "", false, "", "", "", "", "", "", jsonParams, base64JSONParams)
 		require.NoError(t, err)
 
 		require.Equal(t, workflow, params.WorkflowToRunID)
@@ -195,6 +201,7 @@ func TestParseRunAndTriggerParams(t *testing.T) {
 		pushBranch := "master"
 		prSourceBranch := "develop"
 		prTargetBranch := "master"
+		isDraftPR := false
 		tag := "0.9.0"
 		format := "json"
 
@@ -204,13 +211,14 @@ func TestParseRunAndTriggerParams(t *testing.T) {
 		inventoryPath := ".secrets.bitrise.yml"
 		inventoryBase64Data := toBase64(t, ".secrets.bitrise.yml")
 
-		paramsMap := map[string]string{
+		paramsMap := map[string]interface{}{
 			WorkflowKey: workflow,
 
 			PatternKey:        pattern,
 			PushBranchKey:     pushBranch,
 			PRSourceBranchKey: prSourceBranch,
 			PRTargetBranchKey: prTargetBranch,
+			DraftPRKey:        isDraftPR,
 			TagKey:            tag,
 			OuputFormatKey:    format,
 
@@ -224,7 +232,7 @@ func TestParseRunAndTriggerParams(t *testing.T) {
 		jsonParams := ""
 		base64JSONParams := toBase64(t, toJSON(t, paramsMap))
 
-		params, err := parseRunAndTriggerParams("", "", "", "", "", "", "", "", "", "", "", jsonParams, base64JSONParams)
+		params, err := parseRunAndTriggerParams("", "", "", "", "", false, "", "", "", "", "", "", jsonParams, base64JSONParams)
 		require.NoError(t, err)
 
 		require.Equal(t, workflow, params.WorkflowToRunID)
@@ -252,6 +260,7 @@ func TestParseRunAndTriggerParams(t *testing.T) {
 		pushBranch := "master"
 		prSourceBranch := "develop"
 		prTargetBranch := "master"
+		isDraftPR := false
 		tag := "0.9.0"
 		format := "json"
 
@@ -261,13 +270,14 @@ func TestParseRunAndTriggerParams(t *testing.T) {
 		inventoryPath := ".secrets.bitrise.yml"
 		inventoryBase64Data := toBase64(t, ".secrets.bitrise.yml")
 
-		paramsMap := map[string]string{
+		paramsMap := map[string]interface{}{
 			WorkflowKey: workflow,
 
 			PatternKey:        pattern,
 			PushBranchKey:     pushBranch,
 			PRSourceBranchKey: prSourceBranch,
 			PRTargetBranchKey: prTargetBranch,
+			DraftPRKey:        isDraftPR,
 			TagKey:            tag,
 			OuputFormatKey:    format,
 
@@ -281,7 +291,7 @@ func TestParseRunAndTriggerParams(t *testing.T) {
 		jsonParams := `{"workflow":"test"}`
 		base64JSONParams := toBase64(t, toJSON(t, paramsMap))
 
-		params, err := parseRunAndTriggerParams("", "", "", "", "", "", "", "", "", "", "", jsonParams, base64JSONParams)
+		params, err := parseRunAndTriggerParams("", "", "", "", "", false, "", "", "", "", "", "", jsonParams, base64JSONParams)
 		require.NoError(t, err)
 
 		require.Equal(t, "test", params.WorkflowToRunID)
@@ -309,6 +319,7 @@ func TestParseRunAndTriggerParams(t *testing.T) {
 		pushBranch := "master"
 		prSourceBranch := "develop"
 		prTargetBranch := "master"
+		isDraftPR := false
 		tag := "0.9.0"
 		format := "json"
 
@@ -324,7 +335,7 @@ func TestParseRunAndTriggerParams(t *testing.T) {
 		params, err := parseRunAndTriggerParams(
 			workflow,
 			pattern,
-			pushBranch, prSourceBranch, prTargetBranch, tag,
+			pushBranch, prSourceBranch, prTargetBranch, isDraftPR, tag,
 			format,
 			bitriseConfigPath, bitriseConfigBase64Data,
 			inventoryPath, inventoryBase64Data,
@@ -397,6 +408,7 @@ func TestParseTriggerParams(t *testing.T) {
 		pushBranch := "master"
 		prSourceBranch := "develop"
 		prTargetBranch := "master"
+		isDraftPR := false
 		tag := "0.9.0"
 
 		bitriseConfigPath := "bitrise.yml"
@@ -410,7 +422,7 @@ func TestParseTriggerParams(t *testing.T) {
 
 		params, err := parseTriggerParams(
 			pattern,
-			pushBranch, prSourceBranch, prTargetBranch, tag,
+			pushBranch, prSourceBranch, prTargetBranch, isDraftPR, tag,
 			bitriseConfigPath, bitriseConfigBase64Data,
 			inventoryPath, inventoryBase64Data,
 			jsonParams, base64JSONParams,
@@ -442,6 +454,7 @@ func TestParseTriggerCheckParams(t *testing.T) {
 		pushBranch := "master"
 		prSourceBranch := "develop"
 		prTargetBranch := "master"
+		isDraftPR := false
 		tag := "0.9.0"
 		format := "json"
 
@@ -456,7 +469,7 @@ func TestParseTriggerCheckParams(t *testing.T) {
 
 		params, err := parseTriggerCheckParams(
 			pattern,
-			pushBranch, prSourceBranch, prTargetBranch, tag,
+			pushBranch, prSourceBranch, prTargetBranch, isDraftPR, tag,
 			format,
 			bitriseConfigPath, bitriseConfigBase64Data,
 			inventoryPath, inventoryBase64Data,

--- a/cli/run_trigger_params_test.go
+++ b/cli/run_trigger_params_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/bitrise-io/go-utils/pointers"
 	"github.com/stretchr/testify/require"
 )
 
@@ -19,7 +20,6 @@ func toJSON(t *testing.T, stringStringMap map[string]interface{}) string {
 	return string(bytes)
 }
 
-// TODO: test is Draft PR
 func TestParseRunAndTriggerJSONParams(t *testing.T) {
 	t.Log("it parses cli params")
 	{
@@ -30,7 +30,7 @@ func TestParseRunAndTriggerJSONParams(t *testing.T) {
 			PushBranchKey:     "deploy",
 			PRSourceBranchKey: "development",
 			PRTargetBranchKey: "release",
-			DraftPRKey:        false,
+			DraftPRKey:        true,
 			TagKey:            "0.9.0",
 
 			OuputFormatKey: "json",
@@ -50,6 +50,7 @@ func TestParseRunAndTriggerJSONParams(t *testing.T) {
 		require.Equal(t, "deploy", params.PushBranch)
 		require.Equal(t, "development", params.PRSourceBranch)
 		require.Equal(t, "release", params.PRTargetBranch)
+		require.Equal(t, true, params.IsDraftPR)
 		require.Equal(t, "0.9.0", params.Tag)
 
 		require.Equal(t, "json", params.Format)
@@ -72,6 +73,7 @@ func TestParseRunAndTriggerJSONParams(t *testing.T) {
 		require.Equal(t, "", params.PushBranch)
 		require.Equal(t, "", params.PRSourceBranch)
 		require.Equal(t, "", params.PRTargetBranch)
+		require.Equal(t, false, params.IsDraftPR)
 
 		require.Equal(t, "", params.Format)
 
@@ -83,7 +85,6 @@ func TestParseRunAndTriggerJSONParams(t *testing.T) {
 	}
 }
 
-// TODO: test is Draft PR
 func TestParseRunAndTriggerParams(t *testing.T) {
 	t.Log("it parses cli params")
 	{
@@ -93,7 +94,7 @@ func TestParseRunAndTriggerParams(t *testing.T) {
 		pushBranch := "master"
 		prSourceBranch := "develop"
 		prTargetBranch := "master"
-		isDraftPR := false
+		isDraftPR := pointers.NewBoolPtr(true)
 		tag := "0.9.0"
 		format := "json"
 
@@ -123,6 +124,7 @@ func TestParseRunAndTriggerParams(t *testing.T) {
 		require.Equal(t, pushBranch, params.PushBranch)
 		require.Equal(t, prSourceBranch, params.PRSourceBranch)
 		require.Equal(t, prTargetBranch, params.PRTargetBranch)
+		require.Equal(t, true, params.IsDraftPR)
 		require.Equal(t, tag, params.Tag)
 
 		require.Equal(t, format, params.Format)
@@ -142,7 +144,7 @@ func TestParseRunAndTriggerParams(t *testing.T) {
 		pushBranch := "master"
 		prSourceBranch := "develop"
 		prTargetBranch := "master"
-		isDraftPR := false
+		isDraftPR := true
 		tag := "0.9.0"
 		format := "json"
 
@@ -173,7 +175,7 @@ func TestParseRunAndTriggerParams(t *testing.T) {
 		jsonParams := toJSON(t, paramsMap)
 		base64JSONParams := ""
 
-		params, err := parseRunAndTriggerParams("", "", "", "", "", false, "", "", "", "", "", "", jsonParams, base64JSONParams)
+		params, err := parseRunAndTriggerParams("", "", "", "", "", nil, "", "", "", "", "", "", jsonParams, base64JSONParams)
 		require.NoError(t, err)
 
 		require.Equal(t, workflow, params.WorkflowToRunID)
@@ -182,6 +184,7 @@ func TestParseRunAndTriggerParams(t *testing.T) {
 		require.Equal(t, pushBranch, params.PushBranch)
 		require.Equal(t, prSourceBranch, params.PRSourceBranch)
 		require.Equal(t, prTargetBranch, params.PRTargetBranch)
+		require.Equal(t, true, params.IsDraftPR)
 		require.Equal(t, tag, params.Tag)
 
 		require.Equal(t, format, params.Format)
@@ -201,7 +204,7 @@ func TestParseRunAndTriggerParams(t *testing.T) {
 		pushBranch := "master"
 		prSourceBranch := "develop"
 		prTargetBranch := "master"
-		isDraftPR := false
+		isDraftPR := true
 		tag := "0.9.0"
 		format := "json"
 
@@ -232,7 +235,7 @@ func TestParseRunAndTriggerParams(t *testing.T) {
 		jsonParams := ""
 		base64JSONParams := toBase64(t, toJSON(t, paramsMap))
 
-		params, err := parseRunAndTriggerParams("", "", "", "", "", false, "", "", "", "", "", "", jsonParams, base64JSONParams)
+		params, err := parseRunAndTriggerParams("", "", "", "", "", nil, "", "", "", "", "", "", jsonParams, base64JSONParams)
 		require.NoError(t, err)
 
 		require.Equal(t, workflow, params.WorkflowToRunID)
@@ -241,6 +244,7 @@ func TestParseRunAndTriggerParams(t *testing.T) {
 		require.Equal(t, pushBranch, params.PushBranch)
 		require.Equal(t, prSourceBranch, params.PRSourceBranch)
 		require.Equal(t, prTargetBranch, params.PRTargetBranch)
+		require.Equal(t, true, params.IsDraftPR)
 		require.Equal(t, tag, params.Tag)
 
 		require.Equal(t, format, params.Format)
@@ -288,10 +292,10 @@ func TestParseRunAndTriggerParams(t *testing.T) {
 			InventoryBase64Key: inventoryBase64Data,
 		}
 
-		jsonParams := `{"workflow":"test"}`
+		jsonParams := `{"workflow":"test","draft-pr":true}`
 		base64JSONParams := toBase64(t, toJSON(t, paramsMap))
 
-		params, err := parseRunAndTriggerParams("", "", "", "", "", false, "", "", "", "", "", "", jsonParams, base64JSONParams)
+		params, err := parseRunAndTriggerParams("", "", "", "", "", nil, "", "", "", "", "", "", jsonParams, base64JSONParams)
 		require.NoError(t, err)
 
 		require.Equal(t, "test", params.WorkflowToRunID)
@@ -300,6 +304,7 @@ func TestParseRunAndTriggerParams(t *testing.T) {
 		require.Equal(t, "", params.PushBranch)
 		require.Equal(t, "", params.PRSourceBranch)
 		require.Equal(t, "", params.PRTargetBranch)
+		require.Equal(t, true, params.IsDraftPR)
 		require.Equal(t, "", params.Tag)
 
 		require.Equal(t, "", params.Format)
@@ -319,7 +324,7 @@ func TestParseRunAndTriggerParams(t *testing.T) {
 		pushBranch := "master"
 		prSourceBranch := "develop"
 		prTargetBranch := "master"
-		isDraftPR := false
+		isDraftPR := pointers.NewBoolPtr(true)
 		tag := "0.9.0"
 		format := "json"
 
@@ -349,6 +354,7 @@ func TestParseRunAndTriggerParams(t *testing.T) {
 		require.Equal(t, pushBranch, params.PushBranch)
 		require.Equal(t, prSourceBranch, params.PRSourceBranch)
 		require.Equal(t, prTargetBranch, params.PRTargetBranch)
+		require.Equal(t, true, params.IsDraftPR)
 		require.Equal(t, tag, params.Tag)
 
 		require.Equal(t, format, params.Format)
@@ -389,6 +395,7 @@ func TestParseRunParams(t *testing.T) {
 		require.Equal(t, "", params.PushBranch)
 		require.Equal(t, "", params.PRSourceBranch)
 		require.Equal(t, "", params.PRTargetBranch)
+		require.Equal(t, false, params.IsDraftPR)
 		require.Equal(t, "", params.Tag)
 
 		require.Equal(t, "", params.Format)
@@ -408,7 +415,7 @@ func TestParseTriggerParams(t *testing.T) {
 		pushBranch := "master"
 		prSourceBranch := "develop"
 		prTargetBranch := "master"
-		isDraftPR := false
+		isDraftPR := pointers.NewBoolPtr(true)
 		tag := "0.9.0"
 
 		bitriseConfigPath := "bitrise.yml"
@@ -435,6 +442,7 @@ func TestParseTriggerParams(t *testing.T) {
 		require.Equal(t, pushBranch, params.PushBranch)
 		require.Equal(t, prSourceBranch, params.PRSourceBranch)
 		require.Equal(t, prTargetBranch, params.PRTargetBranch)
+		require.Equal(t, true, params.IsDraftPR)
 		require.Equal(t, tag, params.Tag)
 
 		require.Equal(t, "", params.Format)
@@ -454,7 +462,7 @@ func TestParseTriggerCheckParams(t *testing.T) {
 		pushBranch := "master"
 		prSourceBranch := "develop"
 		prTargetBranch := "master"
-		isDraftPR := false
+		isDraftPR := pointers.NewBoolPtr(true)
 		tag := "0.9.0"
 		format := "json"
 
@@ -483,6 +491,7 @@ func TestParseTriggerCheckParams(t *testing.T) {
 		require.Equal(t, pushBranch, params.PushBranch)
 		require.Equal(t, prSourceBranch, params.PRSourceBranch)
 		require.Equal(t, prTargetBranch, params.PRTargetBranch)
+		require.Equal(t, true, params.IsDraftPR)
 		require.Equal(t, tag, params.Tag)
 
 		require.Equal(t, format, params.Format)

--- a/cli/trigger.go
+++ b/cli/trigger.go
@@ -101,10 +101,7 @@ func trigger(c *cli.Context) error {
 	pushBranch := c.String(PushBranchKey)
 	prSourceBranch := c.String(PRSourceBranchKey)
 	prTargetBranch := c.String(PRTargetBranchKey)
-	isDraftPR := false
-	if c.IsSet(DraftPRKey) {
-		isDraftPR = c.Bool(DraftPRKey)
-	}
+	isDraftPR := c.Bool(DraftPRKey)
 	tag := c.String(TagKey)
 
 	bitriseConfigBase64Data := c.String(ConfigBase64Key)

--- a/cli/trigger.go
+++ b/cli/trigger.go
@@ -28,6 +28,7 @@ var triggerCommand = cli.Command{
 		cli.StringFlag{Name: PushBranchKey, Usage: "Git push branch name."},
 		cli.StringFlag{Name: PRSourceBranchKey, Usage: "Git pull request source branch name."},
 		cli.StringFlag{Name: PRTargetBranchKey, Usage: "Git pull request target branch name."},
+		cli.BoolFlag{Name: DraftPRKey, Usage: "Is the pull request in draft state?"},
 		cli.StringFlag{Name: TagKey, Usage: "Git tag name."},
 
 		// cli params used in CI mode
@@ -100,6 +101,10 @@ func trigger(c *cli.Context) error {
 	pushBranch := c.String(PushBranchKey)
 	prSourceBranch := c.String(PRSourceBranchKey)
 	prTargetBranch := c.String(PRTargetBranchKey)
+	isDraftPR := false
+	if c.IsSet(DraftPRKey) {
+		isDraftPR = c.Bool(DraftPRKey)
+	}
 	tag := c.String(TagKey)
 
 	bitriseConfigBase64Data := c.String(ConfigBase64Key)
@@ -113,7 +118,7 @@ func trigger(c *cli.Context) error {
 
 	triggerParams, err := parseTriggerParams(
 		triggerPattern,
-		pushBranch, prSourceBranch, prTargetBranch, tag,
+		pushBranch, prSourceBranch, prTargetBranch, isDraftPR, tag,
 		bitriseConfigPath, bitriseConfigBase64Data,
 		inventoryPath, inventoryBase64Data,
 		jsonParams, jsonParamsBase64)

--- a/cli/trigger.go
+++ b/cli/trigger.go
@@ -101,7 +101,10 @@ func trigger(c *cli.Context) error {
 	pushBranch := c.String(PushBranchKey)
 	prSourceBranch := c.String(PRSourceBranchKey)
 	prTargetBranch := c.String(PRTargetBranchKey)
-	isDraftPR := c.Bool(DraftPRKey)
+	var isDraftPR *bool
+	if c.IsSet(DraftPRKey) {
+		isDraftPR = pointers.NewBoolPtr(c.Bool(DraftPRKey))
+	}
 	tag := c.String(TagKey)
 
 	bitriseConfigBase64Data := c.String(ConfigBase64Key)

--- a/cli/trigger_check.go
+++ b/cli/trigger_check.go
@@ -90,10 +90,7 @@ func triggerCheck(c *cli.Context) error {
 	pushBranch := c.String(PushBranchKey)
 	prSourceBranch := c.String(PRSourceBranchKey)
 	prTargetBranch := c.String(PRTargetBranchKey)
-	isDraftPR := false
-	if c.IsSet(DraftPRKey) {
-		isDraftPR = c.Bool(DraftPRKey)
-	}
+	isDraftPR := c.Bool(DraftPRKey)
 	tag := c.String(TagKey)
 
 	bitriseConfigBase64Data := c.String(ConfigBase64Key)

--- a/cli/trigger_check.go
+++ b/cli/trigger_check.go
@@ -90,7 +90,10 @@ func triggerCheck(c *cli.Context) error {
 	pushBranch := c.String(PushBranchKey)
 	prSourceBranch := c.String(PRSourceBranchKey)
 	prTargetBranch := c.String(PRTargetBranchKey)
-	isDraftPR := c.Bool(DraftPRKey)
+	var isDraftPR *bool
+	if c.IsSet(DraftPRKey) {
+		isDraftPR = pointers.NewBoolPtr(c.Bool(DraftPRKey))
+	}
 	tag := c.String(TagKey)
 
 	bitriseConfigBase64Data := c.String(ConfigBase64Key)

--- a/cli/trigger_check.go
+++ b/cli/trigger_check.go
@@ -65,7 +65,7 @@ func getPipelineAndWorkflowIDByParamsInCompatibleMode(triggerMap models.TriggerM
 		params = migratePatternToParams(params, isPullRequestMode)
 	}
 
-	return triggerMap.FirstMatchingTarget(params.PushBranch, params.PRSourceBranch, params.PRTargetBranch, params.Tag)
+	return triggerMap.FirstMatchingTarget(params.PushBranch, params.PRSourceBranch, params.PRTargetBranch, params.IsDraftPR, params.Tag)
 }
 
 // --------------------
@@ -90,6 +90,10 @@ func triggerCheck(c *cli.Context) error {
 	pushBranch := c.String(PushBranchKey)
 	prSourceBranch := c.String(PRSourceBranchKey)
 	prTargetBranch := c.String(PRTargetBranchKey)
+	isDraftPR := false
+	if c.IsSet(DraftPRKey) {
+		isDraftPR = c.Bool(DraftPRKey)
+	}
 	tag := c.String(TagKey)
 
 	bitriseConfigBase64Data := c.String(ConfigBase64Key)
@@ -105,7 +109,7 @@ func triggerCheck(c *cli.Context) error {
 
 	triggerParams, err := parseTriggerCheckParams(
 		triggerPattern,
-		pushBranch, prSourceBranch, prTargetBranch, tag,
+		pushBranch, prSourceBranch, prTargetBranch, isDraftPR, tag,
 		format,
 		bitriseConfigPath, bitriseConfigBase64Data,
 		inventoryPath, inventoryBase64Data,

--- a/models/trigger_map.go
+++ b/models/trigger_map.go
@@ -21,9 +21,9 @@ func (triggerMap TriggerMapModel) Validate(workflows, pipelines []string) ([]str
 	return warnings, nil
 }
 
-func (triggerMap TriggerMapModel) FirstMatchingTarget(pushBranch, prSourceBranch, prTargetBranch, tag string) (string, string, error) {
+func (triggerMap TriggerMapModel) FirstMatchingTarget(pushBranch, prSourceBranch, prTargetBranch string, isDraftPR bool, tag string) (string, string, error) {
 	for _, item := range triggerMap {
-		match, err := item.MatchWithParams(pushBranch, prSourceBranch, prTargetBranch, tag)
+		match, err := item.MatchWithParams(pushBranch, prSourceBranch, prTargetBranch, isDraftPR, tag)
 		if err != nil {
 			return "", "", err
 		}

--- a/models/trigger_map.go
+++ b/models/trigger_map.go
@@ -36,17 +36,17 @@ func (triggerMap TriggerMapModel) FirstMatchingTarget(pushBranch, prSourceBranch
 }
 
 func (triggerMap TriggerMapModel) checkDuplicatedTriggerMapItems() error {
-	for i := 0; i < len(triggerMap); i++ {
-		triggerItemI := triggerMap[i]
+	items := make(map[string]struct{})
 
-		for j := i + 1; j < len(triggerMap); j++ {
-			triggerItemJ := triggerMap[j]
+	for _, triggerItem := range triggerMap {
+		content := triggerItem.String(false)
 
-			if triggerItemI.String(false) == triggerItemJ.String(false) {
-				return fmt.Errorf("duplicated trigger item found (%s)", triggerItemI.String(false))
-			}
-
+		_, ok := items[content]
+		if ok {
+			return fmt.Errorf("duplicated trigger item found (%s)", content)
 		}
+
+		items[content] = struct{}{}
 	}
 
 	return nil

--- a/models/trigger_map.go
+++ b/models/trigger_map.go
@@ -36,49 +36,16 @@ func (triggerMap TriggerMapModel) FirstMatchingTarget(pushBranch, prSourceBranch
 }
 
 func (triggerMap TriggerMapModel) checkDuplicatedTriggerMapItems() error {
-	triggerTypeItemMap := map[string][]TriggerMapItemModel{}
+	for i := 0; i < len(triggerMap); i++ {
+		triggerItemI := triggerMap[i]
 
-	for _, triggerItem := range triggerMap {
-		if triggerItem.Pattern == "" {
-			triggerType, err := triggerEventType(triggerItem.PushBranch, triggerItem.PullRequestSourceBranch, triggerItem.PullRequestTargetBranch, triggerItem.Tag)
-			if err != nil {
-				return fmt.Errorf("trigger map item (%v) validate failed, error: %s", triggerItem, err)
+		for j := i + 1; j < len(triggerMap); j++ {
+			triggerItemJ := triggerMap[j]
+
+			if triggerItemI.String(false) == triggerItemJ.String(false) {
+				return fmt.Errorf("duplicated trigger item found (%s)", triggerItemI.String(false))
 			}
 
-			triggerItems := triggerTypeItemMap[string(triggerType)]
-
-			for _, item := range triggerItems {
-				switch triggerType {
-				case TriggerEventTypeCodePush:
-					if triggerItem.PushBranch == item.PushBranch {
-						return fmt.Errorf("duplicated trigger item found (%s)", triggerItem.String(false))
-					}
-				case TriggerEventTypePullRequest:
-					if triggerItem.PullRequestSourceBranch == item.PullRequestSourceBranch &&
-						triggerItem.PullRequestTargetBranch == item.PullRequestTargetBranch {
-						return fmt.Errorf("duplicated trigger item found (%s)", triggerItem.String(false))
-					}
-				case TriggerEventTypeTag:
-					if triggerItem.Tag == item.Tag {
-						return fmt.Errorf("duplicated trigger item found (%s)", triggerItem.String(false))
-					}
-				}
-			}
-
-			triggerItems = append(triggerItems, triggerItem)
-			triggerTypeItemMap[string(triggerType)] = triggerItems
-		} else if triggerItem.Pattern != "" {
-			triggerItems := triggerTypeItemMap["deprecated"]
-
-			for _, item := range triggerItems {
-				if triggerItem.Pattern == item.Pattern &&
-					triggerItem.IsPullRequestAllowed == item.IsPullRequestAllowed {
-					return fmt.Errorf("duplicated trigger item found (%s)", triggerItem.String(false))
-				}
-			}
-
-			triggerItems = append(triggerItems, triggerItem)
-			triggerTypeItemMap["deprecated"] = triggerItems
 		}
 	}
 

--- a/models/trigger_map_item.go
+++ b/models/trigger_map_item.go
@@ -16,15 +16,22 @@ const (
 	TriggerEventTypeUnknown     TriggerEventType = "unknown"
 )
 
+const defaultDraftPullRequestEnabled = true
+
 type TriggerMapItemModel struct {
-	PushBranch              string `json:"push_branch,omitempty" yaml:"push_branch,omitempty"`
+	// Trigger target
+	PipelineID string `json:"pipeline,omitempty" yaml:"pipeline,omitempty"`
+	WorkflowID string `json:"workflow,omitempty" yaml:"workflow,omitempty"`
+	// Commit push event criteria
+	PushBranch string `json:"push_branch,omitempty" yaml:"push_branch,omitempty"`
+	// Tag push event criteria
+	Tag string `json:"tag,omitempty" yaml:"tag,omitempty"`
+	// Pull Request event criteria
 	PullRequestSourceBranch string `json:"pull_request_source_branch,omitempty" yaml:"pull_request_source_branch,omitempty"`
 	PullRequestTargetBranch string `json:"pull_request_target_branch,omitempty" yaml:"pull_request_target_branch,omitempty"`
-	Tag                     string `json:"tag,omitempty" yaml:"tag,omitempty"`
-	PipelineID              string `json:"pipeline,omitempty" yaml:"pipeline,omitempty"`
-	WorkflowID              string `json:"workflow,omitempty" yaml:"workflow,omitempty"`
+	DraftPullRequestEnabled *bool  `json:"draft_pull_request_enabled,omitempty" yaml:"draft_pull_request_enabled,omitempty"`
 
-	// deprecated
+	// Deprecated
 	Pattern              string `json:"pattern,omitempty" yaml:"pattern,omitempty"`
 	IsPullRequestAllowed bool   `json:"is_pull_request_allowed,omitempty" yaml:"is_pull_request_allowed,omitempty"`
 }
@@ -155,6 +162,13 @@ func (triggerItem TriggerMapItemModel) String(printTarget bool) string {
 
 			str += fmt.Sprintf("pull_request_target_branch: %s", triggerItem.PullRequestTargetBranch)
 		}
+
+		draftPullRequestEnabled := defaultDraftPullRequestEnabled
+		if triggerItem.DraftPullRequestEnabled != nil {
+			draftPullRequestEnabled = *triggerItem.DraftPullRequestEnabled
+		}
+
+		str += fmt.Sprintf(" && draft_pull_request_enabled: %v", draftPullRequestEnabled)
 	}
 
 	if triggerItem.Tag != "" {

--- a/models/trigger_map_item.go
+++ b/models/trigger_map_item.go
@@ -41,10 +41,10 @@ func (triggerItem TriggerMapItemModel) Validate(workflows, pipelines []string) (
 
 	// Validate target
 	if triggerItem.PipelineID != "" && triggerItem.WorkflowID != "" {
-		return warnings, fmt.Errorf("invalid trigger item: (%s), error: pipeline & workflow both defined", triggerItem.Pattern)
+		return warnings, fmt.Errorf("invalid trigger item: (%s), error: pipeline & workflow both defined", triggerItem.Pattern) // TODO: update error message (triggerItem.Pattern might empty)
 	}
 	if triggerItem.PipelineID == "" && triggerItem.WorkflowID == "" {
-		return warnings, fmt.Errorf("invalid trigger item: (%s), error: empty pipeline & workflow", triggerItem.Pattern)
+		return warnings, fmt.Errorf("invalid trigger item: (%s), error: empty pipeline & workflow", triggerItem.Pattern) // TODO: update error message (triggerItem.Pattern might empty)
 	}
 
 	if strings.HasPrefix(triggerItem.WorkflowID, "_") {

--- a/models/trigger_map_item.go
+++ b/models/trigger_map_item.go
@@ -90,7 +90,7 @@ func (triggerItem TriggerMapItemModel) Validate(workflows, pipelines []string) (
 	return warnings, nil
 }
 
-func (triggerItem TriggerMapItemModel) MatchWithParams(pushBranch, prSourceBranch, prTargetBranch, tag string) (bool, error) {
+func (triggerItem TriggerMapItemModel) MatchWithParams(pushBranch, prSourceBranch, prTargetBranch string, isDraftPR bool, tag string) (bool, error) {
 	paramsEventType, err := triggerEventType(pushBranch, prSourceBranch, prTargetBranch, tag)
 	if err != nil {
 		return false, err
@@ -130,7 +130,12 @@ func (triggerItem TriggerMapItemModel) MatchWithParams(pushBranch, prSourceBranc
 				targetMatch = glob.Glob(migratedTriggerItem.PullRequestTargetBranch, prTargetBranch)
 			}
 
-			return (sourceMatch && targetMatch), nil
+			prStateMatch := true
+			if !migratedTriggerItem.IsDraftPullRequestEnabled() && isDraftPR {
+				prStateMatch = false
+			}
+
+			return sourceMatch && targetMatch && prStateMatch, nil
 		case TriggerEventTypeTag:
 			match := glob.Glob(migratedTriggerItem.Tag, tag)
 			return match, nil

--- a/models/trigger_map_item.go
+++ b/models/trigger_map_item.go
@@ -41,10 +41,10 @@ func (triggerItem TriggerMapItemModel) Validate(workflows, pipelines []string) (
 
 	// Validate target
 	if triggerItem.PipelineID != "" && triggerItem.WorkflowID != "" {
-		return warnings, fmt.Errorf("invalid trigger item: (%s), error: pipeline & workflow both defined", triggerItem.Pattern) // TODO: update error message (triggerItem.Pattern might empty)
+		return warnings, fmt.Errorf("both pipeline and workflow are defined as trigger target: %s", triggerItem.String(false))
 	}
 	if triggerItem.PipelineID == "" && triggerItem.WorkflowID == "" {
-		return warnings, fmt.Errorf("invalid trigger item: (%s), error: empty pipeline & workflow", triggerItem.Pattern) // TODO: update error message (triggerItem.Pattern might empty)
+		return warnings, fmt.Errorf("no pipeline nor workflow is defined as a trigger target: %s", triggerItem.String(false))
 	}
 
 	if strings.HasPrefix(triggerItem.WorkflowID, "_") {

--- a/models/trigger_map_item.go
+++ b/models/trigger_map_item.go
@@ -140,6 +140,14 @@ func (triggerItem TriggerMapItemModel) MatchWithParams(pushBranch, prSourceBranc
 	return false, nil
 }
 
+func (triggerItem TriggerMapItemModel) IsDraftPullRequestEnabled() bool {
+	draftPullRequestEnabled := defaultDraftPullRequestEnabled
+	if triggerItem.DraftPullRequestEnabled != nil {
+		draftPullRequestEnabled = *triggerItem.DraftPullRequestEnabled
+	}
+	return draftPullRequestEnabled
+}
+
 func (triggerItem TriggerMapItemModel) String(printTarget bool) string {
 	str := ""
 
@@ -163,12 +171,7 @@ func (triggerItem TriggerMapItemModel) String(printTarget bool) string {
 			str += fmt.Sprintf("pull_request_target_branch: %s", triggerItem.PullRequestTargetBranch)
 		}
 
-		draftPullRequestEnabled := defaultDraftPullRequestEnabled
-		if triggerItem.DraftPullRequestEnabled != nil {
-			draftPullRequestEnabled = *triggerItem.DraftPullRequestEnabled
-		}
-
-		str += fmt.Sprintf(" && draft_pull_request_enabled: %v", draftPullRequestEnabled)
+		str += fmt.Sprintf(" && draft_pull_request_enabled: %v", triggerItem.IsDraftPullRequestEnabled())
 	}
 
 	if triggerItem.Tag != "" {

--- a/models/trigger_map_item_test.go
+++ b/models/trigger_map_item_test.go
@@ -580,7 +580,7 @@ func TestMatchWithParamsTagTypeItem(t *testing.T) {
 }
 
 func TestTriggerEventType(t *testing.T) {
-	t.Log("it determins trigger event type")
+	t.Log("it determines trigger event type")
 	{
 		pushBranch := "master"
 		prSourceBranch := ""
@@ -592,7 +592,7 @@ func TestTriggerEventType(t *testing.T) {
 		require.Equal(t, TriggerEventTypeCodePush, event)
 	}
 
-	t.Log("it determins trigger event type")
+	t.Log("it determines trigger event type")
 	{
 		pushBranch := ""
 		prSourceBranch := "develop"
@@ -604,7 +604,7 @@ func TestTriggerEventType(t *testing.T) {
 		require.Equal(t, TriggerEventTypePullRequest, event)
 	}
 
-	t.Log("it determins trigger event type")
+	t.Log("it determines trigger event type")
 	{
 		pushBranch := ""
 		prSourceBranch := ""
@@ -616,7 +616,7 @@ func TestTriggerEventType(t *testing.T) {
 		require.Equal(t, TriggerEventTypePullRequest, event)
 	}
 
-	t.Log("it determins trigger event type")
+	t.Log("it determines trigger event type")
 	{
 		pushBranch := ""
 		prSourceBranch := ""

--- a/models/trigger_map_item_test.go
+++ b/models/trigger_map_item_test.go
@@ -7,254 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestTriggerMapItemValidate(t *testing.T) {
-	t.Log("utility workflow triggered - Warning")
-	{
-		configStr := `
-format_version: 1.3.1
-default_step_lib_source: "https://github.com/bitrise-io/bitrise-steplib.git"
-
-trigger_map:
-- push_branch: "/release"
-  workflow: _deps-update
-
-workflows:
-  _deps-update:
-`
-
-		config, err := configModelFromYAMLBytes([]byte(configStr))
-		require.NoError(t, err)
-
-		warnings, err := config.Validate()
-		require.NoError(t, err)
-		require.Equal(t, []string{"workflow (_deps-update) defined in trigger item (push_branch: /release -> workflow: _deps-update), but utility workflows can't be triggered directly"}, warnings)
-	}
-
-	t.Log("pipeline not exists")
-	{
-		configStr := `
-format_version: 1.3.1
-default_step_lib_source: "https://github.com/bitrise-io/bitrise-steplib.git"
-
-trigger_map:
-- push_branch: "/release"
-  pipeline: release
-
-pipelines:
-  primary:
-    stages:
-    - ci-stage: {}
-
-stages:
-  ci-stage:
-    workflows:
-    - ci: {}
-
-workflows:
-  ci:
-`
-
-		config, err := configModelFromYAMLBytes([]byte(configStr))
-		require.NoError(t, err)
-
-		_, err = config.Validate()
-		require.EqualError(t, err, "pipeline (release) defined in trigger item (push_branch: /release -> pipeline: release), but does not exist")
-	}
-
-	t.Log("workflow not exists")
-	{
-		configStr := `
-format_version: 1.3.1
-default_step_lib_source: "https://github.com/bitrise-io/bitrise-steplib.git"
-
-trigger_map:
-- push_branch: "/release"
-  workflow: release
-
-workflows:
-  ci:
-`
-
-		config, err := configModelFromYAMLBytes([]byte(configStr))
-		require.NoError(t, err)
-
-		_, err = config.Validate()
-		require.EqualError(t, err, "workflow (release) defined in trigger item (push_branch: /release -> workflow: release), but does not exist")
-	}
-
-	t.Log("it validates deprecated trigger item with triggered pipeline")
-	{
-		item := TriggerMapItemModel{
-			Pattern:    "*",
-			PipelineID: "primary",
-		}
-		_, err := item.Validate(nil, []string{"primary"})
-		require.NoError(t, err)
-	}
-
-	t.Log("it validates deprecated trigger item with triggered workflow")
-	{
-		item := TriggerMapItemModel{
-			Pattern:    "*",
-			WorkflowID: "primary",
-		}
-		_, err := item.Validate([]string{"primary"}, nil)
-		require.NoError(t, err)
-	}
-
-	t.Log("it fails for invalid deprecated trigger item - pipeline & workflow both defined")
-	{
-		item := TriggerMapItemModel{
-			Pattern:    "*",
-			PipelineID: "pipeline-1",
-			WorkflowID: "workflow-1",
-		}
-		_, err := item.Validate([]string{"pipeline-1"}, []string{"workflow-1"})
-		require.Error(t, err)
-	}
-
-	t.Log("it fails for invalid deprecated trigger item - missing pipeline & workflow")
-	{
-		item := TriggerMapItemModel{
-			Pattern: "*",
-		}
-		_, err := item.Validate([]string{"pipeline-1"}, []string{"workflow-1"})
-		require.Error(t, err)
-	}
-
-	t.Log("it fails for invalid deprecated trigger item - missing pattern")
-	{
-		item := TriggerMapItemModel{
-			Pattern:    "",
-			WorkflowID: "primary",
-		}
-		_, err := item.Validate([]string{"primary"}, nil)
-		require.Error(t, err)
-	}
-
-	t.Log("it validates code-push trigger item with triggered pipeline")
-	{
-		item := TriggerMapItemModel{
-			PushBranch: "*",
-			PipelineID: "primary",
-		}
-		_, err := item.Validate(nil, []string{"primary"})
-		require.NoError(t, err)
-	}
-
-	t.Log("it validates code-push trigger item with triggered workflow")
-	{
-		item := TriggerMapItemModel{
-			PushBranch: "*",
-			WorkflowID: "primary",
-		}
-		_, err := item.Validate([]string{"primary"}, nil)
-		require.NoError(t, err)
-	}
-
-	t.Log("it fails for invalid code-push trigger item - missing push-branch")
-	{
-		item := TriggerMapItemModel{
-			PushBranch: "",
-			WorkflowID: "primary",
-		}
-		_, err := item.Validate([]string{"primary"}, nil)
-		require.Error(t, err)
-	}
-
-	t.Log("it fails for invalid code-push trigger item - missing pipeline & workflow")
-	{
-		item := TriggerMapItemModel{
-			PushBranch: "*",
-		}
-		_, err := item.Validate([]string{"primary"}, nil)
-		require.Error(t, err)
-	}
-
-	t.Log("it validates pull-request trigger item with triggered pipeline")
-	{
-		item := TriggerMapItemModel{
-			PullRequestSourceBranch: "feature/",
-			PipelineID:              "primary",
-		}
-		_, err := item.Validate(nil, []string{"primary"})
-		require.NoError(t, err)
-	}
-
-	t.Log("it validates pull-request trigger item with triggered workflow")
-	{
-		item := TriggerMapItemModel{
-			PullRequestSourceBranch: "feature/",
-			WorkflowID:              "primary",
-		}
-		_, err := item.Validate([]string{"primary"}, nil)
-		require.NoError(t, err)
-	}
-
-	t.Log("it validates pull-request trigger item with triggered pipeline")
-	{
-		item := TriggerMapItemModel{
-			PullRequestTargetBranch: "master",
-			PipelineID:              "primary",
-		}
-		_, err := item.Validate(nil, []string{"primary"})
-		require.NoError(t, err)
-	}
-
-	t.Log("it validates pull-request trigger item with triggered workflow")
-	{
-		item := TriggerMapItemModel{
-			PullRequestTargetBranch: "master",
-			WorkflowID:              "primary",
-		}
-		_, err := item.Validate([]string{"primary"}, nil)
-		require.NoError(t, err)
-	}
-
-	t.Log("it fails for invalid pull-request trigger item - missing pipeline & workflow")
-	{
-		item := TriggerMapItemModel{
-			PullRequestTargetBranch: "*",
-		}
-		_, err := item.Validate([]string{"primary"}, nil)
-		require.Error(t, err)
-	}
-
-	t.Log("it fails for invalid pull-request trigger item - missing pipeline & workflow")
-	{
-		item := TriggerMapItemModel{
-			PullRequestSourceBranch: "",
-			PullRequestTargetBranch: "",
-		}
-		_, err := item.Validate([]string{"primary"}, nil)
-		require.Error(t, err)
-	}
-
-	t.Log("it fails for mixed trigger item")
-	{
-		item := TriggerMapItemModel{
-			PushBranch:              "master",
-			PullRequestSourceBranch: "feature/*",
-			PullRequestTargetBranch: "",
-			WorkflowID:              "primary",
-		}
-		_, err := item.Validate([]string{"primary"}, nil)
-		require.Error(t, err)
-	}
-
-	t.Log("it fails for mixed trigger item")
-	{
-		item := TriggerMapItemModel{
-			PushBranch: "master",
-			Pattern:    "*",
-			WorkflowID: "primary",
-		}
-		_, err := item.Validate([]string{"primary"}, nil)
-		require.Error(t, err)
-	}
-}
-
-func TestMatchWithParamsCodePushItem(t *testing.T) {
+func TestTriggerMapItemModel_MatchWithParams_CodePushParams(t *testing.T) {
 	t.Log("The following patterns are all matches")
 	{
 		for aPattern, aPushBranch := range map[string]string{
@@ -503,7 +256,7 @@ func TestTriggerMapItemModel_MatchWithParams_PRParams(t *testing.T) {
 	}
 }
 
-func TestMatchWithParamsTagTypeItem(t *testing.T) {
+func TestTriggerMapItemModel_MatchWithParams_TagParams(t *testing.T) {
 	t.Log("tag against tag type item - MATCH")
 	{
 		pushBranch := ""
@@ -582,104 +335,6 @@ func TestMatchWithParamsTagTypeItem(t *testing.T) {
 		match, err := item.MatchWithParams(pushBranch, prSourceBranch, prTargetBranch, false, tag)
 		require.NoError(t, err)
 		require.Equal(t, false, match)
-	}
-}
-
-func TestTriggerEventType(t *testing.T) {
-	t.Log("it determines trigger event type")
-	{
-		pushBranch := "master"
-		prSourceBranch := ""
-		prTargetBranch := ""
-		tag := ""
-
-		event, err := triggerEventType(pushBranch, prSourceBranch, prTargetBranch, tag)
-		require.NoError(t, err)
-		require.Equal(t, TriggerEventTypeCodePush, event)
-	}
-
-	t.Log("it determines trigger event type")
-	{
-		pushBranch := ""
-		prSourceBranch := "develop"
-		prTargetBranch := ""
-		tag := ""
-
-		event, err := triggerEventType(pushBranch, prSourceBranch, prTargetBranch, tag)
-		require.NoError(t, err)
-		require.Equal(t, TriggerEventTypePullRequest, event)
-	}
-
-	t.Log("it determines trigger event type")
-	{
-		pushBranch := ""
-		prSourceBranch := ""
-		prTargetBranch := "master"
-		tag := ""
-
-		event, err := triggerEventType(pushBranch, prSourceBranch, prTargetBranch, tag)
-		require.NoError(t, err)
-		require.Equal(t, TriggerEventTypePullRequest, event)
-	}
-
-	t.Log("it determines trigger event type")
-	{
-		pushBranch := ""
-		prSourceBranch := ""
-		prTargetBranch := ""
-		tag := "0.9.0"
-
-		event, err := triggerEventType(pushBranch, prSourceBranch, prTargetBranch, tag)
-		require.NoError(t, err)
-		require.Equal(t, TriggerEventTypeTag, event)
-	}
-
-	t.Log("it fails without inputs")
-	{
-		pushBranch := ""
-		prSourceBranch := ""
-		prTargetBranch := ""
-		tag := ""
-
-		event, err := triggerEventType(pushBranch, prSourceBranch, prTargetBranch, tag)
-		require.Error(t, err)
-		require.Equal(t, TriggerEventTypeUnknown, event)
-	}
-
-	t.Log("it fails if event type not clear")
-	{
-		pushBranch := "master"
-		prSourceBranch := "develop"
-		prTargetBranch := ""
-		tag := ""
-
-		event, err := triggerEventType(pushBranch, prSourceBranch, prTargetBranch, tag)
-		require.Error(t, err)
-		require.Equal(t, TriggerEventTypeUnknown, event)
-	}
-
-	t.Log("it fails if event type not clear")
-	{
-		pushBranch := "master"
-		prSourceBranch := ""
-		prTargetBranch := "master"
-		tag := ""
-
-		event, err := triggerEventType(pushBranch, prSourceBranch, prTargetBranch, tag)
-		require.Error(t, err)
-		require.Equal(t, TriggerEventTypeUnknown, event)
-	}
-
-	t.Log("it fails if event type not clear")
-	{
-		pushBranch := "master"
-		prSourceBranch := ""
-		prTargetBranch := ""
-		tag := "0.9.0"
-
-		event, err := triggerEventType(pushBranch, prSourceBranch, prTargetBranch, tag)
-		require.Error(t, err)
-		require.Equal(t, TriggerEventTypeUnknown, event)
 	}
 }
 
@@ -796,5 +451,268 @@ func TestTriggerMapItemModel_String(t *testing.T) {
 			require.Equal(t, tt.want, tt.triggerMapItem.String(false))
 			require.Equal(t, tt.wantWithPrintTarget, tt.triggerMapItem.String(true))
 		})
+	}
+}
+
+func TestTriggerMapItemModel_Validate(t *testing.T) {
+	tests := []struct {
+		name           string
+		triggerMapItem TriggerMapItemModel
+		workflows      []string
+		pipelines      []string
+		wantWarns      []string
+		wantErr        string
+	}{
+		{
+			name: "it validates deprecated trigger item with triggered pipeline",
+			triggerMapItem: TriggerMapItemModel{
+				Pattern:    "*",
+				PipelineID: "primary",
+			},
+			pipelines: []string{"primary"},
+		},
+		{
+			name: "it validates deprecated trigger item with triggered workflow",
+			triggerMapItem: TriggerMapItemModel{
+				Pattern:    "*",
+				WorkflowID: "primary",
+			},
+			workflows: []string{"primary"},
+		},
+		{
+			name: "it fails for invalid deprecated trigger item - pipeline & workflow both defined",
+			triggerMapItem: TriggerMapItemModel{
+				Pattern:    "*",
+				PipelineID: "pipeline-1",
+				WorkflowID: "workflow-1",
+			},
+			workflows: []string{"pipeline-1", "workflow-1"},
+			wantErr:   "invalid trigger item: (*), error: pipeline & workflow both defined",
+		},
+		{
+			name: "it fails for invalid deprecated trigger item - missing pipeline & workflow",
+			triggerMapItem: TriggerMapItemModel{
+				Pattern: "*",
+			},
+			wantErr: "invalid trigger item: (*), error: empty pipeline & workflow",
+		},
+		{
+			name: "it fails for invalid deprecated trigger item - missing pattern",
+			triggerMapItem: TriggerMapItemModel{
+				Pattern:    "",
+				WorkflowID: "primary",
+			},
+			workflows: []string{"primary"},
+			wantErr:   "trigger map item ( -> workflow: primary) validate failed, error: failed to determin trigger event from params: push-branch: , pr-source-branch: , pr-target-branch: , tag: ",
+		},
+		{
+			name: "it validates code-push trigger item with triggered pipeline",
+			triggerMapItem: TriggerMapItemModel{
+				PushBranch: "*",
+				PipelineID: "primary",
+			},
+			pipelines: []string{"primary"},
+		},
+		{
+			name: "it validates code-push trigger item with triggered workflow",
+			triggerMapItem: TriggerMapItemModel{
+				PushBranch: "*",
+				WorkflowID: "primary",
+			},
+			workflows: []string{"primary"},
+		},
+		{
+			name: "it fails for invalid code-push trigger item - missing push-branch",
+			triggerMapItem: TriggerMapItemModel{
+				PushBranch: "",
+				WorkflowID: "primary",
+			},
+			workflows: []string{"primary"},
+			wantErr:   "trigger map item ( -> workflow: primary) validate failed, error: failed to determin trigger event from params: push-branch: , pr-source-branch: , pr-target-branch: , tag: ",
+		},
+		{
+			name: "it fails for invalid code-push trigger item - missing pipeline & workflow",
+			triggerMapItem: TriggerMapItemModel{
+				PushBranch: "*",
+			},
+			wantErr: "invalid trigger item: (), error: empty pipeline & workflow",
+		},
+		{
+			name: "it validates pull-request trigger item (with source branch) with triggered pipeline",
+			triggerMapItem: TriggerMapItemModel{
+				PullRequestSourceBranch: "feature/",
+				PipelineID:              "primary",
+			},
+			pipelines: []string{"primary"},
+		},
+		{
+			name: "it validates pull-request trigger item (with source branch) with triggered workflow",
+			triggerMapItem: TriggerMapItemModel{
+				PullRequestSourceBranch: "feature/",
+				WorkflowID:              "primary",
+			},
+			workflows: []string{"primary"},
+		},
+		{
+			name: "it validates pull-request trigger item (with target branch) with triggered pipeline",
+			triggerMapItem: TriggerMapItemModel{
+				PullRequestTargetBranch: "master",
+				PipelineID:              "primary",
+			},
+			pipelines: []string{"primary"},
+		},
+		{
+			name: "it validates pull-request trigger item (with target branch) with triggered workflow",
+			triggerMapItem: TriggerMapItemModel{
+				PullRequestTargetBranch: "master",
+				WorkflowID:              "primary",
+			},
+			workflows: []string{"primary"},
+		},
+		{
+			name: "it fails for invalid pull-request trigger item (target branch set) - missing pipeline & workflow",
+			triggerMapItem: TriggerMapItemModel{
+				PullRequestTargetBranch: "*",
+			},
+			wantErr: "invalid trigger item: (), error: empty pipeline & workflow",
+		},
+		{
+			name: "it fails for invalid pull-request trigger item (target and source branch set) - missing pipeline & workflow",
+			triggerMapItem: TriggerMapItemModel{
+				PullRequestSourceBranch: "",
+				PullRequestTargetBranch: "",
+			},
+			wantErr: "invalid trigger item: (), error: empty pipeline & workflow",
+		},
+		{
+			name: "it fails for mixed (mixed types) trigger item",
+			triggerMapItem: TriggerMapItemModel{
+				PushBranch:              "master",
+				PullRequestSourceBranch: "feature/*",
+				PullRequestTargetBranch: "",
+				WorkflowID:              "primary",
+			},
+			workflows: []string{"primary"},
+			wantErr:   "trigger map item (push_branch: master pull_request_source_branch: feature/* && draft_pull_request_enabled: true -> workflow: primary) validate failed, error: push_branch (master) selects code-push trigger event, but pull_request_source_branch (feature/*) also provided",
+		},
+		{
+			name: "it fails for mixed (mixed new and legacy properties) trigger item",
+			triggerMapItem: TriggerMapItemModel{
+				PushBranch: "master",
+				Pattern:    "*",
+				WorkflowID: "primary",
+			},
+			workflows: []string{"primary"},
+			wantErr:   "deprecated trigger item (pattern defined), mixed with trigger params (push_branch: master, pull_request_source_branch: , pull_request_target_branch: , tag: )",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			warns, err := tt.triggerMapItem.Validate(tt.workflows, tt.pipelines)
+			if tt.wantErr != "" {
+				require.EqualError(t, err, tt.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+			require.Equal(t, tt.wantWarns, warns)
+		})
+	}
+}
+
+func TestTriggerEventType(t *testing.T) {
+	t.Log("it determines trigger event type")
+	{
+		pushBranch := "master"
+		prSourceBranch := ""
+		prTargetBranch := ""
+		tag := ""
+
+		event, err := triggerEventType(pushBranch, prSourceBranch, prTargetBranch, tag)
+		require.NoError(t, err)
+		require.Equal(t, TriggerEventTypeCodePush, event)
+	}
+
+	t.Log("it determines trigger event type")
+	{
+		pushBranch := ""
+		prSourceBranch := "develop"
+		prTargetBranch := ""
+		tag := ""
+
+		event, err := triggerEventType(pushBranch, prSourceBranch, prTargetBranch, tag)
+		require.NoError(t, err)
+		require.Equal(t, TriggerEventTypePullRequest, event)
+	}
+
+	t.Log("it determines trigger event type")
+	{
+		pushBranch := ""
+		prSourceBranch := ""
+		prTargetBranch := "master"
+		tag := ""
+
+		event, err := triggerEventType(pushBranch, prSourceBranch, prTargetBranch, tag)
+		require.NoError(t, err)
+		require.Equal(t, TriggerEventTypePullRequest, event)
+	}
+
+	t.Log("it determines trigger event type")
+	{
+		pushBranch := ""
+		prSourceBranch := ""
+		prTargetBranch := ""
+		tag := "0.9.0"
+
+		event, err := triggerEventType(pushBranch, prSourceBranch, prTargetBranch, tag)
+		require.NoError(t, err)
+		require.Equal(t, TriggerEventTypeTag, event)
+	}
+
+	t.Log("it fails without inputs")
+	{
+		pushBranch := ""
+		prSourceBranch := ""
+		prTargetBranch := ""
+		tag := ""
+
+		event, err := triggerEventType(pushBranch, prSourceBranch, prTargetBranch, tag)
+		require.Error(t, err)
+		require.Equal(t, TriggerEventTypeUnknown, event)
+	}
+
+	t.Log("it fails if event type not clear")
+	{
+		pushBranch := "master"
+		prSourceBranch := "develop"
+		prTargetBranch := ""
+		tag := ""
+
+		event, err := triggerEventType(pushBranch, prSourceBranch, prTargetBranch, tag)
+		require.Error(t, err)
+		require.Equal(t, TriggerEventTypeUnknown, event)
+	}
+
+	t.Log("it fails if event type not clear")
+	{
+		pushBranch := "master"
+		prSourceBranch := ""
+		prTargetBranch := "master"
+		tag := ""
+
+		event, err := triggerEventType(pushBranch, prSourceBranch, prTargetBranch, tag)
+		require.Error(t, err)
+		require.Equal(t, TriggerEventTypeUnknown, event)
+	}
+
+	t.Log("it fails if event type not clear")
+	{
+		pushBranch := "master"
+		prSourceBranch := ""
+		prTargetBranch := ""
+		tag := "0.9.0"
+
+		event, err := triggerEventType(pushBranch, prSourceBranch, prTargetBranch, tag)
+		require.Error(t, err)
+		require.Equal(t, TriggerEventTypeUnknown, event)
 	}
 }

--- a/models/trigger_map_item_test.go
+++ b/models/trigger_map_item_test.go
@@ -273,7 +273,7 @@ func TestMatchWithParamsCodePushItem(t *testing.T) {
 				PushBranch: aPattern,
 				WorkflowID: "primary",
 			}
-			match, err := item.MatchWithParams(pushBranch, prSourceBranch, prTargetBranch, tag)
+			match, err := item.MatchWithParams(pushBranch, prSourceBranch, prTargetBranch, false, tag)
 			require.NoError(t, err)
 			require.Equal(t, true, match, "(pattern: %s) (branch: %s)", aPattern, aPushBranch)
 		}
@@ -290,7 +290,7 @@ func TestMatchWithParamsCodePushItem(t *testing.T) {
 			PushBranch: "deploy",
 			WorkflowID: "deploy",
 		}
-		match, err := item.MatchWithParams(pushBranch, prSourceBranch, prTargetBranch, tag)
+		match, err := item.MatchWithParams(pushBranch, prSourceBranch, prTargetBranch, false, tag)
 		require.NoError(t, err)
 		require.Equal(t, false, match)
 	}
@@ -306,7 +306,7 @@ func TestMatchWithParamsCodePushItem(t *testing.T) {
 			PullRequestSourceBranch: "develop",
 			WorkflowID:              "test",
 		}
-		match, err := item.MatchWithParams(pushBranch, prSourceBranch, prTargetBranch, tag)
+		match, err := item.MatchWithParams(pushBranch, prSourceBranch, prTargetBranch, false, tag)
 		require.NoError(t, err)
 		require.Equal(t, false, match)
 	}
@@ -322,7 +322,7 @@ func TestMatchWithParamsCodePushItem(t *testing.T) {
 			PullRequestTargetBranch: "master",
 			WorkflowID:              "primary",
 		}
-		match, err := item.MatchWithParams(pushBranch, prSourceBranch, prTargetBranch, tag)
+		match, err := item.MatchWithParams(pushBranch, prSourceBranch, prTargetBranch, false, tag)
 		require.NoError(t, err)
 		require.Equal(t, false, match)
 	}
@@ -339,12 +339,13 @@ func TestMatchWithParamsCodePushItem(t *testing.T) {
 			PullRequestTargetBranch: "master",
 			WorkflowID:              "primary",
 		}
-		match, err := item.MatchWithParams(pushBranch, prSourceBranch, prTargetBranch, tag)
+		match, err := item.MatchWithParams(pushBranch, prSourceBranch, prTargetBranch, false, tag)
 		require.NoError(t, err)
 		require.Equal(t, false, match)
 	}
 }
 
+// TODO: add test case for draft pr = true
 func TestMatchWithParamsPrTypeItem(t *testing.T) {
 	t.Log("pr against pr type item - MATCH")
 	{
@@ -358,7 +359,7 @@ func TestMatchWithParamsPrTypeItem(t *testing.T) {
 			PullRequestTargetBranch: "master",
 			WorkflowID:              "primary",
 		}
-		match, err := item.MatchWithParams(pushBranch, prSourceBranch, prTargetBranch, tag)
+		match, err := item.MatchWithParams(pushBranch, prSourceBranch, prTargetBranch, false, tag)
 		require.NoError(t, err)
 		require.Equal(t, true, match)
 	}
@@ -375,7 +376,7 @@ func TestMatchWithParamsPrTypeItem(t *testing.T) {
 			PullRequestTargetBranch: "develop",
 			WorkflowID:              "test",
 		}
-		match, err := item.MatchWithParams(pushBranch, prSourceBranch, prTargetBranch, tag)
+		match, err := item.MatchWithParams(pushBranch, prSourceBranch, prTargetBranch, false, tag)
 		require.NoError(t, err)
 		require.Equal(t, true, match)
 	}
@@ -392,7 +393,7 @@ func TestMatchWithParamsPrTypeItem(t *testing.T) {
 			PullRequestTargetBranch: "master",
 			WorkflowID:              "primary",
 		}
-		match, err := item.MatchWithParams(pushBranch, prSourceBranch, prTargetBranch, tag)
+		match, err := item.MatchWithParams(pushBranch, prSourceBranch, prTargetBranch, false, tag)
 		require.NoError(t, err)
 		require.Equal(t, true, match)
 	}
@@ -408,7 +409,7 @@ func TestMatchWithParamsPrTypeItem(t *testing.T) {
 			PullRequestTargetBranch: "master",
 			WorkflowID:              "primary",
 		}
-		match, err := item.MatchWithParams(pushBranch, prSourceBranch, prTargetBranch, tag)
+		match, err := item.MatchWithParams(pushBranch, prSourceBranch, prTargetBranch, false, tag)
 		require.NoError(t, err)
 		require.Equal(t, true, match)
 	}
@@ -424,7 +425,7 @@ func TestMatchWithParamsPrTypeItem(t *testing.T) {
 			PullRequestSourceBranch: "develop",
 			WorkflowID:              "primary",
 		}
-		match, err := item.MatchWithParams(pushBranch, prSourceBranch, prTargetBranch, tag)
+		match, err := item.MatchWithParams(pushBranch, prSourceBranch, prTargetBranch, false, tag)
 		require.NoError(t, err)
 		require.Equal(t, true, match)
 	}
@@ -440,7 +441,7 @@ func TestMatchWithParamsPrTypeItem(t *testing.T) {
 			PullRequestTargetBranch: "deploy_*",
 			WorkflowID:              "primary",
 		}
-		match, err := item.MatchWithParams(pushBranch, prSourceBranch, prTargetBranch, tag)
+		match, err := item.MatchWithParams(pushBranch, prSourceBranch, prTargetBranch, false, tag)
 		require.NoError(t, err)
 		require.Equal(t, true, match)
 	}
@@ -457,7 +458,7 @@ func TestMatchWithParamsPrTypeItem(t *testing.T) {
 			PullRequestTargetBranch: "deploy",
 			WorkflowID:              "primary",
 		}
-		match, err := item.MatchWithParams(pushBranch, prSourceBranch, prTargetBranch, tag)
+		match, err := item.MatchWithParams(pushBranch, prSourceBranch, prTargetBranch, false, tag)
 		require.NoError(t, err)
 		require.Equal(t, false, match)
 	}
@@ -474,7 +475,7 @@ func TestMatchWithParamsPrTypeItem(t *testing.T) {
 			PullRequestTargetBranch: "master",
 			WorkflowID:              "primary",
 		}
-		match, err := item.MatchWithParams(pushBranch, prSourceBranch, prTargetBranch, tag)
+		match, err := item.MatchWithParams(pushBranch, prSourceBranch, prTargetBranch, false, tag)
 		require.NoError(t, err)
 		require.Equal(t, false, match)
 	}
@@ -490,7 +491,7 @@ func TestMatchWithParamsPrTypeItem(t *testing.T) {
 			PushBranch: "master",
 			WorkflowID: "primary",
 		}
-		match, err := item.MatchWithParams(pushBranch, prSourceBranch, prTargetBranch, tag)
+		match, err := item.MatchWithParams(pushBranch, prSourceBranch, prTargetBranch, false, tag)
 		require.NoError(t, err)
 		require.Equal(t, false, match)
 	}
@@ -508,7 +509,7 @@ func TestMatchWithParamsTagTypeItem(t *testing.T) {
 			Tag:        "0.9.*",
 			WorkflowID: "deploy",
 		}
-		match, err := item.MatchWithParams(pushBranch, prSourceBranch, prTargetBranch, tag)
+		match, err := item.MatchWithParams(pushBranch, prSourceBranch, prTargetBranch, false, tag)
 		require.NoError(t, err)
 		require.Equal(t, true, match)
 	}
@@ -524,7 +525,7 @@ func TestMatchWithParamsTagTypeItem(t *testing.T) {
 			Tag:        "0.9.0",
 			WorkflowID: "deploy",
 		}
-		match, err := item.MatchWithParams(pushBranch, prSourceBranch, prTargetBranch, tag)
+		match, err := item.MatchWithParams(pushBranch, prSourceBranch, prTargetBranch, false, tag)
 		require.NoError(t, err)
 		require.Equal(t, true, match)
 	}
@@ -540,7 +541,7 @@ func TestMatchWithParamsTagTypeItem(t *testing.T) {
 			Tag:        "0.9.*",
 			WorkflowID: "deploy",
 		}
-		match, err := item.MatchWithParams(pushBranch, prSourceBranch, prTargetBranch, tag)
+		match, err := item.MatchWithParams(pushBranch, prSourceBranch, prTargetBranch, false, tag)
 		require.NoError(t, err)
 		require.Equal(t, true, match)
 	}
@@ -556,7 +557,7 @@ func TestMatchWithParamsTagTypeItem(t *testing.T) {
 			Tag:        "1.*",
 			WorkflowID: "deploy",
 		}
-		match, err := item.MatchWithParams(pushBranch, prSourceBranch, prTargetBranch, tag)
+		match, err := item.MatchWithParams(pushBranch, prSourceBranch, prTargetBranch, false, tag)
 		require.NoError(t, err)
 		require.Equal(t, false, match)
 	}
@@ -572,7 +573,7 @@ func TestMatchWithParamsTagTypeItem(t *testing.T) {
 			PushBranch: "master",
 			WorkflowID: "primary",
 		}
-		match, err := item.MatchWithParams(pushBranch, prSourceBranch, prTargetBranch, tag)
+		match, err := item.MatchWithParams(pushBranch, prSourceBranch, prTargetBranch, false, tag)
 		require.NoError(t, err)
 		require.Equal(t, false, match)
 	}

--- a/models/trigger_map_item_test.go
+++ b/models/trigger_map_item_test.go
@@ -412,7 +412,7 @@ func TestTriggerMapItemModel_String(t *testing.T) {
 			wantWithPrintTarget: "tag: 0.9.0 -> workflow: release",
 		},
 		{
-			name: "deprecated type - pr disabled", // TODO: should incorporate draft pr enabled control here?
+			name: "deprecated type - pr disabled",
 			triggerMapItem: TriggerMapItemModel{
 				Pattern:              "master",
 				IsPullRequestAllowed: false,
@@ -422,7 +422,7 @@ func TestTriggerMapItemModel_String(t *testing.T) {
 			wantWithPrintTarget: "pattern: master && is_pull_request_allowed: false -> workflow: ci",
 		},
 		{
-			name: "deprecated type - pr enabled", // TODO: should incorporate draft pr enabled control here?
+			name: "deprecated type - pr enabled",
 			triggerMapItem: TriggerMapItemModel{
 				Pattern:              "master",
 				IsPullRequestAllowed: true,
@@ -487,14 +487,14 @@ func TestTriggerMapItemModel_Validate(t *testing.T) {
 				WorkflowID: "workflow-1",
 			},
 			workflows: []string{"pipeline-1", "workflow-1"},
-			wantErr:   "invalid trigger item: (*), error: pipeline & workflow both defined",
+			wantErr:   "both pipeline and workflow are defined as trigger target: pattern: * && is_pull_request_allowed: false",
 		},
 		{
 			name: "it fails for invalid deprecated trigger item - missing pipeline & workflow",
 			triggerMapItem: TriggerMapItemModel{
 				Pattern: "*",
 			},
-			wantErr: "invalid trigger item: (*), error: empty pipeline & workflow",
+			wantErr: "no pipeline nor workflow is defined as a trigger target: pattern: * && is_pull_request_allowed: false",
 		},
 		{
 			name: "it fails for invalid deprecated trigger item - missing pattern",
@@ -535,7 +535,7 @@ func TestTriggerMapItemModel_Validate(t *testing.T) {
 			triggerMapItem: TriggerMapItemModel{
 				PushBranch: "*",
 			},
-			wantErr: "invalid trigger item: (), error: empty pipeline & workflow",
+			wantErr: "no pipeline nor workflow is defined as a trigger target: push_branch: *",
 		},
 		{
 			name: "it validates pull-request trigger item (with source branch) with triggered pipeline",
@@ -574,15 +574,15 @@ func TestTriggerMapItemModel_Validate(t *testing.T) {
 			triggerMapItem: TriggerMapItemModel{
 				PullRequestTargetBranch: "*",
 			},
-			wantErr: "invalid trigger item: (), error: empty pipeline & workflow",
+			wantErr: "no pipeline nor workflow is defined as a trigger target: pull_request_target_branch: * && draft_pull_request_enabled: true",
 		},
 		{
 			name: "it fails for invalid pull-request trigger item (target and source branch set) - missing pipeline & workflow",
 			triggerMapItem: TriggerMapItemModel{
-				PullRequestSourceBranch: "",
-				PullRequestTargetBranch: "",
+				PullRequestSourceBranch: "feature*",
+				PullRequestTargetBranch: "master",
 			},
-			wantErr: "invalid trigger item: (), error: empty pipeline & workflow",
+			wantErr: "no pipeline nor workflow is defined as a trigger target: pull_request_source_branch: feature* && pull_request_target_branch: master && draft_pull_request_enabled: true",
 		},
 		{
 			name: "it fails for mixed (mixed types) trigger item",

--- a/models/trigger_map_test.go
+++ b/models/trigger_map_test.go
@@ -26,6 +26,7 @@ func TestTriggerMapModel_Validate(t *testing.T) {
 				TriggerMapItemModel{
 					PullRequestSourceBranch: "develop",
 					PullRequestTargetBranch: "master",
+					DraftPullRequestEnabled: pointers.NewBoolPtr(false),
 					WorkflowID:              "ci",
 				},
 				TriggerMapItemModel{

--- a/models/trigger_map_test.go
+++ b/models/trigger_map_test.go
@@ -3,107 +3,9 @@ package models
 import (
 	"testing"
 
+	"github.com/bitrise-io/go-utils/pointers"
 	"github.com/stretchr/testify/require"
 )
-
-func TestCheckDuplicatedTriggerMapItems(t *testing.T) {
-	t.Log("duplicated push - error")
-	{
-		err := TriggerMapModel{
-			TriggerMapItemModel{
-				PushBranch: "master",
-				WorkflowID: "ci",
-			},
-			TriggerMapItemModel{
-				PushBranch: "master",
-				WorkflowID: "release",
-			},
-		}.checkDuplicatedTriggerMapItems()
-
-		require.EqualError(t, err, "duplicated trigger item found (push_branch: master)")
-	}
-
-	t.Log("duplicated pull request - error")
-	{
-		err := TriggerMapModel{
-			TriggerMapItemModel{
-				PullRequestSourceBranch: "develop",
-				WorkflowID:              "ci",
-			},
-			TriggerMapItemModel{
-				PullRequestSourceBranch: "develop",
-				WorkflowID:              "release",
-			},
-		}.checkDuplicatedTriggerMapItems()
-
-		require.EqualError(t, err, "duplicated trigger item found (pull_request_source_branch: develop)")
-
-		err = TriggerMapModel{
-			TriggerMapItemModel{
-				PullRequestTargetBranch: "master",
-				WorkflowID:              "ci",
-			},
-			TriggerMapItemModel{
-				PullRequestTargetBranch: "master",
-				WorkflowID:              "release",
-			},
-		}.checkDuplicatedTriggerMapItems()
-
-		require.EqualError(t, err, "duplicated trigger item found (pull_request_target_branch: master)")
-
-		err = TriggerMapModel{
-			TriggerMapItemModel{
-				PullRequestSourceBranch: "develop",
-				PullRequestTargetBranch: "master",
-				WorkflowID:              "ci",
-			},
-			TriggerMapItemModel{
-				PullRequestSourceBranch: "develop",
-				PullRequestTargetBranch: "master",
-				WorkflowID:              "release",
-			},
-		}.checkDuplicatedTriggerMapItems()
-
-		require.EqualError(t, err, "duplicated trigger item found (pull_request_source_branch: develop && pull_request_target_branch: master)")
-	}
-
-	t.Log("duplicated tag - error")
-	{
-		err := TriggerMapModel{
-			TriggerMapItemModel{
-				Tag:        "0.9.0",
-				WorkflowID: "ci",
-			},
-			TriggerMapItemModel{
-				Tag:        "0.9.0",
-				WorkflowID: "release",
-			},
-		}.checkDuplicatedTriggerMapItems()
-
-		require.EqualError(t, err, "duplicated trigger item found (tag: 0.9.0)")
-	}
-
-	t.Log("complex trigger map - no error")
-	{
-		err := TriggerMapModel{
-			TriggerMapItemModel{
-				PushBranch: "master",
-				WorkflowID: "ci",
-			},
-			TriggerMapItemModel{
-				PullRequestSourceBranch: "develop",
-				PullRequestTargetBranch: "master",
-				WorkflowID:              "ci",
-			},
-			TriggerMapItemModel{
-				Tag:        "0.9.0",
-				WorkflowID: "release",
-			},
-		}.checkDuplicatedTriggerMapItems()
-
-		require.NoError(t, err)
-	}
-}
 
 func TestTriggerMapModel_Validate(t *testing.T) {
 	tests := []struct {
@@ -115,7 +17,40 @@ func TestTriggerMapModel_Validate(t *testing.T) {
 		wantWarnings []string
 	}{
 		{
-			name: "duplicated push - error",
+			name: "Simple trigger items",
+			triggerMap: TriggerMapModel{
+				TriggerMapItemModel{
+					PushBranch: "master",
+					WorkflowID: "ci",
+				},
+				TriggerMapItemModel{
+					PullRequestSourceBranch: "develop",
+					PullRequestTargetBranch: "master",
+					WorkflowID:              "ci",
+				},
+				TriggerMapItemModel{
+					Tag:        "0.9.0",
+					WorkflowID: "release",
+				},
+			},
+			workflows: []string{"ci", "release"},
+		},
+		{
+			name: "Push trigger items",
+			triggerMap: TriggerMapModel{
+				TriggerMapItemModel{
+					PushBranch: "master",
+					WorkflowID: "ci",
+				},
+				TriggerMapItemModel{
+					PushBranch: "release",
+					WorkflowID: "release",
+				},
+			},
+			workflows: []string{"ci", "release"},
+		},
+		{
+			name: "Push trigger items - duplication",
 			triggerMap: TriggerMapModel{
 				TriggerMapItemModel{
 					PushBranch: "master",
@@ -130,7 +65,21 @@ func TestTriggerMapModel_Validate(t *testing.T) {
 			wantErr:   "duplicated trigger item found (push_branch: master)",
 		},
 		{
-			name: "duplicated pull request - error",
+			name: "Pull Request trigger items",
+			triggerMap: TriggerMapModel{
+				TriggerMapItemModel{
+					PullRequestSourceBranch: "feature*",
+					WorkflowID:              "ci",
+				},
+				TriggerMapItemModel{
+					PullRequestSourceBranch: "master",
+					WorkflowID:              "release",
+				},
+			},
+			workflows: []string{"ci", "release"},
+		},
+		{
+			name: "Pull Request trigger items - duplicated (source branch)",
 			triggerMap: TriggerMapModel{
 				TriggerMapItemModel{
 					PullRequestSourceBranch: "develop",
@@ -142,7 +91,72 @@ func TestTriggerMapModel_Validate(t *testing.T) {
 				},
 			},
 			workflows: []string{"ci", "release"},
-			wantErr:   "duplicated trigger item found (push_branch: master)",
+			wantErr:   "duplicated trigger item found (pull_request_source_branch: develop && draft_pull_request_enabled: true)",
+		},
+		{
+			name: "Pull Request trigger items - duplicated (target branch)",
+			triggerMap: TriggerMapModel{
+				TriggerMapItemModel{
+					PullRequestTargetBranch: "master",
+					WorkflowID:              "ci",
+				},
+				TriggerMapItemModel{
+					PullRequestTargetBranch: "master",
+					WorkflowID:              "release",
+				},
+			},
+			workflows: []string{"ci", "release"},
+			wantErr:   "duplicated trigger item found (pull_request_target_branch: master && draft_pull_request_enabled: true)",
+		},
+		{
+			name: "Pull Request trigger items - duplicated (source & target branch)",
+			triggerMap: TriggerMapModel{
+				TriggerMapItemModel{
+					PullRequestSourceBranch: "develop",
+					PullRequestTargetBranch: "master",
+					WorkflowID:              "ci",
+				},
+				TriggerMapItemModel{
+					PullRequestSourceBranch: "develop",
+					PullRequestTargetBranch: "master",
+					WorkflowID:              "release",
+				},
+			},
+			workflows: []string{"ci", "release"},
+			wantErr:   "duplicated trigger item found (pull_request_source_branch: develop && pull_request_target_branch: master && draft_pull_request_enabled: true)",
+		},
+		{
+			name: "Pull Request trigger items - different draft pr enabled",
+			triggerMap: TriggerMapModel{
+				TriggerMapItemModel{
+					PullRequestSourceBranch: "develop",
+					PullRequestTargetBranch: "master",
+					DraftPullRequestEnabled: pointers.NewBoolPtr(false),
+					WorkflowID:              "release",
+				},
+				TriggerMapItemModel{
+					PullRequestSourceBranch: "develop",
+					PullRequestTargetBranch: "master",
+					DraftPullRequestEnabled: pointers.NewBoolPtr(true),
+					WorkflowID:              "ci",
+				},
+			},
+			workflows: []string{"ci", "release"},
+		},
+		{
+			name: "Tag trigger items - duplicated",
+			triggerMap: TriggerMapModel{
+				TriggerMapItemModel{
+					Tag:        "0.9.0",
+					WorkflowID: "ci",
+				},
+				TriggerMapItemModel{
+					Tag:        "0.9.0",
+					WorkflowID: "release",
+				},
+			},
+			workflows: []string{"ci", "release"},
+			wantErr:   "duplicated trigger item found (tag: 0.9.0)",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
### Checklist

- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-io/bitrise/blob/master/.github/CONTRIBUTING.md)
- [x] `README.md` is updated with the changes (if needed)

### Version

Requires a *MINOR* [version update](https://semver.org/)

### Context

This PR introduces support for controlling whether a draft Pull Request should trigger a workflow run or not.
To disable the draft PR trigger set `draft_pull_request_enabled: false` on a Pull Request trigger item:

```
trigger_map:
- pull_request_source_branch: feature*
  pull_request_target_branch: main
  draft_pull_request_enabled: false
  workflow: ci
```

By default (when `draft_pull_request_enabled` is not specified) a draft PR will continue to trigger a workflow run.

### Changes

- New `draft_pull_request_enabled` property introduced on the `TriggerMapItemModel`, which controls the draft PR trigger, it defaults to true
- The `trigger` and `trigger-check` commands got a new bool flag `--draft-pr`, which describes if the incoming PR is in a draft state
- The `RunAndTriggerParamsModel` (which can configure the `trigger` and `trigger-check` commands as a single JSON parameter) got a new property `draft-pr`
  - `draft-pr` passed as a flag overrides the same information in the JSON params (just like other flags do)
- Unit tests, affected by the changes, are converter to table tests