### PR TITLE
Setup no longer installs analytics plugin

### DIFF
--- a/bitrise/setup.go
+++ b/bitrise/setup.go
@@ -38,10 +38,6 @@ var PluginDependencyMap = map[string]PluginDependency{
 		Source:     "https://github.com/bitrise-io/bitrise-workflow-editor.git",
 		MinVersion: "1.3.246",
 	},
-	"analytics": {
-		Source:     "https://github.com/bitrise-io/bitrise-plugins-analytics.git",
-		MinVersion: "0.13.1",
-	},
 }
 
 // RunSetupIfNeeded ...

--- a/plugins/install_test.go
+++ b/plugins/install_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 const examplePluginGitURL = "https://github.com/bitrise-io/bitrise-plugins-example.git"
-const analyticsPluginBinURL = "https://github.com/bitrise-io/bitrise-plugins-analytics/releases/download/0.9.1/analytics-Darwin-x86_64"
+const testPluginBinURL = "https://github.com/bitrise-io/bitrise-plugins-step/releases/download/0.10.4/bitrise-plugins-step-Darwin-arm64"
 
 func TestIsLocalURL(t *testing.T) {
 	t.Log("local url - absolute")
@@ -199,7 +199,6 @@ func TestValidateRequirements(t *testing.T) {
 func TestDownloadPluginBin(t *testing.T) {
 	t.Log("example plugin bin - ")
 	{
-		pluginBinURL := analyticsPluginBinURL
 		destinationDir, err := pathutil.NormalizedOSTempDirPath("TestDownloadPluginBin")
 		require.NoError(t, err)
 
@@ -214,7 +213,7 @@ func TestDownloadPluginBin(t *testing.T) {
 
 		destinationPth := filepath.Join(destinationDir, "example")
 
-		require.NoError(t, downloadPluginBin(pluginBinURL, destinationPth))
+		require.NoError(t, downloadPluginBin(testPluginBinURL, destinationPth))
 
 		exist, err = pathutil.IsPathExists(destinationPth)
 		require.NoError(t, err)
@@ -228,12 +227,12 @@ func Test_isSourceURIChanged(t *testing.T) {
 		new       string
 		want      bool
 	}{
-		{installed: "https://github.com/bitrise-core/bitrise-plugins-analytics.git", new: "https://github.com/bitrise-core/bitrise-plugins-analytics.git", want: false},
-		{installed: "https://github.com/bitrise-core/bitrise-plugins-analytics.git", new: "https://github.com/bitrise-io/bitrise-plugins-analytics.git", want: false},
-		{installed: "https://github.com/bitrise-core/bitrise-plugins-analytics.git", new: "https://github.com/myorg/bitrise-plugins-analytics.git", want: true},
-		{installed: "https://github.com/bitrise-core/bitrise-plugins-analytics.git", new: "https://github.com/bitrise-team/bitrise-plugins-analytics.git", want: true},
-		{installed: "https://github.com/bitrise-custom-org/bitrise-plugins-analytics.git", new: "https://github.com/bitrise-core/bitrise-plugins-analytics.git", want: true},
-		{installed: "https://github.com/bitrise-custom-org/bitrise-plugins-analytics.git", new: "https://github.com/bitrise-io/bitrise-plugins-analytics.git", want: true},
+		{installed: "https://github.com/bitrise-core/bitrise-plugins-step.git", new: "https://github.com/bitrise-core/bitrise-plugins-step.git", want: false},
+		{installed: "https://github.com/bitrise-core/bitrise-plugins-step.git", new: "https://github.com/bitrise-io/bitrise-plugins-step.git", want: false}, // resolves to same real URL
+		{installed: "https://github.com/bitrise-core/bitrise-plugins-step.git", new: "https://github.com/myorg/bitrise-plugins-step.git", want: true},
+		{installed: "https://github.com/bitrise-core/bitrise-plugins-step.git", new: "https://github.com/bitrise-team/bitrise-plugins-step.git", want: true},
+		{installed: "https://github.com/bitrise-custom-org/bitrise-plugins-step.git", new: "https://github.com/bitrise-core/bitrise-plugins-step.git", want: true},
+		{installed: "https://github.com/bitrise-custom-org/bitrise-plugins-step.git", new: "https://github.com/bitrise-io/bitrise-plugins-step.git", want: true},
 	} {
 		t.Run("", func(t *testing.T) {
 			if got := isSourceURIChanged(tt.installed, tt.new); got != tt.want {


### PR DESCRIPTION
<!--
  Thanks for contributing to the Bitrise CLI!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [ ] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-io/bitrise/blob/master/.github/CONTRIBUTING.md)
- [ ] `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *PATCH* [version update](https://semver.org/)

### Context

Do no longer install analytics plugin in `bitrise setup`.

<!-- Please link the issue that the PR fixes.
Resolves: #GITHUB_ISSUE_ID or https://link_to_the_issue_on_discuss.bitrise.io.
-->

### Changes

<!-- 
  Details are important, and help maintainers processing your PR.
  Please list additional details, for example:
  - Update dependencies
  - Make `foo` optional in `main.go`
  - `foo` now returns an `error` for better error handling
-->

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->