### PR TITLE
Update version number to 2.8.0

### DIFF
--- a/version/build.go
+++ b/version/build.go
@@ -1,7 +1,7 @@
 package version
 
 // VERSION is the main CLI version number. It's defined at build time using -ldflags
-var VERSION = "2.6.1"
+var VERSION = "2.8.0"
 
 // BuildNumber is the CI build number that creates the release. It's defined at build time using -ldflags
 var BuildNumber = ""


### PR DESCRIPTION
### Checklist

- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-io/bitrise/blob/master/.github/CONTRIBUTING.md)
- [x] `README.md` is updated with the changes (if needed)

### Version

Requires a *NO* [version update](https://semver.org/)

### Context

This PR updates Bitrise CLI version to 2.8.0, to prepare for releasing:
- https://github.com/bitrise-io/bitrise/pull/905
- https://github.com/bitrise-io/bitrise/pull/907

### Changes

- Update version number in `version/build.go` to 2.8.0