### PR TITLE
[CI-2392] Use new model for stage workflow

### DIFF
--- a/models/models.go
+++ b/models/models.go
@@ -30,13 +30,21 @@ type StageListItemModel map[string]StageModel
 
 // StageModel ...
 type StageModel struct {
-	Title           string                  `json:"title,omitempty" yaml:"title,omitempty"`
-	Summary         string                  `json:"summary,omitempty" yaml:"summary,omitempty"`
-	Description     string                  `json:"description,omitempty" yaml:"description,omitempty"`
-	ShouldAlwaysRun bool                    `json:"should_always_run,omitempty" yaml:"should_always_run,omitempty"`
-	AbortOnFail     bool                    `json:"abort_on_fail,omitempty" yaml:"abort_on_fail,omitempty"`
-	RunIf           string                  `json:"run_if,omitempty" yaml:"run_if,omitempty"`
-	Workflows       []WorkflowListItemModel `json:"workflows,omitempty" yaml:"workflows,omitempty"`
+	Title           string                       `json:"title,omitempty" yaml:"title,omitempty"`
+	Summary         string                       `json:"summary,omitempty" yaml:"summary,omitempty"`
+	Description     string                       `json:"description,omitempty" yaml:"description,omitempty"`
+	ShouldAlwaysRun bool                         `json:"should_always_run,omitempty" yaml:"should_always_run,omitempty"`
+	AbortOnFail     bool                         `json:"abort_on_fail,omitempty" yaml:"abort_on_fail,omitempty"`
+	RunIf           string                       `json:"run_if,omitempty" yaml:"run_if,omitempty"`
+	Workflows       []StageWorkflowListItemModel `json:"workflows,omitempty" yaml:"workflows,omitempty"`
+}
+
+// StageWorkflowListItemModel ...
+type StageWorkflowListItemModel map[string]StageWorkflowModel
+
+// StageWorkflowModel ...
+type StageWorkflowModel struct {
+	RunIf string `json:"run_if,omitempty" yaml:"run_if,omitempty"`
 }
 
 // WorkflowListItemModel ...

