### PR TITLE
Fix per-step test result dir handling

### DIFF
--- a/cli/run_util.go
+++ b/cli/run_util.go
@@ -836,16 +836,25 @@ func (r WorkflowRunner) activateAndRunSteps(
 				"BITRISE_STEP_SOURCE_DIR": stepDir,
 			})
 
-			// ensure a new testDirPath and if created successfuly then attach it to the step process by and env
-			testDirPath, err := ioutil.TempDir(os.Getenv(configs.BitriseTestDeployDirEnvKey), "test_result")
+			testDeployDir := os.Getenv(configs.BitriseTestDeployDirEnvKey)
+			// If testDeployDir is empty, MkdirTemp() will use the default temp dir. But if it points to a path,
+			// we have to create it first.
+			if testDeployDir != "" {
+				err = os.MkdirAll(testDeployDir, 0755)
+				if err != nil {
+					log.Warnf("Failed to create %s, error: %s", configs.BitriseTestDeployDirEnvKey, err)
+					testDeployDir = ""
+				}
+			}
+			stepTestDir, err := os.MkdirTemp(testDeployDir, "step_test_result")
 			if err != nil {
-				log.Errorf("Failed to create test result dir, error: %s", err)
+				log.Errorf("Failed to create per-step test result dir: %s", err)
 			}
 
-			if testDirPath != "" {
+			if stepTestDir != "" {
 				// managed to create the test dir, set the env for it for the next step run
 				additionalEnvironments = append(additionalEnvironments, envmanModels.EnvironmentItemModel{
-					configs.BitrisePerStepTestResultDirEnvKey: testDirPath,
+					configs.BitrisePerStepTestResultDirEnvKey: stepTestDir,
 				})
 			}
 
@@ -904,8 +913,8 @@ func (r WorkflowRunner) activateAndRunSteps(
 
 			exit, outEnvironments, err := r.runStep(stepExecutionID, mergedStep, stepIDData, stepDir, stepDeclaredEnvironments, stepSecretValues, workflow, workflowID)
 
-			if testDirPath != "" {
-				if err := addTestMetadata(testDirPath, models.TestResultStepInfo{Number: idx, Title: *mergedStep.Title, ID: stepIDData.IDorURI, Version: stepIDData.Version}); err != nil {
+			if stepTestDir != "" {
+				if err := addTestMetadata(stepTestDir, models.TestResultStepInfo{Number: idx, Title: *mergedStep.Title, ID: stepIDData.IDorURI, Version: stepIDData.Version}); err != nil {
 					log.Errorf("Failed to normalize test result dir, error: %s", err)
 				}
 			}


### PR DESCRIPTION
<!--
  Thanks for contributing to the Bitrise CLI!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [ ] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-io/bitrise/blob/master/.github/CONTRIBUTING.md)
- [ ] `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *MAJOR/MINOR/PATCH* [version update](https://semver.org/)

### Context

When running in agent mode with a configured cleanup, this error happens:

```
Failed to create test result dir, error: stat /opt/bitrise/app-059dfbc7-01c7-4fe5-9e8d-56edac26ef83/build-e7963020-451e-4cde-9b32-09be5de1a73a/test_results: no such file or directory
```

This is caused by not making sure that the parent dir exists before calling `os.MkdirTemp()` on it: https://cs.opensource.google/go/go/+/refs/tags/go1.22.0:src/os/tempfile.go;l=108

### Changes



### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->