### PR TITLE
Advanced trigger map

### DIFF
--- a/_tests/integration/version_test.go
+++ b/_tests/integration/version_test.go
@@ -8,6 +8,8 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/bitrise-io/bitrise/models"
+
 	"github.com/bitrise-io/bitrise/version"
 	"github.com/bitrise-io/go-utils/command"
 	"github.com/stretchr/testify/require"
@@ -21,11 +23,11 @@ func Test_VersionOutput(t *testing.T) {
 
 		expectedOSVersion := fmt.Sprintf("%s (%s)", runtime.GOOS, runtime.GOARCH)
 		expectedVersionOut := fmt.Sprintf(`version: %s
-format version: 13
+format version: %s
 os: %s
 go: %s
 build number: 
-commit: (devel)`, version.VERSION, expectedOSVersion, runtime.Version())
+commit: (devel)`, version.VERSION, models.FormatVersion, expectedOSVersion, runtime.Version())
 
 		require.Equal(t, expectedVersionOut, out)
 	}

--- a/models/models.go
+++ b/models/models.go
@@ -11,7 +11,7 @@ import (
 
 const (
 	// FormatVersion ...
-	FormatVersion = "13"
+	FormatVersion = "14"
 )
 
 // StepListItemModel ...

--- a/models/models_methods.go
+++ b/models/models_methods.go
@@ -142,6 +142,12 @@ func (config *BitriseDataModel) Normalize() error {
 		return err
 	}
 
+	normalizedTriggerMap, err := config.TriggerMap.Normalised()
+	if err != nil {
+		return err
+	}
+	config.TriggerMap = normalizedTriggerMap
+
 	for _, workflow := range config.Workflows {
 		if err := workflow.Normalize(); err != nil {
 			return err

--- a/models/models_methods.go
+++ b/models/models_methods.go
@@ -142,7 +142,7 @@ func (config *BitriseDataModel) Normalize() error {
 		return err
 	}
 
-	normalizedTriggerMap, err := config.TriggerMap.Normalised()
+	normalizedTriggerMap, err := config.TriggerMap.Normalized()
 	if err != nil {
 		return err
 	}

--- a/models/models_methods_test.go
+++ b/models/models_methods_test.go
@@ -405,7 +405,7 @@ workflows:
 
 		warnings, err := config.Validate()
 		require.NoError(t, err)
-		require.Equal(t, []string{"workflow (_deps-update) defined in trigger item (push_branch: /release -> workflow: _deps-update), but utility workflows can't be triggered directly"}, warnings)
+		require.Equal(t, []string{"utility workflow (_deps-update) defined as trigger target for the 1. trigger item, but utility workflows can't be triggered directly"}, warnings)
 	}
 
 	t.Log("pipeline not exists")
@@ -436,7 +436,7 @@ workflows:
 		require.NoError(t, err)
 
 		_, err = config.Validate()
-		require.EqualError(t, err, "pipeline (release) defined in trigger item (push_branch: /release -> pipeline: release), but does not exist")
+		require.EqualError(t, err, "pipeline (release) defined in the 1. trigger item, but does not exist")
 	}
 
 	t.Log("workflow not exists")
@@ -457,7 +457,7 @@ workflows:
 		require.NoError(t, err)
 
 		_, err = config.Validate()
-		require.EqualError(t, err, "workflow (release) defined in trigger item (push_branch: /release -> workflow: release), but does not exist")
+		require.EqualError(t, err, "workflow (release) defined in the 1. trigger item, but does not exist")
 	}
 }
 

--- a/models/models_methods_test.go
+++ b/models/models_methods_test.go
@@ -581,7 +581,7 @@ workflows:
 
 		warnings, err := config.Validate()
 		require.NoError(t, err)
-		require.Equal(t, []string{"utility workflow (_deps-update) defined as trigger target for the 1. trigger item, but utility workflows can't be triggered directly"}, warnings)
+		require.Equal(t, []string{"trigger item #1: utility workflow (_deps-update) defined as trigger target, but utility workflows can't be triggered directly"}, warnings)
 	}
 
 	t.Log("pipeline not exists")
@@ -612,7 +612,7 @@ workflows:
 		require.NoError(t, err)
 
 		_, err = config.Validate()
-		require.EqualError(t, err, "pipeline (release) defined in the 1. trigger item, but does not exist")
+		require.EqualError(t, err, "trigger item #1: non-existent pipeline defined as trigger target: release")
 	}
 
 	t.Log("workflow not exists")
@@ -633,7 +633,7 @@ workflows:
 		require.NoError(t, err)
 
 		_, err = config.Validate()
-		require.EqualError(t, err, "workflow (release) defined in the 1. trigger item, but does not exist")
+		require.EqualError(t, err, "trigger item #1: non-existent workflow defined as trigger target: release")
 	}
 }
 

--- a/models/models_methods_test.go
+++ b/models/models_methods_test.go
@@ -25,7 +25,7 @@ func TestJSONMarshal(t *testing.T) {
 		wantErr   string
 	}{
 		{
-			name: "valid legacy trigger map",
+			name: "Step inputs are normalized",
 			config: `format_version: "13"
 default_step_lib_source: "https://github.com/bitrise-io/bitrise-steplib.git"
 
@@ -39,7 +39,7 @@ workflows:
             is_expand: false`,
 		},
 		{
-			name: "valid legacy trigger map",
+			name: "Trigger map items are normalized",
 			config: `format_version: 13
 default_step_lib_source: "https://github.com/bitrise-io/bitrise-steplib.git"
 

--- a/models/trigger_map.go
+++ b/models/trigger_map.go
@@ -8,8 +8,8 @@ type TriggerMapModel []TriggerMapItemModel
 
 func (triggerMap TriggerMapModel) Normalised() ([]TriggerMapItemModel, error) {
 	var items []TriggerMapItemModel
-	for _, item := range triggerMap {
-		normalizedItem, err := item.Normalized()
+	for idx, item := range triggerMap {
+		normalizedItem, err := item.Normalized(idx)
 		if err != nil {
 			return nil, err
 		}

--- a/models/trigger_map.go
+++ b/models/trigger_map.go
@@ -46,7 +46,7 @@ func (triggerMap TriggerMapModel) checkDuplicatedTriggerMapItems() error {
 
 		storedItemIdx, ok := items[itemStr]
 		if ok {
-			return fmt.Errorf("the %d. trigger item duplicates the %d. trigger item", idx+1, storedItemIdx)
+			return fmt.Errorf("the %d. trigger item duplicates the %d. trigger item", idx+1, storedItemIdx+1)
 		}
 
 		items[itemStr] = idx

--- a/models/trigger_map.go
+++ b/models/trigger_map.go
@@ -6,6 +6,18 @@ import (
 
 type TriggerMapModel []TriggerMapItemModel
 
+func (triggerMap TriggerMapModel) Normalised() ([]TriggerMapItemModel, error) {
+	var items []TriggerMapItemModel
+	for _, item := range triggerMap {
+		normalizedItem, err := item.Normalized()
+		if err != nil {
+			return nil, err
+		}
+		items = append(items, normalizedItem)
+	}
+	return items, nil
+}
+
 func (triggerMap TriggerMapModel) Validate(workflows, pipelines []string) ([]string, error) {
 	var warnings []string
 

--- a/models/trigger_map.go
+++ b/models/trigger_map.go
@@ -42,7 +42,7 @@ func (triggerMap TriggerMapModel) checkDuplicatedTriggerMapItems() error {
 	items := make(map[string]int)
 
 	for idx, triggerItem := range triggerMap {
-		itemStr := triggerItem.String()
+		itemStr := triggerItem.conditionsString()
 
 		storedItemIdx, ok := items[itemStr]
 		if ok {

--- a/models/trigger_map.go
+++ b/models/trigger_map.go
@@ -6,7 +6,7 @@ import (
 
 type TriggerMapModel []TriggerMapItemModel
 
-func (triggerMap TriggerMapModel) Normalised() ([]TriggerMapItemModel, error) {
+func (triggerMap TriggerMapModel) Normalized() ([]TriggerMapItemModel, error) {
 	var items []TriggerMapItemModel
 	for idx, item := range triggerMap {
 		normalizedItem, err := item.Normalized(idx)

--- a/models/trigger_map_item.go
+++ b/models/trigger_map_item.go
@@ -35,9 +35,9 @@ type TriggerItemConditionRegexValue struct {
 type TriggerItemType string
 
 const (
-	CodePushType    TriggerItemType = "code-push"
-	PullRequestType TriggerItemType = "pull-request"
-	TagPushType     TriggerItemType = "tag-push"
+	CodePushType    TriggerItemType = "push"
+	PullRequestType TriggerItemType = "pull_request"
+	TagPushType     TriggerItemType = "tag"
 )
 
 type TriggerMapItemModel struct {

--- a/models/trigger_map_item.go
+++ b/models/trigger_map_item.go
@@ -422,13 +422,13 @@ func validateStringOrRegexType(idx int, field string, value interface{}) error {
 		return nil
 	}
 
-	valueStringMap, ok := value.(map[string]string)
+	valueMap, ok := value.(map[interface{}]interface{})
 	if ok {
-		if len(valueStringMap) != 1 {
+		if len(valueMap) != 1 {
 			return fmt.Errorf("single 'regex' key is expected for regex condition in %s field of the %d. trigger item", field, idx+1)
 		}
 
-		_, ok := valueStringMap["regex"]
+		_, ok := valueMap["regex"]
 		if !ok {
 			return fmt.Errorf("'regex' key is expected for regex condition in %s field of the %d. trigger item", field, idx+1)
 		}
@@ -455,6 +455,20 @@ func validateStringOrRegexType(idx int, field string, value interface{}) error {
 		return nil
 	}
 
+	valueStringMap, ok := value.(map[string]string)
+	if ok {
+		if len(valueStringMap) != 1 {
+			return fmt.Errorf("single 'regex' key is expected for regex condition in %s field of the %d. trigger item", field, idx+1)
+		}
+
+		_, ok := valueStringMap["regex"]
+		if !ok {
+			return fmt.Errorf("'regex' key is expected for regex condition in %s field of the %d. trigger item", field, idx+1)
+		}
+
+		return nil
+	}
+
 	return fmt.Errorf("string literal or regex value is expected for %s in the %d. trigger item", field, idx+1)
 }
 
@@ -474,9 +488,12 @@ func stringLiteralOrRegex(value interface{}) string {
 		return string(str)
 	}
 
-	valueStringMap, ok := value.(map[string]string)
+	valueMap, ok := value.(map[interface{}]interface{})
 	if ok {
-		return valueStringMap["regex"]
+		regex, ok := valueMap["regex"]
+		if ok {
+			return regex.(string)
+		}
 	}
 
 	valueInterfaceMap, ok := value.(map[string]interface{})
@@ -485,6 +502,11 @@ func stringLiteralOrRegex(value interface{}) string {
 		if ok {
 			return regex.(string)
 		}
+	}
+
+	valueStringMap, ok := value.(map[string]string)
+	if ok {
+		return valueStringMap["regex"]
 	}
 
 	return ""

--- a/models/trigger_map_item.go
+++ b/models/trigger_map_item.go
@@ -234,23 +234,23 @@ func (item TriggerMapItemModel) validateTarget(idx int, workflows, pipelines []s
 
 	// Validate target
 	if item.PipelineID != "" && item.WorkflowID != "" {
-		return warnings, fmt.Errorf("both pipeline and workflow are defined as trigger target for the %d. trigger item", idx+1)
+		return warnings, fmt.Errorf("trigger item #%d: both pipeline and workflow are defined as trigger target", idx+1)
 	}
 	if item.PipelineID == "" && item.WorkflowID == "" {
-		return warnings, fmt.Errorf("no pipeline nor workflow is defined as a trigger target for the %d. trigger item", idx+1)
+		return warnings, fmt.Errorf("trigger item #%d: no pipeline nor workflow is defined as trigger target", idx+1)
 	}
 
 	if strings.HasPrefix(item.WorkflowID, "_") {
-		warnings = append(warnings, fmt.Sprintf("utility workflow (%s) defined as trigger target for the %d. trigger item, but utility workflows can't be triggered directly", item.WorkflowID, idx+1))
+		warnings = append(warnings, fmt.Sprintf("trigger item #%d: utility workflow (%s) defined as trigger target, but utility workflows can't be triggered directly", idx+1, item.WorkflowID))
 	}
 
 	if item.PipelineID != "" {
 		if !sliceutil.IsStringInSlice(item.PipelineID, pipelines) {
-			return warnings, fmt.Errorf("pipeline (%s) defined in the %d. trigger item, but does not exist", item.PipelineID, idx+1)
+			return warnings, fmt.Errorf("trigger item #%d: non-existent pipeline defined as trigger target: %s", idx+1, item.PipelineID)
 		}
 	} else {
 		if !sliceutil.IsStringInSlice(item.WorkflowID, workflows) {
-			return warnings, fmt.Errorf("workflow (%s) defined in the %d. trigger item, but does not exist", item.WorkflowID, idx+1)
+			return warnings, fmt.Errorf("trigger item #%d: non-existent workflow defined as trigger target: %s", idx+1, item.WorkflowID)
 		}
 	}
 
@@ -273,7 +273,7 @@ func (item TriggerMapItemModel) validateLegacyItemType(idx int) error {
 func (item TriggerMapItemModel) validateType(idx int) error {
 	if item.Type != "" {
 		if !sliceutil.IsStringInSlice(string(item.Type), []string{string(CodePushType), string(PullRequestType), string(TagPushType)}) {
-			return fmt.Errorf("invalid type (%s) set in the %d. trigger item, valid types are: push, pull_request and tag", item.Type, idx+1)
+			return fmt.Errorf("trigger item #%d: invalid type (%s) defined, valid types are: push, pull_request and tag", idx+1, item.Type)
 		}
 	}
 
@@ -335,7 +335,7 @@ func (item TriggerMapItemModel) validateType(idx int) error {
 		return nil
 	}
 
-	return fmt.Errorf("no type or trigger condition defined in the %d. trigger item", idx+1)
+	return fmt.Errorf("trigger item #%d: no type or relevant trigger condition defined", idx+1)
 }
 
 func (item TriggerMapItemModel) validateConditionValues(idx int) error {
@@ -367,37 +367,37 @@ func (item TriggerMapItemModel) validateConditionValues(idx int) error {
 
 func (item TriggerMapItemModel) validateNoCodePushConditionsSet(idx int, field string) error {
 	if isStringLiteralOrRegexSet(item.PushBranch) {
-		return fmt.Errorf("both %s and push_branch defined in the %d. trigger item", field, idx+1)
+		return fmt.Errorf("trigger item #%d: both %s and push_branch defined", idx+1, field)
 	}
 	if isStringLiteralOrRegexSet(item.CommitMessage) {
-		return fmt.Errorf("both %s and commit_message defined in the %d. trigger item", field, idx+1)
+		return fmt.Errorf("trigger item #%d:  both %s and commit_message defined", idx+1, field)
 	}
 	if isStringLiteralOrRegexSet(item.ChangedFiles) {
-		return fmt.Errorf("both %s and changed_files defined in the %d. trigger item", field, idx+1)
+		return fmt.Errorf("trigger item #%d:  both %s and changed_files defined", idx+1, field)
 	}
 	return nil
 }
 
 func (item TriggerMapItemModel) validateNoTagPushConditionsSet(idx int, field string) error {
 	if isStringLiteralOrRegexSet(item.Tag) {
-		return fmt.Errorf("both %s and tag defined in the %d. trigger item", field, idx+1)
+		return fmt.Errorf("trigger item #%d: both %s and tag defined", idx+1, field)
 	}
 	return nil
 }
 
 func (item TriggerMapItemModel) validateNoPullRequestConditionsSet(idx int, field string) error {
 	if isStringLiteralOrRegexSet(item.PullRequestSourceBranch) {
-		return fmt.Errorf("both %s and pull_request_source_branch defined in the %d. trigger item", field, idx+1)
+		return fmt.Errorf("trigger item #%d: both %s and pull_request_source_branch defined", idx+1, field)
 	}
 	if isStringLiteralOrRegexSet(item.PullRequestTargetBranch) {
-		return fmt.Errorf("both %s and pull_request_target_branch defined in the %d. trigger item", field, idx+1)
+		return fmt.Errorf("trigger item #%d: both %s and pull_request_target_branch defined", idx+1, field)
 	}
 	//nolint:gosimple
 	if item.IsDraftPullRequestEnabled() != defaultDraftPullRequestEnabled {
-		return fmt.Errorf("both %s and draft_pull_request_enabled defined in the %d. trigger item", field, idx+1)
+		return fmt.Errorf("trigger item #%d: both %s and draft_pull_request_enabled defined", idx+1, field)
 	}
 	if isStringLiteralOrRegexSet(item.PullRequestLabel) {
-		return fmt.Errorf("both %s and pull_request_label defined in the %d. trigger item", field, idx+1)
+		return fmt.Errorf("trigger item #%d: both %s and pull_request_label defined", idx+1, field)
 	}
 	return nil
 }
@@ -471,12 +471,12 @@ func validateStringOrRegexType(idx int, field string, value interface{}) error {
 	valueMap, ok := value.(map[interface{}]interface{})
 	if ok {
 		if len(valueMap) != 1 {
-			return fmt.Errorf("single 'regex' key is expected for regex condition in %s field of the %d. trigger item", field, idx+1)
+			return fmt.Errorf("trigger item #%d: single 'regex' key is expected for regex condition in %s field", idx+1, field)
 		}
 
 		_, ok := valueMap["regex"]
 		if !ok {
-			return fmt.Errorf("'regex' key is expected for regex condition in %s field of the %d. trigger item", field, idx+1)
+			return fmt.Errorf("trigger item #%d: 'regex' key is expected for regex condition in %s field", idx+1, field)
 		}
 
 		return nil
@@ -485,17 +485,17 @@ func validateStringOrRegexType(idx int, field string, value interface{}) error {
 	valueInterfaceMap, ok := value.(map[string]interface{})
 	if ok {
 		if len(valueInterfaceMap) != 1 {
-			return fmt.Errorf("single 'regex' key is expected for regex condition in %s field of the %d. trigger item", field, idx+1)
+			return fmt.Errorf("trigger item #%d: single 'regex' key is expected for regex condition in %s field", idx+1, field)
 		}
 
 		regex, ok := valueInterfaceMap["regex"]
 		if !ok {
-			return fmt.Errorf("'regex' key is expected for regex condition in %s field of the %d. trigger item", field, idx+1)
+			return fmt.Errorf("trigger item #%d: 'regex' key is expected for regex condition in %s field", idx+1, field)
 		}
 
 		_, ok = regex.(string)
 		if !ok {
-			return fmt.Errorf("'regex' key is expected to have a string value in %s field of the %d. trigger item", field, idx+1)
+			return fmt.Errorf("trigger item #%d: 'regex' key is expected to have a string value in %s field", idx+1, field)
 		}
 
 		return nil
@@ -504,18 +504,18 @@ func validateStringOrRegexType(idx int, field string, value interface{}) error {
 	valueStringMap, ok := value.(map[string]string)
 	if ok {
 		if len(valueStringMap) != 1 {
-			return fmt.Errorf("single 'regex' key is expected for regex condition in %s field of the %d. trigger item", field, idx+1)
+			return fmt.Errorf("trigger item #%d: single 'regex' key is expected for regex condition in %s field", idx+1, field)
 		}
 
 		_, ok := valueStringMap["regex"]
 		if !ok {
-			return fmt.Errorf("'regex' key is expected for regex condition in %s field of the %d. trigger item", field, idx+1)
+			return fmt.Errorf("trigger item #%d: 'regex' key is expected for regex condition in %s field", idx+1, field)
 		}
 
 		return nil
 	}
 
-	return fmt.Errorf("string literal or regex value is expected for %s in the %d. trigger item", field, idx+1)
+	return fmt.Errorf("trigger item #%d: string literal or regex value is expected for %s field", idx+1, field)
 }
 
 func stringFromTriggerCondition(value interface{}) string {
@@ -613,7 +613,7 @@ func castInterfaceKeysToStringKeys(idx int, field string, value map[interface{}]
 	for key, value := range value {
 		keyStr, ok := key.(string)
 		if !ok {
-			return nil, fmt.Errorf("%s should be a string literal or a hash with a single 'regex' key in the %d. trigger item", field, idx+1)
+			return nil, fmt.Errorf("trigger item #%d: %s field should be a string literal or a hash with a single 'regex' key", idx+1, field)
 		}
 		mapString[keyStr] = value
 	}

--- a/models/trigger_map_item.go
+++ b/models/trigger_map_item.go
@@ -345,6 +345,7 @@ func (item TriggerMapItemModel) validateNoPullRequestConditionsSet(idx int, fiel
 	if isStringLiteralOrRegexSet(item.PullRequestTargetBranch) {
 		return fmt.Errorf("both %s and pull_request_target_branch defined in the %d. trigger item", field, idx+1)
 	}
+	//nolint:gosimple
 	if item.IsDraftPullRequestEnabled() != defaultDraftPullRequestEnabled {
 		return fmt.Errorf("both %s and draft_pull_request_enabled defined in the %d. trigger item", field, idx+1)
 	}
@@ -374,6 +375,7 @@ func (item TriggerMapItemModel) conditionsString() string {
 
 		if tag == "draft_pull_request_enabled" {
 			if boolPtrValue, ok := value.(*bool); ok {
+				//nolint:gosimple
 				if boolPtrValue == nil || *boolPtrValue == defaultDraftPullRequestEnabled {
 					continue
 				}

--- a/models/trigger_map_item.go
+++ b/models/trigger_map_item.go
@@ -38,15 +38,15 @@ const (
 
 type TriggerMapItemModel struct {
 	// Trigger Item shared properties
-	Type       TriggerItemType `json:"type" yaml:"type"`
-	Enabled    bool            `json:"enabled" yaml:"enabled"`
+	Type       TriggerItemType `json:"type,omitempty" yaml:"type,omitempty"`
+	Enabled    bool            `json:"enabled,omitempty" yaml:"enabled,omitempty"`
 	PipelineID string          `json:"pipeline,omitempty" yaml:"pipeline,omitempty"`
 	WorkflowID string          `json:"workflow,omitempty" yaml:"workflow,omitempty"`
 
 	// Code Push Item conditions
 	PushBranch    interface{} `json:"push_branch,omitempty" yaml:"push_branch,omitempty"`
-	CommitMessage interface{} `json:"commit_message" yaml:"commit_message"`
-	ChangedFiles  interface{} `json:"changed_files" yaml:"changed_files"`
+	CommitMessage interface{} `json:"commit_message,omitempty" yaml:"commit_message,omitempty"`
+	ChangedFiles  interface{} `json:"changed_files,omitempty" yaml:"changed_files,omitempty"`
 
 	// Tag Push Item conditions
 	Tag interface{} `json:"tag,omitempty" yaml:"tag,omitempty"`
@@ -55,7 +55,7 @@ type TriggerMapItemModel struct {
 	PullRequestSourceBranch interface{} `json:"pull_request_source_branch,omitempty" yaml:"pull_request_source_branch,omitempty"`
 	PullRequestTargetBranch interface{} `json:"pull_request_target_branch,omitempty" yaml:"pull_request_target_branch,omitempty"`
 	DraftPullRequestEnabled *bool       `json:"draft_pull_request_enabled,omitempty" yaml:"draft_pull_request_enabled,omitempty"`
-	PullRequestLabel        interface{} `json:"pull_request_label" yaml:"pull_request_label"`
+	PullRequestLabel        interface{} `json:"pull_request_label,omitempty" yaml:"pull_request_label,omitempty"`
 
 	// Deprecated properties
 	Pattern              string `json:"pattern,omitempty" yaml:"pattern,omitempty"`

--- a/models/trigger_map_item.go
+++ b/models/trigger_map_item.go
@@ -421,11 +421,40 @@ func validateStringOrRegexType(idx int, field string, value interface{}) error {
 	if ok {
 		return nil
 	}
-	// TODO: check key
-	_, ok = value.(map[string]string)
+
+	valueStringMap, ok := value.(map[string]string)
 	if ok {
+		if len(valueStringMap) != 1 {
+			return fmt.Errorf("single 'regex' key is expected for regex condition in %s field of the %d. trigger item", field, idx+1)
+		}
+
+		_, ok := valueStringMap["regex"]
+		if !ok {
+			return fmt.Errorf("'regex' key is expected for regex condition in %s field of the %d. trigger item", field, idx+1)
+		}
+
 		return nil
 	}
+
+	valueInterfaceMap, ok := value.(map[string]interface{})
+	if ok {
+		if len(valueInterfaceMap) != 1 {
+			return fmt.Errorf("single 'regex' key is expected for regex condition in %s field of the %d. trigger item", field, idx+1)
+		}
+
+		regex, ok := valueInterfaceMap["regex"]
+		if !ok {
+			return fmt.Errorf("'regex' key is expected for regex condition in %s field of the %d. trigger item", field, idx+1)
+		}
+
+		_, ok = regex.(string)
+		if !ok {
+			return fmt.Errorf("'regex' key is expected to have a string value in %s field of the %d. trigger item", field, idx+1)
+		}
+
+		return nil
+	}
+
 	return fmt.Errorf("string literal or regex value is expected for %s in the %d. trigger item", field, idx+1)
 }
 
@@ -445,10 +474,19 @@ func stringLiteralOrRegex(value interface{}) string {
 		return string(str)
 	}
 
-	regex, ok := value.(map[string]string)
+	valueStringMap, ok := value.(map[string]string)
 	if ok {
-		return regex["regex"]
+		return valueStringMap["regex"]
 	}
+
+	valueInterfaceMap, ok := value.(map[string]interface{})
+	if ok {
+		regex, ok := valueInterfaceMap["regex"]
+		if ok {
+			return regex.(string)
+		}
+	}
+
 	return ""
 }
 

--- a/models/trigger_map_item.go
+++ b/models/trigger_map_item.go
@@ -138,6 +138,8 @@ func (item TriggerMapItemModel) IsDraftPullRequestEnabled() bool {
 	return draftPullRequestEnabled
 }
 
+// Normalized casts trigger item values from map[interface{}]interface{} to map[string]interface{}
+// to support JSON marshalling of the bitrise.yml.
 func (item TriggerMapItemModel) Normalized(idx int) (TriggerMapItemModel, error) {
 	mapInterface, ok := item.PushBranch.(map[interface{}]interface{})
 	if ok {

--- a/models/trigger_map_item.go
+++ b/models/trigger_map_item.go
@@ -281,31 +281,58 @@ func (item TriggerMapItemModel) validateLegacyItemType(idx int) error {
 }
 
 func (item TriggerMapItemModel) validateType(idx int) error {
-	// TODO: fix error message (not necessarily condition defines the type)
-
 	if isStringLiteralOrRegexSet(item.PushBranch) || item.Type == CodePushType {
-		if err := item.validateNoTagPushConditionsSet(idx, "push_branch"); err != nil {
+		var field string
+		if item.Type != "" {
+			field = fmt.Sprintf("type: %s", item.Type)
+		} else {
+			field = "push_branch"
+		}
+
+		if err := item.validateNoTagPushConditionsSet(idx, field); err != nil {
 			return err
 		}
-		if err := item.validateNoPullRequestConditionsSet(idx, "push_branch"); err != nil {
+		if err := item.validateNoPullRequestConditionsSet(idx, field); err != nil {
 			return err
 		}
 
 		return nil
 	} else if isStringLiteralOrRegexSet(item.PullRequestSourceBranch) || isStringLiteralOrRegexSet(item.PullRequestTargetBranch) || item.Type == PullRequestType {
-		if err := item.validateNoCodePushConditionsSet(idx, "pull_request_source_branch"); err != nil {
+		var field string
+		if item.Type != "" {
+			field = fmt.Sprintf("type: %s", item.Type)
+		} else {
+			if isStringLiteralOrRegexSet(item.PullRequestSourceBranch) {
+				field = "pull_request_source_branch"
+			}
+			if isStringLiteralOrRegexSet(item.PullRequestTargetBranch) {
+				if field != "" {
+					field += " and "
+				}
+				field += "pull_request_target_branch"
+			}
+		}
+
+		if err := item.validateNoCodePushConditionsSet(idx, field); err != nil {
 			return err
 		}
-		if err := item.validateNoTagPushConditionsSet(idx, "pull_request_source_branch"); err != nil {
+		if err := item.validateNoTagPushConditionsSet(idx, field); err != nil {
 			return err
 		}
 
 		return nil
 	} else if isStringLiteralOrRegexSet(item.Tag) || item.Type == TagPushType {
-		if err := item.validateNoCodePushConditionsSet(idx, "tag"); err != nil {
+		var field string
+		if item.Type != "" {
+			field = fmt.Sprintf("type: %s", item.Type)
+		} else {
+			field = "tag"
+		}
+
+		if err := item.validateNoCodePushConditionsSet(idx, field); err != nil {
 			return err
 		}
-		if err := item.validateNoPullRequestConditionsSet(idx, "tag"); err != nil {
+		if err := item.validateNoPullRequestConditionsSet(idx, field); err != nil {
 			return err
 		}
 

--- a/models/trigger_map_item.go
+++ b/models/trigger_map_item.go
@@ -50,6 +50,7 @@ type TriggerMapItemModel struct {
 	WorkflowID string          `json:"workflow,omitempty" yaml:"workflow,omitempty"`
 
 	// Code Push Item conditions
+	// TODO: introduce regex values
 	PushBranch    string `json:"push_branch,omitempty" yaml:"push_branch,omitempty"`
 	CommitMessage string `json:"commit_message" yaml:"commit_message"`
 	ChangedFiles  string `json:"changed_files" yaml:"changed_files"`
@@ -87,6 +88,8 @@ func (triggerItem TriggerMapItemModel) Validate(idx int, workflows, pipelines []
 			return warnings, err
 		}
 	}
+
+	// TODO: validate condition values (regex or string literal)
 
 	return warnings, nil
 }

--- a/models/trigger_map_item.go
+++ b/models/trigger_map_item.go
@@ -138,10 +138,10 @@ func (item TriggerMapItemModel) IsDraftPullRequestEnabled() bool {
 	return draftPullRequestEnabled
 }
 
-func (item TriggerMapItemModel) Normalized() (TriggerMapItemModel, error) {
+func (item TriggerMapItemModel) Normalized(idx int) (TriggerMapItemModel, error) {
 	mapInterface, ok := item.PushBranch.(map[interface{}]interface{})
 	if ok {
-		value, err := castInterfaceKeysToStringKeys("push_branch", mapInterface)
+		value, err := castInterfaceKeysToStringKeys(idx, "push_branch", mapInterface)
 		if err != nil {
 			return TriggerMapItemModel{}, err
 		}
@@ -150,7 +150,7 @@ func (item TriggerMapItemModel) Normalized() (TriggerMapItemModel, error) {
 
 	mapInterface, ok = item.CommitMessage.(map[interface{}]interface{})
 	if ok {
-		value, err := castInterfaceKeysToStringKeys("commit_message", mapInterface)
+		value, err := castInterfaceKeysToStringKeys(idx, "commit_message", mapInterface)
 		if err != nil {
 			return TriggerMapItemModel{}, err
 		}
@@ -159,7 +159,7 @@ func (item TriggerMapItemModel) Normalized() (TriggerMapItemModel, error) {
 
 	mapInterface, ok = item.ChangedFiles.(map[interface{}]interface{})
 	if ok {
-		value, err := castInterfaceKeysToStringKeys("changed_files", mapInterface)
+		value, err := castInterfaceKeysToStringKeys(idx, "changed_files", mapInterface)
 		if err != nil {
 			return TriggerMapItemModel{}, err
 		}
@@ -168,7 +168,7 @@ func (item TriggerMapItemModel) Normalized() (TriggerMapItemModel, error) {
 
 	mapInterface, ok = item.Tag.(map[interface{}]interface{})
 	if ok {
-		value, err := castInterfaceKeysToStringKeys("tag", mapInterface)
+		value, err := castInterfaceKeysToStringKeys(idx, "tag", mapInterface)
 		if err != nil {
 			return TriggerMapItemModel{}, err
 		}
@@ -177,7 +177,7 @@ func (item TriggerMapItemModel) Normalized() (TriggerMapItemModel, error) {
 
 	mapInterface, ok = item.PullRequestSourceBranch.(map[interface{}]interface{})
 	if ok {
-		value, err := castInterfaceKeysToStringKeys("pull_request_source_branch", mapInterface)
+		value, err := castInterfaceKeysToStringKeys(idx, "pull_request_source_branch", mapInterface)
 		if err != nil {
 			return TriggerMapItemModel{}, err
 		}
@@ -186,7 +186,7 @@ func (item TriggerMapItemModel) Normalized() (TriggerMapItemModel, error) {
 
 	mapInterface, ok = item.PullRequestTargetBranch.(map[interface{}]interface{})
 	if ok {
-		value, err := castInterfaceKeysToStringKeys("pull_request_target_branch", mapInterface)
+		value, err := castInterfaceKeysToStringKeys(idx, "pull_request_target_branch", mapInterface)
 		if err != nil {
 			return TriggerMapItemModel{}, err
 		}
@@ -195,7 +195,7 @@ func (item TriggerMapItemModel) Normalized() (TriggerMapItemModel, error) {
 
 	mapInterface, ok = item.PullRequestLabel.(map[interface{}]interface{})
 	if ok {
-		value, err := castInterfaceKeysToStringKeys("pull_request_label", mapInterface)
+		value, err := castInterfaceKeysToStringKeys(idx, "pull_request_label", mapInterface)
 		if err != nil {
 			return TriggerMapItemModel{}, err
 		}
@@ -205,12 +205,12 @@ func (item TriggerMapItemModel) Normalized() (TriggerMapItemModel, error) {
 	return item, nil
 }
 
-func castInterfaceKeysToStringKeys(field string, value map[interface{}]interface{}) (map[string]interface{}, error) {
+func castInterfaceKeysToStringKeys(idx int, field string, value map[interface{}]interface{}) (map[string]interface{}, error) {
 	mapString := map[string]interface{}{}
 	for key, value := range value {
 		keyStr, ok := key.(string)
 		if !ok {
-			return nil, fmt.Errorf("%s should be a string literal or a hash with a single 'regex' key", field)
+			return nil, fmt.Errorf("%s should be a string literal or a hash with a single 'regex' key in the %d. trigger item", field, idx+1)
 		}
 		mapString[keyStr] = value
 	}

--- a/models/trigger_map_item.go
+++ b/models/trigger_map_item.go
@@ -68,212 +68,15 @@ type TriggerMapItemModel struct {
 	IsPullRequestAllowed bool   `json:"is_pull_request_allowed,omitempty" yaml:"is_pull_request_allowed,omitempty"`
 }
 
-func (triggerItem TriggerMapItemModel) Validate(idx int, workflows, pipelines []string) ([]string, error) {
-	warnings, err := triggerItem.validateTarget(idx, workflows, pipelines)
-	if err != nil {
-		return warnings, err
-	}
-
-	if triggerItem.Pattern != "" {
-		if err := triggerItem.validateTypeOfLegacyItem(idx); err != nil {
-			return warnings, err
-		}
-	} else if triggerItem.Type == "" {
-		if err := triggerItem.validateTypeOfItem(idx); err != nil {
-			return warnings, err
-		}
-	} else {
-		if err := triggerItem.validateTypeOfItemWithExplicitType(idx); err != nil {
-			return warnings, err
-		}
-		if err := triggerItem.validateValuesOfItemWithExplicitType(idx); err != nil {
-			return warnings, err
-		}
-	}
-
-	return warnings, nil
-}
-
-func (triggerItem TriggerMapItemModel) validateTypeOfLegacyItem(idx int) error {
-	if err := triggerItem.validateNoCodePushConditionsSet(idx, "pattern"); err != nil {
-		return err
-	}
-	if err := triggerItem.validateNoTagPushConditionsSet(idx, "pattern"); err != nil {
-		return err
-	}
-	if err := triggerItem.validateNoPullRequestConditionsSet(idx, "pattern"); err != nil {
-		return err
-	}
-	return nil
-}
-
-func (triggerItem TriggerMapItemModel) validateTypeOfItem(idx int) error {
-	if isStringLiteralOrRegexSet(triggerItem.PushBranch) {
-		if err := triggerItem.validateNoTagPushConditionsSet(idx, "push_branch"); err != nil {
-			return err
-		}
-		if err := triggerItem.validateNoPullRequestConditionsSet(idx, "push_branch"); err != nil {
-			return err
-		}
-	} else if isStringLiteralOrRegexSet(triggerItem.PullRequestSourceBranch) {
-		if err := triggerItem.validateNoCodePushConditionsSet(idx, "pull_request_source_branch"); err != nil {
-			return err
-		}
-		if err := triggerItem.validateNoTagPushConditionsSet(idx, "pull_request_source_branch"); err != nil {
-			return err
-		}
-	} else if isStringLiteralOrRegexSet(triggerItem.PullRequestTargetBranch) {
-		if err := triggerItem.validateNoCodePushConditionsSet(idx, "pull_request_target_branch"); err != nil {
-			return err
-		}
-		if err := triggerItem.validateNoTagPushConditionsSet(idx, "pull_request_target_branch"); err != nil {
-			return err
-		}
-	} else if isStringLiteralOrRegexSet(triggerItem.Tag) {
-		if err := triggerItem.validateNoCodePushConditionsSet(idx, "tag"); err != nil {
-			return err
-		}
-		if err := triggerItem.validateNoPullRequestConditionsSet(idx, "tag"); err != nil {
-			return err
-		}
-	} else if !isStringLiteralOrRegexSet(triggerItem.Tag) {
-		return fmt.Errorf("no trigger condition defined defined in the %d. trigger item", idx+1)
-	}
-
-	return nil
-}
-
-func (triggerItem TriggerMapItemModel) validateTypeOfItemWithExplicitType(idx int) error {
-	switch triggerItem.Type {
-	case CodePushType:
-		if err := triggerItem.validateNoTagPushConditionsSet(idx, fmt.Sprintf("%s type", CodePushType)); err != nil {
-			return err
-		}
-		if err := triggerItem.validateNoPullRequestConditionsSet(idx, fmt.Sprintf("%s type", CodePushType)); err != nil {
-			return err
-		}
-	case PullRequestType:
-		if err := triggerItem.validateNoCodePushConditionsSet(idx, fmt.Sprintf("%s type", PullRequestType)); err != nil {
-			return err
-		}
-		if err := triggerItem.validateNoTagPushConditionsSet(idx, fmt.Sprintf("%s type", PullRequestType)); err != nil {
-			return err
-		}
-	case TagPushType:
-		if err := triggerItem.validateNoCodePushConditionsSet(idx, fmt.Sprintf("%s type", TagPushType)); err != nil {
-			return err
-		}
-		if err := triggerItem.validateNoPullRequestConditionsSet(idx, fmt.Sprintf("%s type", TagPushType)); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func (triggerItem TriggerMapItemModel) validateNoCodePushConditionsSet(idx int, field string) error {
-	if isStringLiteralOrRegexSet(triggerItem.PushBranch) {
-		return fmt.Errorf("both %s and push_branch defined in the %d. trigger item", field, idx+1)
-	}
-	if isStringLiteralOrRegexSet(triggerItem.CommitMessage) {
-		return fmt.Errorf("both %s and commit_message defined in the %d. trigger item", field, idx+1)
-	}
-	if isStringLiteralOrRegexSet(triggerItem.ChangedFiles) {
-		return fmt.Errorf("both %s and changed_files defined in the %d. trigger item", field, idx+1)
-	}
-	return nil
-}
-
-func (triggerItem TriggerMapItemModel) validateNoTagPushConditionsSet(idx int, field string) error {
-	if isStringLiteralOrRegexSet(triggerItem.Tag) {
-		return fmt.Errorf("both %s and tag defined in the %d. trigger item", field, idx+1)
-	}
-	return nil
-}
-
-func (triggerItem TriggerMapItemModel) validateNoPullRequestConditionsSet(idx int, field string) error {
-	if isStringLiteralOrRegexSet(triggerItem.PullRequestSourceBranch) {
-		return fmt.Errorf("both %s and pull_request_source_branch defined in the %d. trigger item", field, idx+1)
-	}
-	if isStringLiteralOrRegexSet(triggerItem.PullRequestTargetBranch) {
-		return fmt.Errorf("both %s and pull_request_target_branch defined in the %d. trigger item", field, idx+1)
-	}
-	if triggerItem.IsDraftPullRequestEnabled() != defaultDraftPullRequestEnabled {
-		return fmt.Errorf("both %s and draft_pull_request_enabled defined in the %d. trigger item", field, idx+1)
-	}
-	if isStringLiteralOrRegexSet(triggerItem.PullRequestLabel) {
-		return fmt.Errorf("both %s and pull_request_label defined in the %d. trigger item", field, idx+1)
-	}
-	return nil
-}
-
-func (triggerItem TriggerMapItemModel) validateValuesOfItemWithExplicitType(idx int) error {
-	return nil
-}
-
-func stringFromTriggerCondition(condition interface{}) string {
-	if condition == nil {
-		return ""
-	}
-	return condition.(string)
-}
-
-func stringLiteralOrRegex(value interface{}) string {
-	if value == nil {
-		return ""
-	}
-	str, ok := value.(TriggerItemConditionStringValue)
-	if ok {
-		return string(str)
-	}
-
-	regex, ok := value.(TriggerItemConditionRegexValue)
-	if ok {
-		return regex.Regex
-	}
-	return ""
-}
-
-func isStringLiteralOrRegexSet(value interface{}) bool {
-	return stringLiteralOrRegex(value) != ""
-}
-
-func (triggerItem TriggerMapItemModel) validateTarget(idx int, workflows, pipelines []string) ([]string, error) {
-	var warnings []string
-
-	// Validate target
-	if triggerItem.PipelineID != "" && triggerItem.WorkflowID != "" {
-		return warnings, fmt.Errorf("both pipeline and workflow are defined as trigger target for the %d. trigger item", idx+1)
-	}
-	if triggerItem.PipelineID == "" && triggerItem.WorkflowID == "" {
-		return warnings, fmt.Errorf("no pipeline nor workflow is defined as a trigger target for the %d. trigger item", idx+1)
-	}
-
-	if strings.HasPrefix(triggerItem.WorkflowID, "_") {
-		warnings = append(warnings, fmt.Sprintf("utility workflow (%s) defined as trigger target for the %d. trigger item, but utility workflows can't be triggered directly", triggerItem.WorkflowID, idx+1))
-	}
-
-	if triggerItem.PipelineID != "" {
-		if !sliceutil.IsStringInSlice(triggerItem.PipelineID, pipelines) {
-			return warnings, fmt.Errorf("pipeline (%s) defined in the %d. trigger item, but does not exist", triggerItem.PipelineID, idx+1)
-		}
-	} else {
-		if !sliceutil.IsStringInSlice(triggerItem.WorkflowID, workflows) {
-			return warnings, fmt.Errorf("workflow (%s) defined in the %d. trigger item, but does not exist", triggerItem.WorkflowID, idx+1)
-		}
-	}
-
-	return warnings, nil
-}
-
-func (triggerItem TriggerMapItemModel) MatchWithParams(pushBranch, prSourceBranch, prTargetBranch string, prReadyState PullRequestReadyState, tag string) (bool, error) {
+func (item TriggerMapItemModel) MatchWithParams(pushBranch, prSourceBranch, prTargetBranch string, prReadyState PullRequestReadyState, tag string) (bool, error) {
 	paramsEventType, err := triggerEventType(pushBranch, prSourceBranch, prTargetBranch, tag)
 	if err != nil {
 		return false, err
 	}
 
-	migratedTriggerItems := []TriggerMapItemModel{triggerItem}
-	if triggerItem.Pattern != "" {
-		migratedTriggerItems = migrateDeprecatedTriggerItem(triggerItem)
+	migratedTriggerItems := []TriggerMapItemModel{item}
+	if item.Pattern != "" {
+		migratedTriggerItems = migrateDeprecatedTriggerItem(item)
 	}
 
 	for _, migratedTriggerItem := range migratedTriggerItems {
@@ -333,18 +136,230 @@ func (triggerItem TriggerMapItemModel) MatchWithParams(pushBranch, prSourceBranc
 	return false, nil
 }
 
-func (triggerItem TriggerMapItemModel) IsDraftPullRequestEnabled() bool {
+func (item TriggerMapItemModel) IsDraftPullRequestEnabled() bool {
 	draftPullRequestEnabled := defaultDraftPullRequestEnabled
-	if triggerItem.DraftPullRequestEnabled != nil {
-		draftPullRequestEnabled = *triggerItem.DraftPullRequestEnabled
+	if item.DraftPullRequestEnabled != nil {
+		draftPullRequestEnabled = *item.DraftPullRequestEnabled
 	}
 	return draftPullRequestEnabled
 }
 
-func (triggerItem TriggerMapItemModel) String() string {
+func (item TriggerMapItemModel) Validate(idx int, workflows, pipelines []string) ([]string, error) {
+	warnings, err := item.validateTarget(idx, workflows, pipelines)
+	if err != nil {
+		return warnings, err
+	}
+
+	if item.Pattern != "" {
+		if err := item.validateTypeOfLegacyItem(idx); err != nil {
+			return warnings, err
+		}
+	} else if item.Type == "" {
+		if err := item.validateTypeOfItem(idx); err != nil {
+			return warnings, err
+		}
+		if err := item.validateConditionValuesOfItem(idx); err != nil {
+			return warnings, err
+		}
+	} else {
+		if err := item.validateTypeOfItemWithExplicitType(idx); err != nil {
+			return warnings, err
+		}
+		if err := item.validateConditionValuesOfItemWithExplicitType(idx); err != nil {
+			return warnings, err
+		}
+	}
+
+	return warnings, nil
+}
+
+func (item TriggerMapItemModel) validateTarget(idx int, workflows, pipelines []string) ([]string, error) {
+	var warnings []string
+
+	// Validate target
+	if item.PipelineID != "" && item.WorkflowID != "" {
+		return warnings, fmt.Errorf("both pipeline and workflow are defined as trigger target for the %d. trigger item", idx+1)
+	}
+	if item.PipelineID == "" && item.WorkflowID == "" {
+		return warnings, fmt.Errorf("no pipeline nor workflow is defined as a trigger target for the %d. trigger item", idx+1)
+	}
+
+	if strings.HasPrefix(item.WorkflowID, "_") {
+		warnings = append(warnings, fmt.Sprintf("utility workflow (%s) defined as trigger target for the %d. trigger item, but utility workflows can't be triggered directly", item.WorkflowID, idx+1))
+	}
+
+	if item.PipelineID != "" {
+		if !sliceutil.IsStringInSlice(item.PipelineID, pipelines) {
+			return warnings, fmt.Errorf("pipeline (%s) defined in the %d. trigger item, but does not exist", item.PipelineID, idx+1)
+		}
+	} else {
+		if !sliceutil.IsStringInSlice(item.WorkflowID, workflows) {
+			return warnings, fmt.Errorf("workflow (%s) defined in the %d. trigger item, but does not exist", item.WorkflowID, idx+1)
+		}
+	}
+
+	return warnings, nil
+}
+
+func (item TriggerMapItemModel) validateTypeOfLegacyItem(idx int) error {
+	if err := item.validateNoCodePushConditionsSet(idx, "pattern"); err != nil {
+		return err
+	}
+	if err := item.validateNoTagPushConditionsSet(idx, "pattern"); err != nil {
+		return err
+	}
+	if err := item.validateNoPullRequestConditionsSet(idx, "pattern"); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (item TriggerMapItemModel) validateTypeOfItem(idx int) error {
+	if isStringLiteralOrRegexSet(item.PushBranch) {
+		if err := item.validateNoTagPushConditionsSet(idx, "push_branch"); err != nil {
+			return err
+		}
+		if err := item.validateNoPullRequestConditionsSet(idx, "push_branch"); err != nil {
+			return err
+		}
+	} else if isStringLiteralOrRegexSet(item.PullRequestSourceBranch) {
+		if err := item.validateNoCodePushConditionsSet(idx, "pull_request_source_branch"); err != nil {
+			return err
+		}
+		if err := item.validateNoTagPushConditionsSet(idx, "pull_request_source_branch"); err != nil {
+			return err
+		}
+	} else if isStringLiteralOrRegexSet(item.PullRequestTargetBranch) {
+		if err := item.validateNoCodePushConditionsSet(idx, "pull_request_target_branch"); err != nil {
+			return err
+		}
+		if err := item.validateNoTagPushConditionsSet(idx, "pull_request_target_branch"); err != nil {
+			return err
+		}
+	} else if isStringLiteralOrRegexSet(item.Tag) {
+		if err := item.validateNoCodePushConditionsSet(idx, "tag"); err != nil {
+			return err
+		}
+		if err := item.validateNoPullRequestConditionsSet(idx, "tag"); err != nil {
+			return err
+		}
+	} else if !isStringLiteralOrRegexSet(item.Tag) {
+		return fmt.Errorf("no trigger condition defined defined in the %d. trigger item", idx+1)
+	}
+
+	return nil
+}
+
+func (item TriggerMapItemModel) validateTypeOfItemWithExplicitType(idx int) error {
+	switch item.Type {
+	case CodePushType:
+		if err := item.validateNoTagPushConditionsSet(idx, fmt.Sprintf("%s type", CodePushType)); err != nil {
+			return err
+		}
+		if err := item.validateNoPullRequestConditionsSet(idx, fmt.Sprintf("%s type", CodePushType)); err != nil {
+			return err
+		}
+	case PullRequestType:
+		if err := item.validateNoCodePushConditionsSet(idx, fmt.Sprintf("%s type", PullRequestType)); err != nil {
+			return err
+		}
+		if err := item.validateNoTagPushConditionsSet(idx, fmt.Sprintf("%s type", PullRequestType)); err != nil {
+			return err
+		}
+	case TagPushType:
+		if err := item.validateNoCodePushConditionsSet(idx, fmt.Sprintf("%s type", TagPushType)); err != nil {
+			return err
+		}
+		if err := item.validateNoPullRequestConditionsSet(idx, fmt.Sprintf("%s type", TagPushType)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (item TriggerMapItemModel) validateConditionValuesOfItem(idx int) error {
+	if err := validateStringType(idx, "push_branch", item.PushBranch); err != nil {
+		return err
+	}
+	if err := validateStringType(idx, "tag", item.Tag); err != nil {
+		return err
+	}
+	if err := validateStringType(idx, "pull_request_source_branch", item.PullRequestSourceBranch); err != nil {
+		return err
+	}
+	if err := validateStringType(idx, "pull_request_target_branch", item.PullRequestTargetBranch); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (item TriggerMapItemModel) validateConditionValuesOfItemWithExplicitType(idx int) error {
+	if err := validateStringOrRegexType(idx, "push_branch", item.PushBranch); err != nil {
+		return err
+	}
+	if err := validateStringOrRegexType(idx, "commit_message", item.CommitMessage); err != nil {
+		return err
+	}
+	if err := validateStringOrRegexType(idx, "changed_files", item.ChangedFiles); err != nil {
+		return err
+	}
+
+	if err := validateStringOrRegexType(idx, "tag", item.Tag); err != nil {
+		return err
+	}
+
+	if err := validateStringOrRegexType(idx, "pull_request_source_branch", item.PullRequestSourceBranch); err != nil {
+		return err
+	}
+	if err := validateStringOrRegexType(idx, "pull_request_target_branch", item.PullRequestTargetBranch); err != nil {
+		return err
+	}
+	if err := validateStringOrRegexType(idx, "pull_request_label", item.PullRequestLabel); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (item TriggerMapItemModel) validateNoCodePushConditionsSet(idx int, field string) error {
+	if isStringLiteralOrRegexSet(item.PushBranch) {
+		return fmt.Errorf("both %s and push_branch defined in the %d. trigger item", field, idx+1)
+	}
+	if isStringLiteralOrRegexSet(item.CommitMessage) {
+		return fmt.Errorf("both %s and commit_message defined in the %d. trigger item", field, idx+1)
+	}
+	if isStringLiteralOrRegexSet(item.ChangedFiles) {
+		return fmt.Errorf("both %s and changed_files defined in the %d. trigger item", field, idx+1)
+	}
+	return nil
+}
+
+func (item TriggerMapItemModel) validateNoTagPushConditionsSet(idx int, field string) error {
+	if isStringLiteralOrRegexSet(item.Tag) {
+		return fmt.Errorf("both %s and tag defined in the %d. trigger item", field, idx+1)
+	}
+	return nil
+}
+
+func (item TriggerMapItemModel) validateNoPullRequestConditionsSet(idx int, field string) error {
+	if isStringLiteralOrRegexSet(item.PullRequestSourceBranch) {
+		return fmt.Errorf("both %s and pull_request_source_branch defined in the %d. trigger item", field, idx+1)
+	}
+	if isStringLiteralOrRegexSet(item.PullRequestTargetBranch) {
+		return fmt.Errorf("both %s and pull_request_target_branch defined in the %d. trigger item", field, idx+1)
+	}
+	if item.IsDraftPullRequestEnabled() != defaultDraftPullRequestEnabled {
+		return fmt.Errorf("both %s and draft_pull_request_enabled defined in the %d. trigger item", field, idx+1)
+	}
+	if isStringLiteralOrRegexSet(item.PullRequestLabel) {
+		return fmt.Errorf("both %s and pull_request_label defined in the %d. trigger item", field, idx+1)
+	}
+	return nil
+}
+
+func (item TriggerMapItemModel) conditionsString() string {
 	str := ""
 
-	rv := reflect.Indirect(reflect.ValueOf(&triggerItem))
+	rv := reflect.Indirect(reflect.ValueOf(&item))
 	rt := rv.Type()
 	for i := 0; i < rt.NumField(); i++ {
 		field := rt.Field(i)
@@ -363,6 +378,59 @@ func (triggerItem TriggerMapItemModel) String() string {
 	}
 
 	return str
+}
+
+func validateStringType(idx int, field string, value interface{}) error {
+	if value == nil {
+		return nil
+	}
+	_, ok := value.(TriggerItemConditionStringValue)
+	if ok {
+		return nil
+	}
+	return fmt.Errorf("string literal value is expected for %s in the %d. trigger item", field, idx+1)
+}
+
+func validateStringOrRegexType(idx int, field string, value interface{}) error {
+	if value == nil {
+		return nil
+	}
+	_, ok := value.(TriggerItemConditionStringValue)
+	if ok {
+		return nil
+	}
+	_, ok = value.(TriggerItemConditionRegexValue)
+	if ok {
+		return nil
+	}
+	return fmt.Errorf("string literal or regex value is expected for %s in the %d. trigger item", field, idx+1)
+}
+
+func stringFromTriggerCondition(condition interface{}) string {
+	if condition == nil {
+		return ""
+	}
+	return condition.(string)
+}
+
+func stringLiteralOrRegex(value interface{}) string {
+	if value == nil {
+		return ""
+	}
+	str, ok := value.(TriggerItemConditionStringValue)
+	if ok {
+		return string(str)
+	}
+
+	regex, ok := value.(TriggerItemConditionRegexValue)
+	if ok {
+		return regex.Regex
+	}
+	return ""
+}
+
+func isStringLiteralOrRegexSet(value interface{}) bool {
+	return stringLiteralOrRegex(value) != ""
 }
 
 func triggerEventType(pushBranch, prSourceBranch, prTargetBranch, tag string) (TriggerEventType, error) {

--- a/models/trigger_map_item.go
+++ b/models/trigger_map_item.go
@@ -138,6 +138,85 @@ func (item TriggerMapItemModel) IsDraftPullRequestEnabled() bool {
 	return draftPullRequestEnabled
 }
 
+func (item TriggerMapItemModel) Normalized() (TriggerMapItemModel, error) {
+	mapInterface, ok := item.PushBranch.(map[interface{}]interface{})
+	if ok {
+		value, err := castInterfaceKeysToStringKeys("push_branch", mapInterface)
+		if err != nil {
+			return TriggerMapItemModel{}, err
+		}
+		item.PushBranch = value
+	}
+
+	mapInterface, ok = item.CommitMessage.(map[interface{}]interface{})
+	if ok {
+		value, err := castInterfaceKeysToStringKeys("commit_message", mapInterface)
+		if err != nil {
+			return TriggerMapItemModel{}, err
+		}
+		item.CommitMessage = value
+	}
+
+	mapInterface, ok = item.ChangedFiles.(map[interface{}]interface{})
+	if ok {
+		value, err := castInterfaceKeysToStringKeys("changed_files", mapInterface)
+		if err != nil {
+			return TriggerMapItemModel{}, err
+		}
+		item.ChangedFiles = value
+	}
+
+	mapInterface, ok = item.Tag.(map[interface{}]interface{})
+	if ok {
+		value, err := castInterfaceKeysToStringKeys("tag", mapInterface)
+		if err != nil {
+			return TriggerMapItemModel{}, err
+		}
+		item.Tag = value
+	}
+
+	mapInterface, ok = item.PullRequestSourceBranch.(map[interface{}]interface{})
+	if ok {
+		value, err := castInterfaceKeysToStringKeys("pull_request_source_branch", mapInterface)
+		if err != nil {
+			return TriggerMapItemModel{}, err
+		}
+		item.PullRequestSourceBranch = value
+	}
+
+	mapInterface, ok = item.PullRequestTargetBranch.(map[interface{}]interface{})
+	if ok {
+		value, err := castInterfaceKeysToStringKeys("pull_request_target_branch", mapInterface)
+		if err != nil {
+			return TriggerMapItemModel{}, err
+		}
+		item.PullRequestTargetBranch = value
+	}
+
+	mapInterface, ok = item.PullRequestLabel.(map[interface{}]interface{})
+	if ok {
+		value, err := castInterfaceKeysToStringKeys("pull_request_label", mapInterface)
+		if err != nil {
+			return TriggerMapItemModel{}, err
+		}
+		item.PullRequestLabel = value
+	}
+
+	return item, nil
+}
+
+func castInterfaceKeysToStringKeys(field string, value map[interface{}]interface{}) (map[string]interface{}, error) {
+	mapString := map[string]interface{}{}
+	for key, value := range value {
+		keyStr, ok := key.(string)
+		if !ok {
+			return nil, fmt.Errorf("%s should be a string literal or a hash with a single 'regex' key", field)
+		}
+		mapString[keyStr] = value
+	}
+	return mapString, nil
+}
+
 func (item TriggerMapItemModel) Validate(idx int, workflows, pipelines []string) ([]string, error) {
 	warnings, err := item.validateTarget(idx, workflows, pipelines)
 	if err != nil {

--- a/models/trigger_map_item.go
+++ b/models/trigger_map_item.go
@@ -28,10 +28,6 @@ const (
 
 const defaultDraftPullRequestEnabled = true
 
-type TriggerItemConditionRegexValue struct {
-	Regex string `json:"regex" yaml:"regex"`
-}
-
 type TriggerItemType string
 
 const (
@@ -425,7 +421,8 @@ func validateStringOrRegexType(idx int, field string, value interface{}) error {
 	if ok {
 		return nil
 	}
-	_, ok = value.(TriggerItemConditionRegexValue)
+	// TODO: check key
+	_, ok = value.(map[string]string)
 	if ok {
 		return nil
 	}
@@ -448,9 +445,9 @@ func stringLiteralOrRegex(value interface{}) string {
 		return string(str)
 	}
 
-	regex, ok := value.(TriggerItemConditionRegexValue)
+	regex, ok := value.(map[string]string)
 	if ok {
-		return regex.Regex
+		return regex["regex"]
 	}
 	return ""
 }

--- a/models/trigger_map_item.go
+++ b/models/trigger_map_item.go
@@ -233,7 +233,7 @@ func (item TriggerMapItemModel) validateType(idx int) error {
 		return nil
 	}
 
-	return fmt.Errorf("no trigger condition defined defined in the %d. trigger item", idx+1)
+	return fmt.Errorf("no type or trigger condition defined in the %d. trigger item", idx+1)
 }
 
 func (item TriggerMapItemModel) validateConditionValues(idx int) error {
@@ -346,6 +346,12 @@ func (item TriggerMapItemModel) conditionsString() string {
 			str += " & "
 		}
 		str += fmt.Sprintf("%s: %v", tag, value)
+	}
+
+	if str == "" && item.Type != "" {
+		// Trigger Item without any condition is valid,
+		// this case we use the type to differentiate push, pull-request and tag items
+		str = "type: " + string(item.Type)
 	}
 
 	return str

--- a/models/trigger_map_item.go
+++ b/models/trigger_map_item.go
@@ -39,7 +39,7 @@ const (
 type TriggerMapItemModel struct {
 	// Trigger Item shared properties
 	Type       TriggerItemType `json:"type,omitempty" yaml:"type,omitempty"`
-	Enabled    bool            `json:"enabled,omitempty" yaml:"enabled,omitempty"`
+	Enabled    *bool           `json:"enabled,omitempty" yaml:"enabled,omitempty"`
 	PipelineID string          `json:"pipeline,omitempty" yaml:"pipeline,omitempty"`
 	WorkflowID string          `json:"workflow,omitempty" yaml:"workflow,omitempty"`
 

--- a/models/trigger_map_item_test.go
+++ b/models/trigger_map_item_test.go
@@ -448,8 +448,8 @@ func TestTriggerMapItemModel_String(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			require.Equal(t, tt.want, tt.triggerMapItem.String(false))
-			require.Equal(t, tt.wantWithPrintTarget, tt.triggerMapItem.String(true))
+			require.Equal(t, tt.want, tt.triggerMapItem.String())
+			require.Equal(t, tt.wantWithPrintTarget, tt.triggerMapItem.String())
 		})
 	}
 }
@@ -608,7 +608,7 @@ func TestTriggerMapItemModel_Validate(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			warns, err := tt.triggerMapItem.Validate(tt.workflows, tt.pipelines)
+			warns, err := tt.triggerMapItem.Validate(0, tt.workflows, tt.pipelines)
 			if tt.wantErr != "" {
 				require.EqualError(t, err, tt.wantErr)
 			} else {

--- a/models/trigger_map_item_test.go
+++ b/models/trigger_map_item_test.go
@@ -483,14 +483,14 @@ func TestTriggerMapItemModel_Validate_LegacyItem(t *testing.T) {
 				WorkflowID: "workflow-1",
 			},
 			workflows: []string{"pipeline-1", "workflow-1"},
-			wantErr:   "both pipeline and workflow are defined as trigger target for the 1. trigger item",
+			wantErr:   "trigger item #1: both pipeline and workflow are defined as trigger target",
 		},
 		{
 			name: "it fails for invalid deprecated trigger item - missing pipeline & workflow",
 			triggerMapItem: TriggerMapItemModel{
 				Pattern: "*",
 			},
-			wantErr: "no pipeline nor workflow is defined as a trigger target for the 1. trigger item",
+			wantErr: "trigger item #1: no pipeline nor workflow is defined as trigger target",
 		},
 		{
 			name: "it fails for invalid deprecated trigger item - missing pattern",
@@ -499,7 +499,7 @@ func TestTriggerMapItemModel_Validate_LegacyItem(t *testing.T) {
 				WorkflowID: "primary",
 			},
 			workflows: []string{"primary"},
-			wantErr:   "no type or trigger condition defined in the 1. trigger item",
+			wantErr:   "trigger item #1: no type or relevant trigger condition defined",
 		},
 		{
 			name: "it fails for mixed (mixed new and legacy properties) trigger item",
@@ -509,7 +509,7 @@ func TestTriggerMapItemModel_Validate_LegacyItem(t *testing.T) {
 				WorkflowID: "primary",
 			},
 			workflows: []string{"primary"},
-			wantErr:   "both pattern and push_branch defined in the 1. trigger item",
+			wantErr:   "trigger item #1: both pattern and push_branch defined",
 		},
 	}
 	for _, tt := range tests {
@@ -565,7 +565,7 @@ func TestTriggerMapItemModel_Validate_CodePushItem(t *testing.T) {
 				WorkflowID: "primary",
 			},
 			workflows: []string{"primary"},
-			wantErr:   "no type or trigger condition defined in the 1. trigger item",
+			wantErr:   "trigger item #1: no type or relevant trigger condition defined",
 		},
 		{
 			name: "type is required, when no push_branch defined (commit_message)",
@@ -574,7 +574,7 @@ func TestTriggerMapItemModel_Validate_CodePushItem(t *testing.T) {
 				WorkflowID:    "primary",
 			},
 			workflows: []string{"primary"},
-			wantErr:   "no type or trigger condition defined in the 1. trigger item",
+			wantErr:   "trigger item #1: no type or relevant trigger condition defined",
 		},
 		{
 			name: "type is required, when no push_branch defined (changed_files)",
@@ -583,14 +583,14 @@ func TestTriggerMapItemModel_Validate_CodePushItem(t *testing.T) {
 				WorkflowID:   "primary",
 			},
 			workflows: []string{"primary"},
-			wantErr:   "no type or trigger condition defined in the 1. trigger item",
+			wantErr:   "trigger item #1: no type or relevant trigger condition defined",
 		},
 		{
 			name: "it fails for invalid code-push trigger item - missing pipeline & workflow",
 			triggerMapItem: TriggerMapItemModel{
 				PushBranch: "*",
 			},
-			wantErr: "no pipeline nor workflow is defined as a trigger target for the 1. trigger item",
+			wantErr: "trigger item #1: no pipeline nor workflow is defined as trigger target",
 		},
 		{
 			name: "it fails for mixed (mixed types) trigger item",
@@ -601,7 +601,7 @@ func TestTriggerMapItemModel_Validate_CodePushItem(t *testing.T) {
 				WorkflowID:              "primary",
 			},
 			workflows: []string{"primary"},
-			wantErr:   "both push_branch and pull_request_source_branch defined in the 1. trigger item",
+			wantErr:   "trigger item #1: both push_branch and pull_request_source_branch defined",
 		},
 		{
 			name: "push_branch can be a regex",
@@ -645,7 +645,7 @@ func TestTriggerMapItemModel_Validate_CodePushItem(t *testing.T) {
 				WorkflowID: "primary",
 			},
 			workflows: []string{"primary"},
-			wantErr:   "'regex' key is expected for regex condition in changed_files field of the 1. trigger item",
+			wantErr:   "trigger item #1: 'regex' key is expected for regex condition in changed_files field",
 		},
 		{
 			name: "condition value can be a hash with a single key",
@@ -658,7 +658,7 @@ func TestTriggerMapItemModel_Validate_CodePushItem(t *testing.T) {
 				WorkflowID: "primary",
 			},
 			workflows: []string{"primary"},
-			wantErr:   "single 'regex' key is expected for regex condition in changed_files field of the 1. trigger item",
+			wantErr:   "trigger item #1: single 'regex' key is expected for regex condition in changed_files field",
 		},
 		{
 			name: "invalid type",
@@ -667,7 +667,7 @@ func TestTriggerMapItemModel_Validate_CodePushItem(t *testing.T) {
 				WorkflowID: "primary",
 			},
 			workflows: []string{"primary"},
-			wantErr:   "invalid type (code-push) set in the 1. trigger item, valid types are: push, pull_request and tag",
+			wantErr:   "trigger item #1: invalid type (code-push) defined, valid types are: push, pull_request and tag",
 		},
 	}
 	for _, tt := range tests {
@@ -723,14 +723,14 @@ func TestTriggerMapItemModel_Validate_TagPushItem(t *testing.T) {
 				WorkflowID: "primary",
 			},
 			workflows: []string{"primary"},
-			wantErr:   "no type or trigger condition defined in the 1. trigger item",
+			wantErr:   "trigger item #1: no type or relevant trigger condition defined",
 		},
 		{
 			name: "it fails for invalid code-push trigger item - missing pipeline & workflow",
 			triggerMapItem: TriggerMapItemModel{
 				Tag: "*",
 			},
-			wantErr: "no pipeline nor workflow is defined as a trigger target for the 1. trigger item",
+			wantErr: "trigger item #1: no pipeline nor workflow is defined as trigger target",
 		},
 		{
 			name: "tag can be a regex",
@@ -812,7 +812,7 @@ func TestTriggerMapItemModel_Validate_PullRequestItem(t *testing.T) {
 				PipelineID:       "primary",
 			},
 			pipelines: []string{"primary"},
-			wantErr:   "no type or trigger condition defined in the 1. trigger item",
+			wantErr:   "trigger item #1: no type or relevant trigger condition defined",
 		},
 		{
 			name: "type is required, when no pull_request_source_branch defined (draft_pull_request_enabled)",
@@ -821,14 +821,14 @@ func TestTriggerMapItemModel_Validate_PullRequestItem(t *testing.T) {
 				PipelineID:              "primary",
 			},
 			pipelines: []string{"primary"},
-			wantErr:   "no type or trigger condition defined in the 1. trigger item",
+			wantErr:   "trigger item #1: no type or relevant trigger condition defined",
 		},
 		{
 			name: "it fails for invalid pull-request trigger item (target branch set) - missing pipeline & workflow",
 			triggerMapItem: TriggerMapItemModel{
 				PullRequestTargetBranch: "*",
 			},
-			wantErr: "no pipeline nor workflow is defined as a trigger target for the 1. trigger item",
+			wantErr: "trigger item #1: no pipeline nor workflow is defined as trigger target",
 		},
 		{
 			name: "it fails for invalid pull-request trigger item (target and source branch set) - missing pipeline & workflow",
@@ -836,7 +836,7 @@ func TestTriggerMapItemModel_Validate_PullRequestItem(t *testing.T) {
 				PullRequestSourceBranch: "feature*",
 				PullRequestTargetBranch: "master",
 			},
-			wantErr: "no pipeline nor workflow is defined as a trigger target for the 1. trigger item",
+			wantErr: "trigger item #1: no pipeline nor workflow is defined as trigger target",
 		},
 		{
 			name: "pull_request_source_branch can be a regex",
@@ -877,7 +877,7 @@ func TestTriggerMapItemModel_Validate_PullRequestItem(t *testing.T) {
 				WorkflowID:              "primary",
 			},
 			workflows: []string{"primary"},
-			wantErr:   "both pull_request_source_branch and tag defined in the 1. trigger item",
+			wantErr:   "trigger item #1: both pull_request_source_branch and tag defined",
 		},
 		{
 			name: "it fails for mixed type trigger item (pull_request_target_branch + tag)",
@@ -887,7 +887,7 @@ func TestTriggerMapItemModel_Validate_PullRequestItem(t *testing.T) {
 				WorkflowID:              "primary",
 			},
 			workflows: []string{"primary"},
-			wantErr:   "both pull_request_target_branch and tag defined in the 1. trigger item",
+			wantErr:   "trigger item #1: both pull_request_target_branch and tag defined",
 		},
 		{
 			name: "it fails for mixed type trigger item (pull_request_source_branch + pull_request_target_branch + tag)",
@@ -898,7 +898,7 @@ func TestTriggerMapItemModel_Validate_PullRequestItem(t *testing.T) {
 				WorkflowID:              "primary",
 			},
 			workflows: []string{"primary"},
-			wantErr:   "both pull_request_source_branch and pull_request_target_branch and tag defined in the 1. trigger item",
+			wantErr:   "trigger item #1: both pull_request_source_branch and pull_request_target_branch and tag defined",
 		},
 		{
 			name: "it fails for mixed type trigger item (type + tag)",
@@ -908,7 +908,7 @@ func TestTriggerMapItemModel_Validate_PullRequestItem(t *testing.T) {
 				WorkflowID: "primary",
 			},
 			workflows: []string{"primary"},
-			wantErr:   "both type: pull_request and tag defined in the 1. trigger item",
+			wantErr:   "trigger item #1: both type: pull_request and tag defined",
 		},
 	}
 	for _, tt := range tests {

--- a/models/trigger_map_item_test.go
+++ b/models/trigger_map_item_test.go
@@ -499,7 +499,7 @@ func TestTriggerMapItemModel_Validate_LegacyItem(t *testing.T) {
 				WorkflowID: "primary",
 			},
 			workflows: []string{"primary"},
-			wantErr:   "no trigger condition defined defined in the 1. trigger item",
+			wantErr:   "no type or trigger condition defined in the 1. trigger item",
 		},
 		{
 			name: "it fails for mixed (mixed new and legacy properties) trigger item",
@@ -724,17 +724,6 @@ func TestTriggerMapItemModel_Validate_TagPushItem(t *testing.T) {
 			wantErr: "no pipeline nor workflow is defined as a trigger target for the 1. trigger item",
 		},
 		{
-			name: "it fails for mixed (mixed types) trigger item",
-			triggerMapItem: TriggerMapItemModel{
-				Tag:                     "master",
-				PullRequestSourceBranch: "feature/*",
-				PullRequestTargetBranch: "",
-				WorkflowID:              "primary",
-			},
-			workflows: []string{"primary"},
-			wantErr:   "both pull_request_source_branch and tag defined in the 1. trigger item",
-		},
-		{
 			name: "tag can be a regex",
 			triggerMapItem: TriggerMapItemModel{
 				Tag: map[interface{}]interface{}{
@@ -870,6 +859,47 @@ func TestTriggerMapItemModel_Validate_PullRequestItem(t *testing.T) {
 				PipelineID: "primary",
 			},
 			pipelines: []string{"primary"},
+		},
+		{
+			name: "it fails for mixed type trigger item (pull_request_source_branch + tag)",
+			triggerMapItem: TriggerMapItemModel{
+				PullRequestSourceBranch: "feature/*",
+				Tag:                     "master",
+				WorkflowID:              "primary",
+			},
+			workflows: []string{"primary"},
+			wantErr:   "both pull_request_source_branch and tag defined in the 1. trigger item",
+		},
+		{
+			name: "it fails for mixed type trigger item (pull_request_target_branch + tag)",
+			triggerMapItem: TriggerMapItemModel{
+				PullRequestTargetBranch: "feature/*",
+				Tag:                     "master",
+				WorkflowID:              "primary",
+			},
+			workflows: []string{"primary"},
+			wantErr:   "both pull_request_target_branch and tag defined in the 1. trigger item",
+		},
+		{
+			name: "it fails for mixed type trigger item (pull_request_source_branch + pull_request_target_branch + tag)",
+			triggerMapItem: TriggerMapItemModel{
+				PullRequestSourceBranch: "main",
+				PullRequestTargetBranch: "feature/*",
+				Tag:                     "master",
+				WorkflowID:              "primary",
+			},
+			workflows: []string{"primary"},
+			wantErr:   "both pull_request_source_branch and pull_request_target_branch and tag defined in the 1. trigger item",
+		},
+		{
+			name: "it fails for mixed type trigger item (type + tag)",
+			triggerMapItem: TriggerMapItemModel{
+				Type:       PullRequestType,
+				Tag:        "master",
+				WorkflowID: "primary",
+			},
+			workflows: []string{"primary"},
+			wantErr:   "both type: pull_request and tag defined in the 1. trigger item",
 		},
 	}
 	for _, tt := range tests {

--- a/models/trigger_map_item_test.go
+++ b/models/trigger_map_item_test.go
@@ -448,8 +448,8 @@ func TestTriggerMapItemModel_String(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			require.Equal(t, tt.want, tt.triggerMapItem.String())
-			require.Equal(t, tt.wantWithPrintTarget, tt.triggerMapItem.String())
+			require.Equal(t, tt.want, tt.triggerMapItem.conditionsString())
+			require.Equal(t, tt.wantWithPrintTarget, tt.triggerMapItem.conditionsString())
 		})
 	}
 }

--- a/models/trigger_map_item_test.go
+++ b/models/trigger_map_item_test.go
@@ -340,10 +340,9 @@ func TestTriggerMapItemModel_MatchWithParams_TagParams(t *testing.T) {
 
 func TestTriggerMapItemModel_String(t *testing.T) {
 	tests := []struct {
-		name                string
-		triggerMapItem      TriggerMapItemModel
-		want                string
-		wantWithPrintTarget string
+		name           string
+		triggerMapItem TriggerMapItemModel
+		want           string
 	}{
 		{
 			name: "triggering pipeline",
@@ -351,8 +350,7 @@ func TestTriggerMapItemModel_String(t *testing.T) {
 				PushBranch: "master",
 				PipelineID: "pipeline-1",
 			},
-			want:                "push_branch: master",
-			wantWithPrintTarget: "push_branch: master -> pipeline: pipeline-1",
+			want: "push_branch: master",
 		},
 		{
 			name: "push event",
@@ -360,8 +358,7 @@ func TestTriggerMapItemModel_String(t *testing.T) {
 				PushBranch: "master",
 				WorkflowID: "ci",
 			},
-			want:                "push_branch: master",
-			wantWithPrintTarget: "push_branch: master -> workflow: ci",
+			want: "push_branch: master",
 		},
 		{
 			name: "pull request event - pr source branch",
@@ -369,8 +366,7 @@ func TestTriggerMapItemModel_String(t *testing.T) {
 				PullRequestSourceBranch: "develop",
 				WorkflowID:              "ci",
 			},
-			want:                "pull_request_source_branch: develop && draft_pull_request_enabled: true",
-			wantWithPrintTarget: "pull_request_source_branch: develop && draft_pull_request_enabled: true -> workflow: ci",
+			want: "pull_request_source_branch: develop",
 		},
 		{
 			name: "pull request event - pr target branch",
@@ -378,8 +374,7 @@ func TestTriggerMapItemModel_String(t *testing.T) {
 				PullRequestTargetBranch: "master",
 				WorkflowID:              "ci",
 			},
-			want:                "pull_request_target_branch: master && draft_pull_request_enabled: true",
-			wantWithPrintTarget: "pull_request_target_branch: master && draft_pull_request_enabled: true -> workflow: ci",
+			want: "pull_request_target_branch: master",
 		},
 		{
 			name: "pull request event - pr target and source branch",
@@ -388,8 +383,7 @@ func TestTriggerMapItemModel_String(t *testing.T) {
 				PullRequestTargetBranch: "master",
 				WorkflowID:              "ci",
 			},
-			want:                "pull_request_source_branch: develop && pull_request_target_branch: master && draft_pull_request_enabled: true",
-			wantWithPrintTarget: "pull_request_source_branch: develop && pull_request_target_branch: master && draft_pull_request_enabled: true -> workflow: ci",
+			want: "pull_request_source_branch: develop & pull_request_target_branch: master",
 		},
 		{
 			name: "pull request event - pr target and source branch and disable draft prs",
@@ -399,8 +393,7 @@ func TestTriggerMapItemModel_String(t *testing.T) {
 				DraftPullRequestEnabled: pointers.NewBoolPtr(false),
 				WorkflowID:              "ci",
 			},
-			want:                "pull_request_source_branch: develop && pull_request_target_branch: master && draft_pull_request_enabled: false",
-			wantWithPrintTarget: "pull_request_source_branch: develop && pull_request_target_branch: master && draft_pull_request_enabled: false -> workflow: ci",
+			want: "pull_request_source_branch: develop & pull_request_target_branch: master & draft_pull_request_enabled: false",
 		},
 		{
 			name: "tag event",
@@ -408,8 +401,7 @@ func TestTriggerMapItemModel_String(t *testing.T) {
 				Tag:        "0.9.0",
 				WorkflowID: "release",
 			},
-			want:                "tag: 0.9.0",
-			wantWithPrintTarget: "tag: 0.9.0 -> workflow: release",
+			want: "tag: 0.9.0",
 		},
 		{
 			name: "deprecated type - pr disabled",
@@ -418,8 +410,7 @@ func TestTriggerMapItemModel_String(t *testing.T) {
 				IsPullRequestAllowed: false,
 				WorkflowID:           "ci",
 			},
-			want:                "pattern: master && is_pull_request_allowed: false",
-			wantWithPrintTarget: "pattern: master && is_pull_request_allowed: false -> workflow: ci",
+			want: "pattern: master",
 		},
 		{
 			name: "deprecated type - pr enabled",
@@ -428,8 +419,7 @@ func TestTriggerMapItemModel_String(t *testing.T) {
 				IsPullRequestAllowed: true,
 				WorkflowID:           "ci",
 			},
-			want:                "pattern: master && is_pull_request_allowed: true",
-			wantWithPrintTarget: "pattern: master && is_pull_request_allowed: true -> workflow: ci",
+			want: "pattern: master & is_pull_request_allowed: true",
 		},
 		{
 			name: "mixed",
@@ -442,14 +432,12 @@ func TestTriggerMapItemModel_String(t *testing.T) {
 				IsPullRequestAllowed:    true,
 				WorkflowID:              "ci",
 			},
-			want:                "push_branch: master pull_request_source_branch: develop && pull_request_target_branch: master && draft_pull_request_enabled: true tag: 0.9.0 pattern: * && is_pull_request_allowed: true",
-			wantWithPrintTarget: "push_branch: master pull_request_source_branch: develop && pull_request_target_branch: master && draft_pull_request_enabled: true tag: 0.9.0 pattern: * && is_pull_request_allowed: true -> workflow: ci",
+			want: "push_branch: master & tag: 0.9.0 & pull_request_source_branch: develop & pull_request_target_branch: master & pattern: * & is_pull_request_allowed: true",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			require.Equal(t, tt.want, tt.triggerMapItem.conditionsString())
-			require.Equal(t, tt.wantWithPrintTarget, tt.triggerMapItem.conditionsString())
 		})
 	}
 }
@@ -487,14 +475,14 @@ func TestTriggerMapItemModel_Validate(t *testing.T) {
 				WorkflowID: "workflow-1",
 			},
 			workflows: []string{"pipeline-1", "workflow-1"},
-			wantErr:   "both pipeline and workflow are defined as trigger target: pattern: * && is_pull_request_allowed: false",
+			wantErr:   "both pipeline and workflow are defined as trigger target for the 1. trigger item",
 		},
 		{
 			name: "it fails for invalid deprecated trigger item - missing pipeline & workflow",
 			triggerMapItem: TriggerMapItemModel{
 				Pattern: "*",
 			},
-			wantErr: "no pipeline nor workflow is defined as a trigger target: pattern: * && is_pull_request_allowed: false",
+			wantErr: "no pipeline nor workflow is defined as a trigger target for the 1. trigger item",
 		},
 		{
 			name: "it fails for invalid deprecated trigger item - missing pattern",
@@ -503,7 +491,7 @@ func TestTriggerMapItemModel_Validate(t *testing.T) {
 				WorkflowID: "primary",
 			},
 			workflows: []string{"primary"},
-			wantErr:   "trigger map item ( -> workflow: primary) validate failed, error: failed to determin trigger event from params: push-branch: , pr-source-branch: , pr-target-branch: , tag: ",
+			wantErr:   "no trigger condition defined defined in the 1. trigger item",
 		},
 		{
 			name: "it validates code-push trigger item with triggered pipeline",
@@ -528,14 +516,14 @@ func TestTriggerMapItemModel_Validate(t *testing.T) {
 				WorkflowID: "primary",
 			},
 			workflows: []string{"primary"},
-			wantErr:   "trigger map item ( -> workflow: primary) validate failed, error: failed to determin trigger event from params: push-branch: , pr-source-branch: , pr-target-branch: , tag: ",
+			wantErr:   "no trigger condition defined defined in the 1. trigger item",
 		},
 		{
 			name: "it fails for invalid code-push trigger item - missing pipeline & workflow",
 			triggerMapItem: TriggerMapItemModel{
 				PushBranch: "*",
 			},
-			wantErr: "no pipeline nor workflow is defined as a trigger target: push_branch: *",
+			wantErr: "no pipeline nor workflow is defined as a trigger target for the 1. trigger item",
 		},
 		{
 			name: "it validates pull-request trigger item (with source branch) with triggered pipeline",
@@ -574,7 +562,7 @@ func TestTriggerMapItemModel_Validate(t *testing.T) {
 			triggerMapItem: TriggerMapItemModel{
 				PullRequestTargetBranch: "*",
 			},
-			wantErr: "no pipeline nor workflow is defined as a trigger target: pull_request_target_branch: * && draft_pull_request_enabled: true",
+			wantErr: "no pipeline nor workflow is defined as a trigger target for the 1. trigger item",
 		},
 		{
 			name: "it fails for invalid pull-request trigger item (target and source branch set) - missing pipeline & workflow",
@@ -582,7 +570,7 @@ func TestTriggerMapItemModel_Validate(t *testing.T) {
 				PullRequestSourceBranch: "feature*",
 				PullRequestTargetBranch: "master",
 			},
-			wantErr: "no pipeline nor workflow is defined as a trigger target: pull_request_source_branch: feature* && pull_request_target_branch: master && draft_pull_request_enabled: true",
+			wantErr: "no pipeline nor workflow is defined as a trigger target for the 1. trigger item",
 		},
 		{
 			name: "it fails for mixed (mixed types) trigger item",
@@ -593,7 +581,7 @@ func TestTriggerMapItemModel_Validate(t *testing.T) {
 				WorkflowID:              "primary",
 			},
 			workflows: []string{"primary"},
-			wantErr:   "trigger map item (push_branch: master pull_request_source_branch: feature/* && draft_pull_request_enabled: true -> workflow: primary) validate failed, error: push_branch (master) selects code-push trigger event, but pull_request_source_branch (feature/*) also provided",
+			wantErr:   "both push_branch and pull_request_source_branch defined in the 1. trigger item",
 		},
 		{
 			name: "it fails for mixed (mixed new and legacy properties) trigger item",
@@ -603,7 +591,7 @@ func TestTriggerMapItemModel_Validate(t *testing.T) {
 				WorkflowID: "primary",
 			},
 			workflows: []string{"primary"},
-			wantErr:   "deprecated trigger item (pattern defined), mixed with trigger params (push_branch: master, pull_request_source_branch: , pull_request_target_branch: , tag: )",
+			wantErr:   "both pattern and push_branch defined in the 1. trigger item",
 		},
 	}
 	for _, tt := range tests {

--- a/models/trigger_map_item_test.go
+++ b/models/trigger_map_item_test.go
@@ -660,6 +660,15 @@ func TestTriggerMapItemModel_Validate_CodePushItem(t *testing.T) {
 			workflows: []string{"primary"},
 			wantErr:   "single 'regex' key is expected for regex condition in changed_files field of the 1. trigger item",
 		},
+		{
+			name: "invalid type",
+			triggerMapItem: TriggerMapItemModel{
+				Type:       "code-push",
+				WorkflowID: "primary",
+			},
+			workflows: []string{"primary"},
+			wantErr:   "invalid type (code-push) set in the 1. trigger item, valid types are: push, pull_request and tag",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/models/trigger_map_test.go
+++ b/models/trigger_map_test.go
@@ -63,7 +63,7 @@ func TestTriggerMapModel_Validate(t *testing.T) {
 				},
 			},
 			workflows: []string{"ci", "release"},
-			wantErr:   "duplicated trigger item found (push_branch: master)",
+			wantErr:   "the 2. trigger item duplicates the 1. trigger item",
 		},
 		{
 			name: "Pull Request trigger items",
@@ -92,7 +92,7 @@ func TestTriggerMapModel_Validate(t *testing.T) {
 				},
 			},
 			workflows: []string{"ci", "release"},
-			wantErr:   "duplicated trigger item found (pull_request_source_branch: develop && draft_pull_request_enabled: true)",
+			wantErr:   "the 2. trigger item duplicates the 1. trigger item",
 		},
 		{
 			name: "Pull Request trigger items - duplicated (target branch)",
@@ -107,7 +107,7 @@ func TestTriggerMapModel_Validate(t *testing.T) {
 				},
 			},
 			workflows: []string{"ci", "release"},
-			wantErr:   "duplicated trigger item found (pull_request_target_branch: master && draft_pull_request_enabled: true)",
+			wantErr:   "the 2. trigger item duplicates the 1. trigger item",
 		},
 		{
 			name: "Pull Request trigger items - duplicated (source & target branch)",
@@ -124,7 +124,7 @@ func TestTriggerMapModel_Validate(t *testing.T) {
 				},
 			},
 			workflows: []string{"ci", "release"},
-			wantErr:   "duplicated trigger item found (pull_request_source_branch: develop && pull_request_target_branch: master && draft_pull_request_enabled: true)",
+			wantErr:   "the 2. trigger item duplicates the 1. trigger item",
 		},
 		{
 			name: "Pull Request trigger items - different draft pr enabled",
@@ -157,7 +157,7 @@ func TestTriggerMapModel_Validate(t *testing.T) {
 				},
 			},
 			workflows: []string{"ci", "release"},
-			wantErr:   "duplicated trigger item found (tag: 0.9.0)",
+			wantErr:   "the 2. trigger item duplicates the 1. trigger item",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
### Checklist

- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-io/bitrise/blob/master/.github/CONTRIBUTING.md)
- [x] `README.md` is updated with the changes (if needed)

### Version

Requires a *MINOR* [version update](https://semver.org/)

### Context

Resolves: https://bitrise.atlassian.net/browse/BIVS-2506

### Changes

This PR updates the bitrise.yml data model to support advanced trigger map features:

New fields introduced on the Trigger Map items:
- `type`: describes whether the item responds to a Code Push (`push`), Pull Request (`pull_request`) or Tag (`tag`) webhook event. This field is required if the item type can be determined based on the item conditions:
  - A Code Push Item doesn't have `push_branch` set
  - A Pull Request item doesn't have `pull_request_source_branch` or `pull_request_target_branch` set
  - A Tag item doesn't have `tag` set
- `enabled`: tells if the given item should be considered at trigger check. Defaults to `true`.
- For Code Push Items:
  - `commit_message`
  - `changed_files`
- For Pull Request Items:
  - `pull_request_label`

Trigger item conditions now support regex values, next to the current simple glob pattern values:

```
trigger_map:
- push_branch: main
  changed_files:
    regex: '^ios\/.*'
  workflow: ios-test
- push_branch: "feature-*"
  workflow: test
```

A trigger item validation has also changed: there are no required conditions anymore for the different trigger item types. Simply specifying the `type` of the item, means that all related events will match the given trigger item:

```
trigger_map:
- type: push
  workflow: primary
```

The evaluation of these items (trigger check) has been moved to another Bitrise component, for now the original trigger check functionality is kept here intact and will be removed in the future. 