### PR TITLE
Clean up temp plugin installation folder

### DIFF
--- a/plugins/install.go
+++ b/plugins/install.go
@@ -146,9 +146,9 @@ func installLocalPlugin(pluginSourceURI, pluginLocalPth string) (Plugin, error) 
 		}
 
 		if installedPluginVersionPtr != nil {
-			log.Warnf("installed plugin found with version (%s), overriding it...", (*installedPluginVersionPtr).String())
+			log.Warnf("installed plugin found with version %s, upgrading...", (*installedPluginVersionPtr).String())
 		} else {
-			log.Warnf("installed local plugin found, overriding it...")
+			log.Warnf("installed local plugin found, upgrading...")
 		}
 	}
 	// ---
@@ -213,6 +213,11 @@ func installLocalPlugin(pluginSourceURI, pluginLocalPth string) (Plugin, error) 
 			}
 			return Plugin{}, fmt.Errorf("failed to make plugin bin executable, error: %s", err)
 		}
+	}
+
+	err = os.RemoveAll(tmpPluginDir)
+	if err != nil {
+		log.Warnf("Failed to clean up temp dir after plugin installation, error: %s", err)
 	}
 
 	return newPlugin, nil

--- a/plugins/install.go
+++ b/plugins/install.go
@@ -157,6 +157,12 @@ func installLocalPlugin(pluginSourceURI, pluginLocalPth string) (Plugin, error) 
 	if err != nil {
 		return Plugin{}, fmt.Errorf("failed to create tmp plugin dir, error: %s", err)
 	}
+	defer func() {
+		err = os.RemoveAll(tmpPluginDir)
+		if err != nil {
+			log.Warnf("Failed to clean up temp dir after plugin installation, error: %s", err)
+		}
+	}()
 
 	// Install plugin executable
 	executableURL := newPlugin.ExecutableURL()
@@ -213,11 +219,6 @@ func installLocalPlugin(pluginSourceURI, pluginLocalPth string) (Plugin, error) 
 			}
 			return Plugin{}, fmt.Errorf("failed to make plugin bin executable, error: %s", err)
 		}
-	}
-
-	err = os.RemoveAll(tmpPluginDir)
-	if err != nil {
-		log.Warnf("Failed to clean up temp dir after plugin installation, error: %s", err)
 	}
 
 	return newPlugin, nil


### PR DESCRIPTION
<!--
  Thanks for contributing to the Bitrise CLI!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [ ] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-io/bitrise/blob/master/.github/CONTRIBUTING.md)
- [ ] `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *MAJOR/MINOR/PATCH* [version update](https://semver.org/)

### Context

The CLI installs plugins by first extracting them to a temp folder, and then copying the plugin files over to the final location at `~/.bitrise/plugins`.

### Changes

Clean up temp folder after the plugin is validated and copied to the final location. Cleanup error is treated as a warning, it doesn't break the execution.


### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->