--- a/models/models_methods.go
+++ b/models/models_methods.go
@@ -281,7 +281,7 @@ func validatePipelines(config *BitriseDataModel) ([]string, error) {
 		}
 
 		for _, pipelineStage := range pipeline.Stages {
-			pipelineStageID, err := GetStageIDFromListItemModel(pipelineStage)
+			pipelineStageID, err := getStageID(pipelineStage)
 			if err != nil {
 				return pipelineWarnings, err
 			}
@@ -318,7 +318,7 @@ func validateStages(config *BitriseDataModel) ([]string, error) {
 
 		for _, stageWorkflow := range stage.Workflows {
 			found := false
-			stageWorkflowID, err := GetWorkflowIDFromListItemModel(stageWorkflow)
+			stageWorkflowID, err := getWorkflowID(stageWorkflow)
 
 			if isUtilityWorkflow(stageWorkflowID) {
 				return stageWarnings, fmt.Errorf("workflow (%s) defined in stage (%s), is a utility workflow", stageWorkflowID, ID)
@@ -778,29 +778,27 @@ func MergeStepWith(step, otherStep stepmanModels.StepModel) (stepmanModels.StepM
 // ----------------------------
 // --- WorkflowIDData
 
-// GetWorkflowIDFromListItemModel ...
-func GetWorkflowIDFromListItemModel(workflowListItem StageWorkflowListItemModel) (string, error) {
+func getWorkflowID(workflowListItem StageWorkflowListItemModel) (string, error) {
 	if len(workflowListItem) > 1 {
-		return "", errors.New("WorkflowListItem contains more than 1 key-value pair")
+		return "", errors.New("StageWorkflowListItemModel contains more than 1 key-value pair")
 	}
 	for key := range workflowListItem {
 		return key, nil
 	}
-	return "", errors.New("WorkflowListItem does not contain a key-value pair")
+	return "", errors.New("StageWorkflowListItemModel does not contain a key-value pair")
 }
 
 // ----------------------------
 // --- StageIDData
 
-// GetStageIDFromListItemModel ...
-func GetStageIDFromListItemModel(stageListItem StageListItemModel) (string, error) {
+func getStageID(stageListItem StageListItemModel) (string, error) {
 	if len(stageListItem) > 1 {
-		return "", errors.New("StageListItem contains more than 1 key-value pair")
+		return "", errors.New("StageListItemModel contains more than 1 key-value pair")
 	}
 	for key := range stageListItem {
 		return key, nil
 	}
-	return "", errors.New("StageListItem does not contain a key-value pair")
+	return "", errors.New("StageListItemModel does not contain a key-value pair")
 }
 
 // ----------------------------

--- a/models/models_methods.go
+++ b/models/models_methods.go
@@ -779,7 +779,7 @@ func MergeStepWith(step, otherStep stepmanModels.StepModel) (stepmanModels.StepM
 // --- WorkflowIDData
 
 // GetWorkflowIDFromListItemModel ...
-func GetWorkflowIDFromListItemModel(workflowListItem WorkflowListItemModel) (string, error) {
+func GetWorkflowIDFromListItemModel(workflowListItem StageWorkflowListItemModel) (string, error) {
 	if len(workflowListItem) > 1 {
 		return "", errors.New("WorkflowListItem contains more than 1 key-value pair")
 	}

--- a/models/models_methods_test.go
+++ b/models/models_methods_test.go
@@ -6,11 +6,12 @@ import (
 	"testing"
 	"time"
 
+	"gopkg.in/yaml.v2"
+
 	envmanModels "github.com/bitrise-io/envman/models"
 	"github.com/bitrise-io/go-utils/pointers"
 	stepmanModels "github.com/bitrise-io/stepman/models"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v2"
 )
 
 // ----------------------------
@@ -38,27 +39,27 @@ func TestValidateConfig(t *testing.T) {
 			},
 			Stages: map[string]StageModel{
 				"stage1": StageModel{
-					Workflows: []WorkflowListItemModel{
-						WorkflowListItemModel{"workflow1": WorkflowModel{}},
-						WorkflowListItemModel{"workflow2": WorkflowModel{}},
+					Workflows: []StageWorkflowListItemModel{
+						StageWorkflowListItemModel{"workflow1": StageWorkflowModel{}},
+						StageWorkflowListItemModel{"workflow2": StageWorkflowModel{}},
 					},
 				},
 				"stage2": StageModel{
-					Workflows: []WorkflowListItemModel{
-						WorkflowListItemModel{"workflow3": WorkflowModel{}},
-						WorkflowListItemModel{"workflow4": WorkflowModel{}},
+					Workflows: []StageWorkflowListItemModel{
+						StageWorkflowListItemModel{"workflow3": StageWorkflowModel{}},
+						StageWorkflowListItemModel{"workflow4": StageWorkflowModel{}},
 					},
 				},
 				"stage3": StageModel{
-					Workflows: []WorkflowListItemModel{
-						WorkflowListItemModel{"workflow5": WorkflowModel{}},
-						WorkflowListItemModel{"workflow6": WorkflowModel{}},
+					Workflows: []StageWorkflowListItemModel{
+						StageWorkflowListItemModel{"workflow5": StageWorkflowModel{}},
+						StageWorkflowListItemModel{"workflow6": StageWorkflowModel{}},
 					},
 				},
 				"stage4": StageModel{
-					Workflows: []WorkflowListItemModel{
-						WorkflowListItemModel{"workflow7": WorkflowModel{}},
-						WorkflowListItemModel{"workflow8": WorkflowModel{}},
+					Workflows: []StageWorkflowListItemModel{
+						StageWorkflowListItemModel{"workflow7": StageWorkflowModel{}},
+						StageWorkflowListItemModel{"workflow8": StageWorkflowModel{}},
 					},
 				},
 			},
@@ -105,8 +106,8 @@ func TestValidateConfig(t *testing.T) {
 			},
 			Stages: map[string]StageModel{
 				"stage1": StageModel{
-					Workflows: []WorkflowListItemModel{
-						WorkflowListItemModel{"workflow1": WorkflowModel{}},
+					Workflows: []StageWorkflowListItemModel{
+						StageWorkflowListItemModel{"workflow1": StageWorkflowModel{}},
 					},
 				},
 			},
@@ -163,8 +164,8 @@ func TestValidateConfig(t *testing.T) {
 			},
 			Stages: map[string]StageModel{
 				"stage1": StageModel{
-					Workflows: []WorkflowListItemModel{
-						WorkflowListItemModel{"workflow1": WorkflowModel{}},
+					Workflows: []StageWorkflowListItemModel{
+						StageWorkflowListItemModel{"workflow1": StageWorkflowModel{}},
 					},
 				},
 			},
@@ -197,8 +198,8 @@ func TestValidateConfig(t *testing.T) {
 			FormatVersion: "1.4.0",
 			Stages: map[string]StageModel{
 				"st/id": StageModel{
-					Workflows: []WorkflowListItemModel{
-						WorkflowListItemModel{"workflow1": WorkflowModel{}},
+					Workflows: []StageWorkflowListItemModel{
+						StageWorkflowListItemModel{"workflow1": StageWorkflowModel{}},
 					},
 				},
 			},
@@ -218,7 +219,7 @@ func TestValidateConfig(t *testing.T) {
 			FormatVersion: "1.4.0",
 			Stages: map[string]StageModel{
 				"stage1": StageModel{
-					Workflows: []WorkflowListItemModel{},
+					Workflows: []StageWorkflowListItemModel{},
 				},
 			},
 		}
@@ -248,8 +249,8 @@ func TestValidateConfig(t *testing.T) {
 			FormatVersion: "1.4.0",
 			Stages: map[string]StageModel{
 				"stage1": StageModel{
-					Workflows: []WorkflowListItemModel{
-						WorkflowListItemModel{"workflow2": WorkflowModel{}},
+					Workflows: []StageWorkflowListItemModel{
+						StageWorkflowListItemModel{"workflow2": StageWorkflowModel{}},
 					},
 				},
 			},
@@ -269,8 +270,8 @@ func TestValidateConfig(t *testing.T) {
 			FormatVersion: "12",
 			Stages: map[string]StageModel{
 				"stage1": StageModel{
-					Workflows: []WorkflowListItemModel{
-						WorkflowListItemModel{"_utility_workflow": WorkflowModel{}},
+					Workflows: []StageWorkflowListItemModel{
+						StageWorkflowListItemModel{"_utility_workflow": StageWorkflowModel{}},
 					},
 				},
 			},
@@ -634,11 +635,11 @@ func TestGetInputByKey(t *testing.T) {
 // --- WorkflowIDData
 
 func TestGetWorkflowIDFromListItemModel(t *testing.T) {
-	workflowData := WorkflowModel{}
+	workflowData := StageWorkflowModel{}
 
 	t.Log("valid workflowlist item")
 	{
-		workflowListItem := WorkflowListItemModel{
+		workflowListItem := StageWorkflowListItemModel{
 			"workflow1": workflowData,
 		}
 
@@ -649,7 +650,7 @@ func TestGetWorkflowIDFromListItemModel(t *testing.T) {
 
 	t.Log("invalid workflowlist item - more than 1 workflow")
 	{
-		workflowListItem := WorkflowListItemModel{
+		workflowListItem := StageWorkflowListItemModel{
 			"workflow1": workflowData,
 			"workflow2": workflowData,
 		}
@@ -661,7 +662,7 @@ func TestGetWorkflowIDFromListItemModel(t *testing.T) {
 
 	t.Log("invalid workflowlist item - no workflow")
 	{
-		workflowListItem := WorkflowListItemModel{}
+		workflowListItem := StageWorkflowListItemModel{}
 
 		id, err := GetWorkflowIDFromListItemModel(workflowListItem)
 		require.Error(t, err)

--- a/models/models_methods_test.go
+++ b/models/models_methods_test.go
@@ -6,12 +6,11 @@ import (
 	"testing"
 	"time"
 
-	"gopkg.in/yaml.v2"
-
 	envmanModels "github.com/bitrise-io/envman/models"
 	"github.com/bitrise-io/go-utils/pointers"
 	stepmanModels "github.com/bitrise-io/stepman/models"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v2"
 )
 
 // ----------------------------
@@ -643,7 +642,7 @@ func TestGetWorkflowIDFromListItemModel(t *testing.T) {
 			"workflow1": workflowData,
 		}
 
-		id, err := GetWorkflowIDFromListItemModel(workflowListItem)
+		id, err := getWorkflowID(workflowListItem)
 		require.NoError(t, err)
 		require.Equal(t, "workflow1", id)
 	}
@@ -655,7 +654,7 @@ func TestGetWorkflowIDFromListItemModel(t *testing.T) {
 			"workflow2": workflowData,
 		}
 
-		id, err := GetWorkflowIDFromListItemModel(workflowListItem)
+		id, err := getWorkflowID(workflowListItem)
 		require.Error(t, err)
 		require.Equal(t, "", id)
 	}
@@ -664,7 +663,7 @@ func TestGetWorkflowIDFromListItemModel(t *testing.T) {
 	{
 		workflowListItem := StageWorkflowListItemModel{}
 
-		id, err := GetWorkflowIDFromListItemModel(workflowListItem)
+		id, err := getWorkflowID(workflowListItem)
 		require.Error(t, err)
 		require.Equal(t, "", id)
 	}
@@ -682,7 +681,7 @@ func TestGetStageIDFromListItemModel(t *testing.T) {
 			"stage1": stageData,
 		}
 
-		id, err := GetStageIDFromListItemModel(stageListItem)
+		id, err := getStageID(stageListItem)
 		require.NoError(t, err)
 		require.Equal(t, "stage1", id)
 	}
@@ -694,7 +693,7 @@ func TestGetStageIDFromListItemModel(t *testing.T) {
 			"stage2": stageData,
 		}
 
-		id, err := GetStageIDFromListItemModel(stageListItem)
+		id, err := getStageID(stageListItem)
 		require.Error(t, err)
 		require.Equal(t, "", id)
 	}
@@ -703,7 +702,7 @@ func TestGetStageIDFromListItemModel(t *testing.T) {
 	{
 		stageListItem := StageListItemModel{}
 
-		id, err := GetStageIDFromListItemModel(stageListItem)
+		id, err := getStageID(stageListItem)
 		require.Error(t, err)
 		require.Equal(t, "", id)
 	}


### PR DESCRIPTION
<!--
  Thanks for contributing to the Bitrise CLI!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [ ] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-io/bitrise/blob/master/.github/CONTRIBUTING.md)
- [ ] `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *PATCH* [version update](https://semver.org/)

### Context

The `StageModel` struct used the `WorkflowListItemModel` for its workflows which is the same model as what is used to describe the actual workflows. This is wrong for two reasons. 

One is that obviously you should not be able to define a whole workflow in the stage itself because that is not the place for it. For example, our yaml validation only allows a single `run_if` field to be defined in a stage workflow definition:
https://github.com/bitrise-io/bitrise-json-schemas/blob/2742accae7a40620f9d6d2322aa3f8679e2a3a6f/bitrise.schema.json#L400-L408

Second is that right now when the local workflow editor customers save their yaml the `run_if` field is removed from the stage workflows. They need to manually edit the yaml and add it back. The reason is the same which is we are using the wrong model which does not have a `run_if` field.

### Changes

I am introducing a new set of stage specific models which have only the necessary fields. Then I will create a separate PR for the workflow editor where I will pull in these changes (because the workflow editor import the data model from the CLI).