### PR TITLE
Update draft PR control

### DIFF
--- a/_tests/integration/new_trigger_test.go
+++ b/_tests/integration/new_trigger_test.go
@@ -186,7 +186,7 @@ func Test_NewTrigger(t *testing.T) {
 		config := map[string]interface{}{
 			"config":           configPth,
 			"pr-source-branch": "no_draft_pr",
-			"draft-pr":         true,
+			"pr-ready-state":   "draft",
 			"format":           "json",
 		}
 

--- a/cli/commands.go
+++ b/cli/commands.go
@@ -13,7 +13,7 @@ const (
 	PushBranchKey     = "push-branch"
 	PRSourceBranchKey = "pr-source-branch"
 	PRTargetBranchKey = "pr-target-branch"
-	DraftPRKey        = "draft-pr"
+	PRReadyState      = "pr-ready-state"
 
 	ConfigKey      = "config"
 	InventoryKey   = "inventory"
@@ -60,7 +60,7 @@ var (
 				cli.StringFlag{Name: PushBranchKey, Usage: "Git push branch name."},
 				cli.StringFlag{Name: PRSourceBranchKey, Usage: "Git pull request source branch name."},
 				cli.StringFlag{Name: PRTargetBranchKey, Usage: "Git pull request target branch name."},
-				cli.BoolFlag{Name: DraftPRKey, Usage: "Is the pull request in draft state?"},
+				cli.StringFlag{Name: PRReadyState, Usage: "Git pull request ready state"}, //TODO: list values
 				cli.StringFlag{Name: TagKey, Usage: "Git tag name."},
 
 				cli.StringFlag{Name: OuputFormatKey, Usage: "Output format. Accepted: json, yml."},

--- a/cli/commands.go
+++ b/cli/commands.go
@@ -13,7 +13,7 @@ const (
 	PushBranchKey     = "push-branch"
 	PRSourceBranchKey = "pr-source-branch"
 	PRTargetBranchKey = "pr-target-branch"
-	PRReadyState      = "pr-ready-state"
+	PRReadyStateKey   = "pr-ready-state"
 
 	ConfigKey      = "config"
 	InventoryKey   = "inventory"
@@ -60,7 +60,7 @@ var (
 				cli.StringFlag{Name: PushBranchKey, Usage: "Git push branch name."},
 				cli.StringFlag{Name: PRSourceBranchKey, Usage: "Git pull request source branch name."},
 				cli.StringFlag{Name: PRTargetBranchKey, Usage: "Git pull request target branch name."},
-				cli.StringFlag{Name: PRReadyState, Usage: "Git pull request ready state"}, //TODO: list values
+				cli.StringFlag{Name: PRReadyStateKey, Usage: "Git pull request ready state. Options: ready_for_review draft converted_to_ready_for_review"},
 				cli.StringFlag{Name: TagKey, Usage: "Git tag name."},
 
 				cli.StringFlag{Name: OuputFormatKey, Usage: "Output format. Accepted: json, yml."},

--- a/cli/run_trigger_params.go
+++ b/cli/run_trigger_params.go
@@ -3,6 +3,8 @@ package cli
 import (
 	"encoding/base64"
 	"encoding/json"
+
+	"github.com/bitrise-io/bitrise/models"
 )
 
 // --------------------
@@ -17,11 +19,11 @@ type RunAndTriggerParamsModel struct {
 	// Trigger Params
 	TriggerPattern string `json:"pattern"`
 
-	PushBranch     string `json:"push-branch"`
-	PRSourceBranch string `json:"pr-source-branch"`
-	PRTargetBranch string `json:"pr-target-branch"`
-	PRReadyState   string `json:"pr-ready-state"`
-	Tag            string `json:"tag"`
+	PushBranch     string                       `json:"push-branch"`
+	PRSourceBranch string                       `json:"pr-source-branch"`
+	PRTargetBranch string                       `json:"pr-target-branch"`
+	PRReadyState   models.PullRequestReadyState `json:"pr-ready-state"`
+	Tag            string                       `json:"tag"`
 
 	// Trigger Check Params
 	Format string `json:"format"`
@@ -45,7 +47,7 @@ func parseRunAndTriggerJSONParams(jsonParams string) (RunAndTriggerParamsModel, 
 func parseRunAndTriggerParams(
 	workflowToRunID,
 	triggerPattern,
-	pushBranch, prSourceBranch, prTargetBranch string, prReadyState string, tag,
+	pushBranch, prSourceBranch, prTargetBranch string, prReadyState models.PullRequestReadyState, tag,
 	format,
 	bitriseConfigPath, bitriseConfigBase64Data,
 	inventoryPath, inventoryBase64Data,
@@ -124,7 +126,7 @@ func parseRunParams(
 
 func parseTriggerParams(
 	triggerPattern,
-	pushBranch, prSourceBranch, prTargetBranch string, prReadyState string, tag,
+	pushBranch, prSourceBranch, prTargetBranch string, prReadyState models.PullRequestReadyState, tag,
 	bitriseConfigPath, bitriseConfigBase64Data,
 	inventoryPath, inventoryBase64Data,
 	jsonParams, base64JSONParams string) (RunAndTriggerParamsModel, error) {
@@ -133,7 +135,7 @@ func parseTriggerParams(
 
 func parseTriggerCheckParams(
 	triggerPattern,
-	pushBranch, prSourceBranch, prTargetBranch string, prReadyState string, tag,
+	pushBranch, prSourceBranch, prTargetBranch string, prReadyState models.PullRequestReadyState, tag,
 	format,
 	bitriseConfigPath, bitriseConfigBase64Data,
 	inventoryPath, inventoryBase64Data,

--- a/cli/run_trigger_params.go
+++ b/cli/run_trigger_params.go
@@ -20,7 +20,7 @@ type RunAndTriggerParamsModel struct {
 	PushBranch     string `json:"push-branch"`
 	PRSourceBranch string `json:"pr-source-branch"`
 	PRTargetBranch string `json:"pr-target-branch"`
-	IsDraftPR      bool   `json:"draft-pr"`
+	PRReadyState   string `json:"pr-ready-state"`
 	Tag            string `json:"tag"`
 
 	// Trigger Check Params
@@ -45,7 +45,7 @@ func parseRunAndTriggerJSONParams(jsonParams string) (RunAndTriggerParamsModel, 
 func parseRunAndTriggerParams(
 	workflowToRunID,
 	triggerPattern,
-	pushBranch, prSourceBranch, prTargetBranch string, isDraftPR *bool, tag,
+	pushBranch, prSourceBranch, prTargetBranch string, prReadyState string, tag,
 	format,
 	bitriseConfigPath, bitriseConfigBase64Data,
 	inventoryPath, inventoryBase64Data,
@@ -87,8 +87,8 @@ func parseRunAndTriggerParams(
 	if prTargetBranch != "" {
 		params.PRTargetBranch = prTargetBranch
 	}
-	if isDraftPR != nil {
-		params.IsDraftPR = *isDraftPR
+	if prReadyState != "" {
+		params.PRReadyState = prReadyState
 	}
 	if tag != "" {
 		params.Tag = tag
@@ -119,24 +119,24 @@ func parseRunParams(
 	bitriseConfigPath, bitriseConfigBase64Data,
 	inventoryPath, inventoryBase64Data,
 	jsonParams, base64JSONParams string) (RunAndTriggerParamsModel, error) {
-	return parseRunAndTriggerParams(workflowToRunID, "", "", "", "", nil, "", "", bitriseConfigPath, bitriseConfigBase64Data, inventoryPath, inventoryBase64Data, jsonParams, base64JSONParams)
+	return parseRunAndTriggerParams(workflowToRunID, "", "", "", "", "", "", "", bitriseConfigPath, bitriseConfigBase64Data, inventoryPath, inventoryBase64Data, jsonParams, base64JSONParams)
 }
 
 func parseTriggerParams(
 	triggerPattern,
-	pushBranch, prSourceBranch, prTargetBranch string, isDraftPR *bool, tag,
+	pushBranch, prSourceBranch, prTargetBranch string, prReadyState string, tag,
 	bitriseConfigPath, bitriseConfigBase64Data,
 	inventoryPath, inventoryBase64Data,
 	jsonParams, base64JSONParams string) (RunAndTriggerParamsModel, error) {
-	return parseRunAndTriggerParams("", triggerPattern, pushBranch, prSourceBranch, prTargetBranch, isDraftPR, tag, "", bitriseConfigPath, bitriseConfigBase64Data, inventoryPath, inventoryBase64Data, jsonParams, base64JSONParams)
+	return parseRunAndTriggerParams("", triggerPattern, pushBranch, prSourceBranch, prTargetBranch, prReadyState, tag, "", bitriseConfigPath, bitriseConfigBase64Data, inventoryPath, inventoryBase64Data, jsonParams, base64JSONParams)
 }
 
 func parseTriggerCheckParams(
 	triggerPattern,
-	pushBranch, prSourceBranch, prTargetBranch string, isDraftPR *bool, tag,
+	pushBranch, prSourceBranch, prTargetBranch string, prReadyState string, tag,
 	format,
 	bitriseConfigPath, bitriseConfigBase64Data,
 	inventoryPath, inventoryBase64Data,
 	jsonParams, base64JSONParams string) (RunAndTriggerParamsModel, error) {
-	return parseRunAndTriggerParams("", triggerPattern, pushBranch, prSourceBranch, prTargetBranch, isDraftPR, tag, format, bitriseConfigPath, bitriseConfigBase64Data, inventoryPath, inventoryBase64Data, jsonParams, base64JSONParams)
+	return parseRunAndTriggerParams("", triggerPattern, pushBranch, prSourceBranch, prTargetBranch, prReadyState, tag, format, bitriseConfigPath, bitriseConfigBase64Data, inventoryPath, inventoryBase64Data, jsonParams, base64JSONParams)
 }

--- a/cli/run_trigger_params_test.go
+++ b/cli/run_trigger_params_test.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/bitrise-io/go-utils/pointers"
+	"github.com/bitrise-io/bitrise/models"
 	"github.com/stretchr/testify/require"
 )
 
@@ -30,7 +30,7 @@ func TestParseRunAndTriggerJSONParams(t *testing.T) {
 			PushBranchKey:     "deploy",
 			PRSourceBranchKey: "development",
 			PRTargetBranchKey: "release",
-			DraftPRKey:        true,
+			PRReadyStateKey:   models.PullRequestReadyStateReadyForReview,
 			TagKey:            "0.9.0",
 
 			OuputFormatKey: "json",
@@ -50,7 +50,7 @@ func TestParseRunAndTriggerJSONParams(t *testing.T) {
 		require.Equal(t, "deploy", params.PushBranch)
 		require.Equal(t, "development", params.PRSourceBranch)
 		require.Equal(t, "release", params.PRTargetBranch)
-		require.Equal(t, true, params.IsDraftPR)
+		require.Equal(t, models.PullRequestReadyStateReadyForReview, params.PRReadyState)
 		require.Equal(t, "0.9.0", params.Tag)
 
 		require.Equal(t, "json", params.Format)
@@ -73,7 +73,7 @@ func TestParseRunAndTriggerJSONParams(t *testing.T) {
 		require.Equal(t, "", params.PushBranch)
 		require.Equal(t, "", params.PRSourceBranch)
 		require.Equal(t, "", params.PRTargetBranch)
-		require.Equal(t, false, params.IsDraftPR)
+		require.Equal(t, models.PullRequestReadyState(""), params.PRReadyState)
 
 		require.Equal(t, "", params.Format)
 
@@ -94,7 +94,7 @@ func TestParseRunAndTriggerParams(t *testing.T) {
 		pushBranch := "master"
 		prSourceBranch := "develop"
 		prTargetBranch := "master"
-		isDraftPR := pointers.NewBoolPtr(true)
+		prReadyState := models.PullRequestReadyStateReadyForReview
 		tag := "0.9.0"
 		format := "json"
 
@@ -110,7 +110,7 @@ func TestParseRunAndTriggerParams(t *testing.T) {
 		params, err := parseRunAndTriggerParams(
 			workflow,
 			pattern,
-			pushBranch, prSourceBranch, prTargetBranch, isDraftPR, tag,
+			pushBranch, prSourceBranch, prTargetBranch, prReadyState, tag,
 			format,
 			bitriseConfigPath, bitriseConfigBase64Data,
 			inventoryPath, inventoryBase64Data,
@@ -124,7 +124,7 @@ func TestParseRunAndTriggerParams(t *testing.T) {
 		require.Equal(t, pushBranch, params.PushBranch)
 		require.Equal(t, prSourceBranch, params.PRSourceBranch)
 		require.Equal(t, prTargetBranch, params.PRTargetBranch)
-		require.Equal(t, true, params.IsDraftPR)
+		require.Equal(t, models.PullRequestReadyStateReadyForReview, params.PRReadyState)
 		require.Equal(t, tag, params.Tag)
 
 		require.Equal(t, format, params.Format)
@@ -144,7 +144,7 @@ func TestParseRunAndTriggerParams(t *testing.T) {
 		pushBranch := "master"
 		prSourceBranch := "develop"
 		prTargetBranch := "master"
-		isDraftPR := true
+		prReadyState := models.PullRequestReadyStateDraft
 		tag := "0.9.0"
 		format := "json"
 
@@ -161,7 +161,7 @@ func TestParseRunAndTriggerParams(t *testing.T) {
 			PushBranchKey:     pushBranch,
 			PRSourceBranchKey: prSourceBranch,
 			PRTargetBranchKey: prTargetBranch,
-			DraftPRKey:        isDraftPR,
+			PRReadyStateKey:   prReadyState,
 			TagKey:            tag,
 			OuputFormatKey:    format,
 
@@ -175,7 +175,7 @@ func TestParseRunAndTriggerParams(t *testing.T) {
 		jsonParams := toJSON(t, paramsMap)
 		base64JSONParams := ""
 
-		params, err := parseRunAndTriggerParams("", "", "", "", "", nil, "", "", "", "", "", "", jsonParams, base64JSONParams)
+		params, err := parseRunAndTriggerParams("", "", "", "", "", "", "", "", "", "", "", "", jsonParams, base64JSONParams)
 		require.NoError(t, err)
 
 		require.Equal(t, workflow, params.WorkflowToRunID)
@@ -184,7 +184,7 @@ func TestParseRunAndTriggerParams(t *testing.T) {
 		require.Equal(t, pushBranch, params.PushBranch)
 		require.Equal(t, prSourceBranch, params.PRSourceBranch)
 		require.Equal(t, prTargetBranch, params.PRTargetBranch)
-		require.Equal(t, true, params.IsDraftPR)
+		require.Equal(t, models.PullRequestReadyState("draft"), params.PRReadyState)
 		require.Equal(t, tag, params.Tag)
 
 		require.Equal(t, format, params.Format)
@@ -204,7 +204,7 @@ func TestParseRunAndTriggerParams(t *testing.T) {
 		pushBranch := "master"
 		prSourceBranch := "develop"
 		prTargetBranch := "master"
-		isDraftPR := true
+		prReadyState := models.PullRequestReadyStateDraft
 		tag := "0.9.0"
 		format := "json"
 
@@ -221,7 +221,7 @@ func TestParseRunAndTriggerParams(t *testing.T) {
 			PushBranchKey:     pushBranch,
 			PRSourceBranchKey: prSourceBranch,
 			PRTargetBranchKey: prTargetBranch,
-			DraftPRKey:        isDraftPR,
+			PRReadyStateKey:   prReadyState,
 			TagKey:            tag,
 			OuputFormatKey:    format,
 
@@ -235,7 +235,7 @@ func TestParseRunAndTriggerParams(t *testing.T) {
 		jsonParams := ""
 		base64JSONParams := toBase64(t, toJSON(t, paramsMap))
 
-		params, err := parseRunAndTriggerParams("", "", "", "", "", nil, "", "", "", "", "", "", jsonParams, base64JSONParams)
+		params, err := parseRunAndTriggerParams("", "", "", "", "", "", "", "", "", "", "", "", jsonParams, base64JSONParams)
 		require.NoError(t, err)
 
 		require.Equal(t, workflow, params.WorkflowToRunID)
@@ -244,7 +244,7 @@ func TestParseRunAndTriggerParams(t *testing.T) {
 		require.Equal(t, pushBranch, params.PushBranch)
 		require.Equal(t, prSourceBranch, params.PRSourceBranch)
 		require.Equal(t, prTargetBranch, params.PRTargetBranch)
-		require.Equal(t, true, params.IsDraftPR)
+		require.Equal(t, models.PullRequestReadyState("draft"), params.PRReadyState)
 		require.Equal(t, tag, params.Tag)
 
 		require.Equal(t, format, params.Format)
@@ -264,7 +264,7 @@ func TestParseRunAndTriggerParams(t *testing.T) {
 		pushBranch := "master"
 		prSourceBranch := "develop"
 		prTargetBranch := "master"
-		isDraftPR := false
+		prReadyState := models.PullRequestReadyStateReadyForReview
 		tag := "0.9.0"
 		format := "json"
 
@@ -281,7 +281,7 @@ func TestParseRunAndTriggerParams(t *testing.T) {
 			PushBranchKey:     pushBranch,
 			PRSourceBranchKey: prSourceBranch,
 			PRTargetBranchKey: prTargetBranch,
-			DraftPRKey:        isDraftPR,
+			PRReadyStateKey:   prReadyState,
 			TagKey:            tag,
 			OuputFormatKey:    format,
 
@@ -292,10 +292,10 @@ func TestParseRunAndTriggerParams(t *testing.T) {
 			InventoryBase64Key: inventoryBase64Data,
 		}
 
-		jsonParams := `{"workflow":"test","draft-pr":true}`
+		jsonParams := `{"workflow":"test","pr-ready-state":"draft"}`
 		base64JSONParams := toBase64(t, toJSON(t, paramsMap))
 
-		params, err := parseRunAndTriggerParams("", "", "", "", "", nil, "", "", "", "", "", "", jsonParams, base64JSONParams)
+		params, err := parseRunAndTriggerParams("", "", "", "", "", "", "", "", "", "", "", "", jsonParams, base64JSONParams)
 		require.NoError(t, err)
 
 		require.Equal(t, "test", params.WorkflowToRunID)
@@ -304,7 +304,7 @@ func TestParseRunAndTriggerParams(t *testing.T) {
 		require.Equal(t, "", params.PushBranch)
 		require.Equal(t, "", params.PRSourceBranch)
 		require.Equal(t, "", params.PRTargetBranch)
-		require.Equal(t, true, params.IsDraftPR)
+		require.Equal(t, models.PullRequestReadyStateDraft, params.PRReadyState)
 		require.Equal(t, "", params.Tag)
 
 		require.Equal(t, "", params.Format)
@@ -324,7 +324,7 @@ func TestParseRunAndTriggerParams(t *testing.T) {
 		pushBranch := "master"
 		prSourceBranch := "develop"
 		prTargetBranch := "master"
-		isDraftPR := pointers.NewBoolPtr(true)
+		prReadyState := models.PullRequestReadyStateDraft
 		tag := "0.9.0"
 		format := "json"
 
@@ -340,7 +340,7 @@ func TestParseRunAndTriggerParams(t *testing.T) {
 		params, err := parseRunAndTriggerParams(
 			workflow,
 			pattern,
-			pushBranch, prSourceBranch, prTargetBranch, isDraftPR, tag,
+			pushBranch, prSourceBranch, prTargetBranch, prReadyState, tag,
 			format,
 			bitriseConfigPath, bitriseConfigBase64Data,
 			inventoryPath, inventoryBase64Data,
@@ -354,7 +354,7 @@ func TestParseRunAndTriggerParams(t *testing.T) {
 		require.Equal(t, pushBranch, params.PushBranch)
 		require.Equal(t, prSourceBranch, params.PRSourceBranch)
 		require.Equal(t, prTargetBranch, params.PRTargetBranch)
-		require.Equal(t, true, params.IsDraftPR)
+		require.Equal(t, models.PullRequestReadyStateDraft, params.PRReadyState)
 		require.Equal(t, tag, params.Tag)
 
 		require.Equal(t, format, params.Format)
@@ -395,7 +395,7 @@ func TestParseRunParams(t *testing.T) {
 		require.Equal(t, "", params.PushBranch)
 		require.Equal(t, "", params.PRSourceBranch)
 		require.Equal(t, "", params.PRTargetBranch)
-		require.Equal(t, false, params.IsDraftPR)
+		require.Equal(t, models.PullRequestReadyState(""), params.PRReadyState)
 		require.Equal(t, "", params.Tag)
 
 		require.Equal(t, "", params.Format)
@@ -415,7 +415,7 @@ func TestParseTriggerParams(t *testing.T) {
 		pushBranch := "master"
 		prSourceBranch := "develop"
 		prTargetBranch := "master"
-		isDraftPR := pointers.NewBoolPtr(true)
+		prReadyState := models.PullRequestReadyStateDraft
 		tag := "0.9.0"
 
 		bitriseConfigPath := "bitrise.yml"
@@ -429,7 +429,7 @@ func TestParseTriggerParams(t *testing.T) {
 
 		params, err := parseTriggerParams(
 			pattern,
-			pushBranch, prSourceBranch, prTargetBranch, isDraftPR, tag,
+			pushBranch, prSourceBranch, prTargetBranch, prReadyState, tag,
 			bitriseConfigPath, bitriseConfigBase64Data,
 			inventoryPath, inventoryBase64Data,
 			jsonParams, base64JSONParams,
@@ -442,7 +442,7 @@ func TestParseTriggerParams(t *testing.T) {
 		require.Equal(t, pushBranch, params.PushBranch)
 		require.Equal(t, prSourceBranch, params.PRSourceBranch)
 		require.Equal(t, prTargetBranch, params.PRTargetBranch)
-		require.Equal(t, true, params.IsDraftPR)
+		require.Equal(t, models.PullRequestReadyStateDraft, params.PRReadyState)
 		require.Equal(t, tag, params.Tag)
 
 		require.Equal(t, "", params.Format)
@@ -462,7 +462,7 @@ func TestParseTriggerCheckParams(t *testing.T) {
 		pushBranch := "master"
 		prSourceBranch := "develop"
 		prTargetBranch := "master"
-		isDraftPR := pointers.NewBoolPtr(true)
+		prReadyState := models.PullRequestReadyStateDraft
 		tag := "0.9.0"
 		format := "json"
 
@@ -477,7 +477,7 @@ func TestParseTriggerCheckParams(t *testing.T) {
 
 		params, err := parseTriggerCheckParams(
 			pattern,
-			pushBranch, prSourceBranch, prTargetBranch, isDraftPR, tag,
+			pushBranch, prSourceBranch, prTargetBranch, prReadyState, tag,
 			format,
 			bitriseConfigPath, bitriseConfigBase64Data,
 			inventoryPath, inventoryBase64Data,
@@ -491,7 +491,7 @@ func TestParseTriggerCheckParams(t *testing.T) {
 		require.Equal(t, pushBranch, params.PushBranch)
 		require.Equal(t, prSourceBranch, params.PRSourceBranch)
 		require.Equal(t, prTargetBranch, params.PRTargetBranch)
-		require.Equal(t, true, params.IsDraftPR)
+		require.Equal(t, models.PullRequestReadyStateDraft, params.PRReadyState)
 		require.Equal(t, tag, params.Tag)
 
 		require.Equal(t, format, params.Format)

--- a/cli/trigger.go
+++ b/cli/trigger.go
@@ -28,7 +28,7 @@ var triggerCommand = cli.Command{
 		cli.StringFlag{Name: PushBranchKey, Usage: "Git push branch name."},
 		cli.StringFlag{Name: PRSourceBranchKey, Usage: "Git pull request source branch name."},
 		cli.StringFlag{Name: PRTargetBranchKey, Usage: "Git pull request target branch name."},
-		cli.BoolFlag{Name: DraftPRKey, Usage: "Is the pull request in draft state?"},
+		cli.StringFlag{Name: PRReadyState, Usage: "Git pull request ready state"}, //TODO: list values
 		cli.StringFlag{Name: TagKey, Usage: "Git tag name."},
 
 		// cli params used in CI mode
@@ -101,10 +101,7 @@ func trigger(c *cli.Context) error {
 	pushBranch := c.String(PushBranchKey)
 	prSourceBranch := c.String(PRSourceBranchKey)
 	prTargetBranch := c.String(PRTargetBranchKey)
-	var isDraftPR *bool
-	if c.IsSet(DraftPRKey) {
-		isDraftPR = pointers.NewBoolPtr(c.Bool(DraftPRKey))
-	}
+	prReadyState := c.String(PRReadyState)
 	tag := c.String(TagKey)
 
 	bitriseConfigBase64Data := c.String(ConfigBase64Key)
@@ -118,7 +115,7 @@ func trigger(c *cli.Context) error {
 
 	triggerParams, err := parseTriggerParams(
 		triggerPattern,
-		pushBranch, prSourceBranch, prTargetBranch, isDraftPR, tag,
+		pushBranch, prSourceBranch, prTargetBranch, prReadyState, tag,
 		bitriseConfigPath, bitriseConfigBase64Data,
 		inventoryPath, inventoryBase64Data,
 		jsonParams, jsonParamsBase64)

--- a/cli/trigger.go
+++ b/cli/trigger.go
@@ -28,7 +28,7 @@ var triggerCommand = cli.Command{
 		cli.StringFlag{Name: PushBranchKey, Usage: "Git push branch name."},
 		cli.StringFlag{Name: PRSourceBranchKey, Usage: "Git pull request source branch name."},
 		cli.StringFlag{Name: PRTargetBranchKey, Usage: "Git pull request target branch name."},
-		cli.StringFlag{Name: PRReadyState, Usage: "Git pull request ready state"}, //TODO: list values
+		cli.StringFlag{Name: PRReadyStateKey, Usage: "Git pull request ready state. Options: ready_for_review draft converted_to_ready_for_review"},
 		cli.StringFlag{Name: TagKey, Usage: "Git tag name."},
 
 		// cli params used in CI mode
@@ -101,7 +101,7 @@ func trigger(c *cli.Context) error {
 	pushBranch := c.String(PushBranchKey)
 	prSourceBranch := c.String(PRSourceBranchKey)
 	prTargetBranch := c.String(PRTargetBranchKey)
-	prReadyState := c.String(PRReadyState)
+	prReadyState := models.PullRequestReadyState(c.String(PRReadyStateKey))
 	tag := c.String(TagKey)
 
 	bitriseConfigBase64Data := c.String(ConfigBase64Key)

--- a/cli/trigger_check.go
+++ b/cli/trigger_check.go
@@ -90,7 +90,7 @@ func triggerCheck(c *cli.Context) error {
 	pushBranch := c.String(PushBranchKey)
 	prSourceBranch := c.String(PRSourceBranchKey)
 	prTargetBranch := c.String(PRTargetBranchKey)
-	prReadyState := c.String(PRReadyState)
+	prReadyState := models.PullRequestReadyState(c.String(PRReadyStateKey))
 	tag := c.String(TagKey)
 
 	bitriseConfigBase64Data := c.String(ConfigBase64Key)

--- a/cli/trigger_check.go
+++ b/cli/trigger_check.go
@@ -65,7 +65,7 @@ func getPipelineAndWorkflowIDByParamsInCompatibleMode(triggerMap models.TriggerM
 		params = migratePatternToParams(params, isPullRequestMode)
 	}
 
-	return triggerMap.FirstMatchingTarget(params.PushBranch, params.PRSourceBranch, params.PRTargetBranch, params.IsDraftPR, params.Tag)
+	return triggerMap.FirstMatchingTarget(params.PushBranch, params.PRSourceBranch, params.PRTargetBranch, params.PRReadyState, params.Tag)
 }
 
 // --------------------
@@ -90,10 +90,7 @@ func triggerCheck(c *cli.Context) error {
 	pushBranch := c.String(PushBranchKey)
 	prSourceBranch := c.String(PRSourceBranchKey)
 	prTargetBranch := c.String(PRTargetBranchKey)
-	var isDraftPR *bool
-	if c.IsSet(DraftPRKey) {
-		isDraftPR = pointers.NewBoolPtr(c.Bool(DraftPRKey))
-	}
+	prReadyState := c.String(PRReadyState)
 	tag := c.String(TagKey)
 
 	bitriseConfigBase64Data := c.String(ConfigBase64Key)
@@ -109,7 +106,7 @@ func triggerCheck(c *cli.Context) error {
 
 	triggerParams, err := parseTriggerCheckParams(
 		triggerPattern,
-		pushBranch, prSourceBranch, prTargetBranch, isDraftPR, tag,
+		pushBranch, prSourceBranch, prTargetBranch, prReadyState, tag,
 		format,
 		bitriseConfigPath, bitriseConfigBase64Data,
 		inventoryPath, inventoryBase64Data,

--- a/models/trigger_map.go
+++ b/models/trigger_map.go
@@ -23,7 +23,7 @@ func (triggerMap TriggerMapModel) Validate(workflows, pipelines []string) ([]str
 	return warnings, nil
 }
 
-func (triggerMap TriggerMapModel) FirstMatchingTarget(pushBranch, prSourceBranch, prTargetBranch string, prReadyState string, tag string) (string, string, error) {
+func (triggerMap TriggerMapModel) FirstMatchingTarget(pushBranch, prSourceBranch, prTargetBranch string, prReadyState PullRequestReadyState, tag string) (string, string, error) {
 	for _, item := range triggerMap {
 		match, err := item.MatchWithParams(pushBranch, prSourceBranch, prTargetBranch, prReadyState, tag)
 		if err != nil {

--- a/models/trigger_map.go
+++ b/models/trigger_map.go
@@ -1,7 +1,6 @@
 package models
 
 import (
-	"errors"
 	"fmt"
 )
 
@@ -26,19 +25,10 @@ func (triggerMap TriggerMapModel) Validate(workflows, pipelines []string) ([]str
 
 func (triggerMap TriggerMapModel) FirstMatchingTarget(pushBranch, prSourceBranch, prTargetBranch string, prReadyState string, tag string) (string, string, error) {
 	for _, item := range triggerMap {
-		match, err := item.MatchWithParams(pushBranch, prSourceBranch, prTargetBranch, tag)
+		match, err := item.MatchWithParams(pushBranch, prSourceBranch, prTargetBranch, prReadyState, tag)
 		if err != nil {
 			return "", "", err
 		}
-		if match {
-			if item.IsDraftPullRequestEnabled() == true && prReadyState == "converted_to_ready_for_review" {
-				return "", "", errors.New("skipped")
-			}
-			if item.IsDraftPullRequestEnabled() == false && prReadyState == "draft" {
-				return "", "", errors.New("skipped")
-			}
-		}
-
 		if match {
 			return item.PipelineID, item.WorkflowID, nil
 		}

--- a/models/trigger_map_item.go
+++ b/models/trigger_map_item.go
@@ -90,7 +90,7 @@ func (triggerItem TriggerMapItemModel) Validate(workflows, pipelines []string) (
 	return warnings, nil
 }
 
-func (triggerItem TriggerMapItemModel) MatchWithParams(pushBranch, prSourceBranch, prTargetBranch string, isDraftPR bool, tag string) (bool, error) {
+func (triggerItem TriggerMapItemModel) MatchWithParams(pushBranch, prSourceBranch, prTargetBranch string, tag string) (bool, error) {
 	paramsEventType, err := triggerEventType(pushBranch, prSourceBranch, prTargetBranch, tag)
 	if err != nil {
 		return false, err
@@ -130,12 +130,7 @@ func (triggerItem TriggerMapItemModel) MatchWithParams(pushBranch, prSourceBranc
 				targetMatch = glob.Glob(migratedTriggerItem.PullRequestTargetBranch, prTargetBranch)
 			}
 
-			prStateMatch := true
-			if !migratedTriggerItem.IsDraftPullRequestEnabled() && isDraftPR {
-				prStateMatch = false
-			}
-
-			return sourceMatch && targetMatch && prStateMatch, nil
+			return sourceMatch && targetMatch, nil
 		case TriggerEventTypeTag:
 			match := glob.Glob(migratedTriggerItem.Tag, tag)
 			return match, nil

--- a/models/trigger_map_item.go
+++ b/models/trigger_map_item.go
@@ -138,18 +138,18 @@ func (triggerItem TriggerMapItemModel) MatchWithParams(pushBranch, prSourceBranc
 				targetMatch = glob.Glob(migratedTriggerItem.PullRequestTargetBranch, prTargetBranch)
 			}
 
-			shouldSkipDraftPRTrigger := false
+			stateMismatch := false
 			if migratedTriggerItem.IsDraftPullRequestEnabled() {
 				if prReadyState == PullRequestReadyStateConvertedToReadyForReview {
-					shouldSkipDraftPRTrigger = true
+					stateMismatch = true
 				}
 			} else {
 				if prReadyState == PullRequestReadyStateDraft {
-					shouldSkipDraftPRTrigger = true
+					stateMismatch = true
 				}
 			}
 
-			return sourceMatch && targetMatch && !shouldSkipDraftPRTrigger, nil
+			return sourceMatch && targetMatch && !stateMismatch, nil
 		case TriggerEventTypeTag:
 			match := glob.Glob(migratedTriggerItem.Tag, tag)
 			return match, nil

--- a/models/trigger_map_item.go
+++ b/models/trigger_map_item.go
@@ -138,15 +138,18 @@ func (triggerItem TriggerMapItemModel) MatchWithParams(pushBranch, prSourceBranc
 				targetMatch = glob.Glob(migratedTriggerItem.PullRequestTargetBranch, prTargetBranch)
 			}
 
-			prReadyStateMatch := true
-			// TODO: explain this if statement
+			shouldSkipDraftPRTrigger := false
 			if migratedTriggerItem.IsDraftPullRequestEnabled() {
-				prReadyStateMatch = prReadyState != PullRequestReadyStateConvertedToReadyForReview
+				if prReadyState == PullRequestReadyStateConvertedToReadyForReview {
+					shouldSkipDraftPRTrigger = true
+				}
 			} else {
-				prReadyStateMatch = prReadyState != PullRequestReadyStateDraft
+				if prReadyState == PullRequestReadyStateDraft {
+					shouldSkipDraftPRTrigger = true
+				}
 			}
 
-			return sourceMatch && targetMatch && prReadyStateMatch, nil
+			return sourceMatch && targetMatch && !shouldSkipDraftPRTrigger, nil
 		case TriggerEventTypeTag:
 			match := glob.Glob(migratedTriggerItem.Tag, tag)
 			return match, nil

--- a/models/trigger_map_item.go
+++ b/models/trigger_map_item.go
@@ -138,6 +138,10 @@ func (triggerItem TriggerMapItemModel) MatchWithParams(pushBranch, prSourceBranc
 				targetMatch = glob.Glob(migratedTriggerItem.PullRequestTargetBranch, prTargetBranch)
 			}
 
+			// When a PR is converted to ready for review:
+			// - if draft PR trigger is enabled, this event is just a status change on the PR
+			// 	 and the given status of the code base already triggered a build.
+			// - if draft PR trigger is disabled, the given status of the code base didn't trigger a build yet.
 			stateMismatch := false
 			if migratedTriggerItem.IsDraftPullRequestEnabled() {
 				if prReadyState == PullRequestReadyStateConvertedToReadyForReview {

--- a/models/trigger_map_item_test.go
+++ b/models/trigger_map_item_test.go
@@ -27,7 +27,7 @@ func TestTriggerMapItemModel_MatchWithParams_CodePushParams(t *testing.T) {
 				PushBranch: aPattern,
 				WorkflowID: "primary",
 			}
-			match, err := item.MatchWithParams(pushBranch, prSourceBranch, prTargetBranch, false, tag)
+			match, err := item.MatchWithParams(pushBranch, prSourceBranch, prTargetBranch, PullRequestReadyStateReadyForReview, tag)
 			require.NoError(t, err)
 			require.Equal(t, true, match, "(pattern: %s) (branch: %s)", aPattern, aPushBranch)
 		}
@@ -44,7 +44,7 @@ func TestTriggerMapItemModel_MatchWithParams_CodePushParams(t *testing.T) {
 			PushBranch: "deploy",
 			WorkflowID: "deploy",
 		}
-		match, err := item.MatchWithParams(pushBranch, prSourceBranch, prTargetBranch, false, tag)
+		match, err := item.MatchWithParams(pushBranch, prSourceBranch, prTargetBranch, PullRequestReadyStateReadyForReview, tag)
 		require.NoError(t, err)
 		require.Equal(t, false, match)
 	}
@@ -60,7 +60,7 @@ func TestTriggerMapItemModel_MatchWithParams_CodePushParams(t *testing.T) {
 			PullRequestSourceBranch: "develop",
 			WorkflowID:              "test",
 		}
-		match, err := item.MatchWithParams(pushBranch, prSourceBranch, prTargetBranch, false, tag)
+		match, err := item.MatchWithParams(pushBranch, prSourceBranch, prTargetBranch, PullRequestReadyStateReadyForReview, tag)
 		require.NoError(t, err)
 		require.Equal(t, false, match)
 	}
@@ -76,7 +76,7 @@ func TestTriggerMapItemModel_MatchWithParams_CodePushParams(t *testing.T) {
 			PullRequestTargetBranch: "master",
 			WorkflowID:              "primary",
 		}
-		match, err := item.MatchWithParams(pushBranch, prSourceBranch, prTargetBranch, false, tag)
+		match, err := item.MatchWithParams(pushBranch, prSourceBranch, prTargetBranch, PullRequestReadyStateReadyForReview, tag)
 		require.NoError(t, err)
 		require.Equal(t, false, match)
 	}
@@ -93,7 +93,7 @@ func TestTriggerMapItemModel_MatchWithParams_CodePushParams(t *testing.T) {
 			PullRequestTargetBranch: "master",
 			WorkflowID:              "primary",
 		}
-		match, err := item.MatchWithParams(pushBranch, prSourceBranch, prTargetBranch, false, tag)
+		match, err := item.MatchWithParams(pushBranch, prSourceBranch, prTargetBranch, PullRequestReadyStateReadyForReview, tag)
 		require.NoError(t, err)
 		require.Equal(t, false, match)
 	}
@@ -245,7 +245,7 @@ func TestTriggerMapItemModel_MatchWithParams_PRParams(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := tt.triggerMapItem.MatchWithParams(tt.pushBranch, tt.prSourceBranch, tt.prTargetBranch, tt.isDraftPR, tt.tag)
+			got, err := tt.triggerMapItem.MatchWithParams(tt.pushBranch, tt.prSourceBranch, tt.prTargetBranch, PullRequestReadyStateDraft, tt.tag)
 			if tt.wantErr != "" {
 				require.EqualError(t, err, tt.wantErr)
 			} else {
@@ -268,7 +268,7 @@ func TestTriggerMapItemModel_MatchWithParams_TagParams(t *testing.T) {
 			Tag:        "0.9.*",
 			WorkflowID: "deploy",
 		}
-		match, err := item.MatchWithParams(pushBranch, prSourceBranch, prTargetBranch, false, tag)
+		match, err := item.MatchWithParams(pushBranch, prSourceBranch, prTargetBranch, PullRequestReadyStateReadyForReview, tag)
 		require.NoError(t, err)
 		require.Equal(t, true, match)
 	}
@@ -284,7 +284,7 @@ func TestTriggerMapItemModel_MatchWithParams_TagParams(t *testing.T) {
 			Tag:        "0.9.0",
 			WorkflowID: "deploy",
 		}
-		match, err := item.MatchWithParams(pushBranch, prSourceBranch, prTargetBranch, false, tag)
+		match, err := item.MatchWithParams(pushBranch, prSourceBranch, prTargetBranch, PullRequestReadyStateReadyForReview, tag)
 		require.NoError(t, err)
 		require.Equal(t, true, match)
 	}
@@ -300,7 +300,7 @@ func TestTriggerMapItemModel_MatchWithParams_TagParams(t *testing.T) {
 			Tag:        "0.9.*",
 			WorkflowID: "deploy",
 		}
-		match, err := item.MatchWithParams(pushBranch, prSourceBranch, prTargetBranch, false, tag)
+		match, err := item.MatchWithParams(pushBranch, prSourceBranch, prTargetBranch, PullRequestReadyStateReadyForReview, tag)
 		require.NoError(t, err)
 		require.Equal(t, true, match)
 	}
@@ -316,7 +316,7 @@ func TestTriggerMapItemModel_MatchWithParams_TagParams(t *testing.T) {
 			Tag:        "1.*",
 			WorkflowID: "deploy",
 		}
-		match, err := item.MatchWithParams(pushBranch, prSourceBranch, prTargetBranch, false, tag)
+		match, err := item.MatchWithParams(pushBranch, prSourceBranch, prTargetBranch, PullRequestReadyStateReadyForReview, tag)
 		require.NoError(t, err)
 		require.Equal(t, false, match)
 	}
@@ -332,7 +332,7 @@ func TestTriggerMapItemModel_MatchWithParams_TagParams(t *testing.T) {
 			PushBranch: "master",
 			WorkflowID: "primary",
 		}
-		match, err := item.MatchWithParams(pushBranch, prSourceBranch, prTargetBranch, false, tag)
+		match, err := item.MatchWithParams(pushBranch, prSourceBranch, prTargetBranch, PullRequestReadyStateReadyForReview, tag)
 		require.NoError(t, err)
 		require.Equal(t, false, match)
 	}

--- a/models/trigger_map_test.go
+++ b/models/trigger_map_test.go
@@ -172,3 +172,171 @@ func TestTriggerMapModel_Validate(t *testing.T) {
 		})
 	}
 }
+
+func TestTriggerMapModel_FirstMatchingTarget_SimplePRTriggerMap(t *testing.T) {
+	triggerMap := TriggerMapModel{
+		TriggerMapItemModel{
+			PullRequestTargetBranch: "*",
+			WorkflowID:              "ci",
+		},
+	}
+
+	tests := []struct {
+		name           string
+		prTargetBranch string
+		prReadyState   PullRequestReadyState
+		wantWorkflow   string
+		wantErr        string
+	}{
+		{
+			name:           "PR with draft status",
+			prTargetBranch: "master",
+			prReadyState:   PullRequestReadyStateDraft,
+			wantWorkflow:   "ci",
+		},
+		{
+			name:           "PR with ready for review status",
+			prTargetBranch: "master",
+			prReadyState:   PullRequestReadyStateReadyForReview,
+			wantWorkflow:   "ci",
+		},
+		{
+			name:           "PR without status",
+			prTargetBranch: "master",
+			prReadyState:   "",
+			wantWorkflow:   "ci",
+		},
+		{
+			name:           "PR with converted to ready for review status",
+			prTargetBranch: "master",
+			prReadyState:   PullRequestReadyStateConvertedToReadyForReview,
+			wantErr:        "no matching pipeline & workflow found with trigger params: push-branch: , pr-source-branch: , pr-target-branch: master, tag: ",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotPipeline, gotWorkflow, err := triggerMap.FirstMatchingTarget("", "", tt.prTargetBranch, tt.prReadyState, "")
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+			} else {
+				require.EqualError(t, err, tt.wantErr)
+			}
+			require.Equal(t, "", gotPipeline)
+			require.Equal(t, tt.wantWorkflow, gotWorkflow)
+		})
+	}
+}
+
+func TestTriggerMapModel_FirstMatchingTarget_DraftPRDisabledTriggerMap(t *testing.T) {
+	triggerMap := TriggerMapModel{
+		TriggerMapItemModel{
+			PullRequestTargetBranch: "*",
+			DraftPullRequestEnabled: pointers.NewBoolPtr(false),
+			WorkflowID:              "ci",
+		},
+	}
+
+	tests := []struct {
+		name           string
+		prTargetBranch string
+		prReadyState   PullRequestReadyState
+		wantWorkflow   string
+		wantErr        string
+	}{
+		{
+			name:           "PR with draft status",
+			prTargetBranch: "master",
+			prReadyState:   PullRequestReadyStateDraft,
+			wantErr:        "no matching pipeline & workflow found with trigger params: push-branch: , pr-source-branch: , pr-target-branch: master, tag: ",
+		},
+		{
+			name:           "PR with ready for review status",
+			prTargetBranch: "master",
+			prReadyState:   PullRequestReadyStateReadyForReview,
+			wantWorkflow:   "ci",
+		},
+		{
+			name:           "PR without status",
+			prTargetBranch: "master",
+			prReadyState:   "",
+			wantWorkflow:   "ci",
+		},
+		{
+			name:           "PR with converted to ready for review status",
+			prTargetBranch: "master",
+			prReadyState:   PullRequestReadyStateConvertedToReadyForReview,
+			wantWorkflow:   "ci",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotPipeline, gotWorkflow, err := triggerMap.FirstMatchingTarget("", "", tt.prTargetBranch, tt.prReadyState, "")
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+			} else {
+				require.EqualError(t, err, tt.wantErr)
+			}
+			require.Equal(t, "", gotPipeline)
+			require.Equal(t, tt.wantWorkflow, gotWorkflow)
+		})
+	}
+}
+
+func TestTriggerMapModel_FirstMatchingTarget_PRTriggerMapWithDraftPRDisabledAndEnabledItems(t *testing.T) {
+	triggerMap := TriggerMapModel{
+		TriggerMapItemModel{
+			PullRequestTargetBranch: "master",
+			DraftPullRequestEnabled: pointers.NewBoolPtr(false),
+			WorkflowID:              "ci",
+		},
+		TriggerMapItemModel{
+			PullRequestTargetBranch: "*",
+			WorkflowID:              "lint",
+		},
+	}
+
+	tests := []struct {
+		name           string
+		prTargetBranch string
+		prReadyState   PullRequestReadyState
+		wantWorkflow   string
+		wantErr        string
+	}{
+		{
+			name:           "PR with draft status",
+			prTargetBranch: "master",
+			prReadyState:   PullRequestReadyStateDraft,
+			wantWorkflow:   "lint",
+		},
+		{
+			name:           "PR with ready for review status",
+			prTargetBranch: "master",
+			prReadyState:   PullRequestReadyStateReadyForReview,
+			wantWorkflow:   "ci",
+		},
+		{
+			name:           "PR without status",
+			prTargetBranch: "master",
+			prReadyState:   "",
+			wantWorkflow:   "ci",
+		},
+		{
+			name:           "PR with converted to ready for review status",
+			prTargetBranch: "master",
+			prReadyState:   PullRequestReadyStateConvertedToReadyForReview,
+			wantWorkflow:   "ci",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotPipeline, gotWorkflow, err := triggerMap.FirstMatchingTarget("", "", tt.prTargetBranch, tt.prReadyState, "")
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+			} else {
+				require.EqualError(t, err, tt.wantErr)
+			}
+			require.Equal(t, "", gotPipeline)
+			require.Equal(t, tt.wantWorkflow, gotWorkflow)
+		})
+	}
+}


### PR DESCRIPTION
### Checklist

- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-io/bitrise/blob/master/.github/CONTRIBUTING.md)
- [x] `README.md` is updated with the changes (if needed)

### Version

Requires a *PATCH* [version update](https://semver.org/)

### Context

This PR fixes an issue with the previously introduced draft PR trigger control.

The previous implementation couldn't handle properly when a draft PR is converted to a ready-for-review status.

The new implementation compares PR trigger map items to a PR readiness status with three possible values: `draft`, `ready_for_review` and `converted_to_ready_for_review ` this way:

If the draft PR trigger is enabled:
- build params with `pull_request_ready_state=draft` → trigger a build
- build params with `pull_request_ready_state=ready_for_review` → trigger a build
- build params with `pull_request_ready_state=converted_to_ready_for_review` → skip build (only the ready state has changed, build was already running on this state of the code)

If the draft PR trigger is disabled:
- build params with `pull_request_ready_state=draft` → skip a build
- build params with `pull_request_ready_state=ready_for_review` → trigger a build
- build params with `pull_request_ready_state=converted_to_ready_for_review` → trigger a build (state changed to ready to review)

The new comparison is aligned with the related webhook service changes: https://github.com/bitrise-io/bitrise-webhooks/pull/158

### Changes

- Update TriggerMapItemModel.MatchWithParams based on the above-explained matching logic
- The `trigger` and `trigger-check` commands' `--draft-pr` flag was replaced by the `pr-ready-state` flag
- The `RunAndTriggerParamsModel`s `draft-pr` property was replaced by the `PRReadyState` property
