### PR TITLE
Update Bitrise CLI and default plugins' version

### DIFF
--- a/bitrise/setup.go
+++ b/bitrise/setup.go
@@ -36,11 +36,11 @@ var PluginDependencyMap = map[string]PluginDependency{
 	},
 	"workflow-editor": {
 		Source:     "https://github.com/bitrise-io/bitrise-workflow-editor.git",
-		MinVersion: "1.3.246",
+		MinVersion: "1.3.305",
 	},
 	"analytics": {
 		Source:     "https://github.com/bitrise-io/bitrise-plugins-analytics.git",
-		MinVersion: "0.13.1",
+		MinVersion: "0.13.2",
 	},
 }
 

--- a/version/build.go
+++ b/version/build.go
@@ -1,7 +1,7 @@
 package version
 
 // VERSION is the main CLI version number. It's defined at build time using -ldflags
-var VERSION = "2.10.0"
+var VERSION = "2.11.0"
 
 // BuildNumber is the CI build number that creates the release. It's defined at build time using -ldflags
 var BuildNumber = ""


### PR DESCRIPTION
### Checklist

- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-io/bitrise/blob/master/.github/CONTRIBUTING.md)
- [x] `README.md` is updated with the changes (if needed)

### Version

Requires a *MINOR* [version update](https://semver.org/)

### Context

This PR bumps Bitrise CLI version to 2.11.0 and updates the default plugins to the current latest versions, as a preparation for releasing the [recent 'advanced trigger map' related changes](https://github.com/bitrise-io/bitrise/pull/932).