### PR TITLE
Minimal setup flag

### DIFF
--- a/bitrise/dependencies.go
+++ b/bitrise/dependencies.go
@@ -132,47 +132,6 @@ func CheckIsHomebrewInstalled() error {
 	return nil
 }
 
-// PrintInstalledXcodeInfos ...
-func PrintInstalledXcodeInfos() error {
-	xcodeSelectPth, err := command.RunCommandAndReturnStdout("xcode-select", "--print-path")
-	if err != nil {
-		xcodeSelectPth = "xcode-select --print-path failed to detect the location of activate Xcode Command Line Tools path"
-	}
-
-	progInstallPth, err := utils.CheckProgramInstalledPath("xcodebuild")
-	if err != nil {
-		return errors.New("xcodebuild is not installed")
-	}
-
-	isFullXcodeAvailable := false
-	verStr, err := command.RunCommandAndReturnCombinedStdoutAndStderr("xcodebuild", "-version")
-	if err != nil {
-		// No full Xcode available, only the Command Line Tools
-		// verStr is something like "xcode-select: error: tool 'xcodebuild' requires Xcode, but active developer directory '/Library/Developer/CommandLineTools' is a command line tools instance"
-		isFullXcodeAvailable = false
-	} else {
-		// version OK - full Xcode available
-		//  we'll just format it a bit to fit into one line
-		isFullXcodeAvailable = true
-		verStr = strings.Join(strings.Split(verStr, "\n"), " | ")
-	}
-
-	if !isFullXcodeAvailable {
-		log.Printf("%s xcodebuild (%s): %s", colorstring.Green("[OK]"), colorstring.Yellow(verStr), progInstallPth)
-	} else {
-		log.Printf("%s xcodebuild (%s): %s", colorstring.Green("[OK]"), verStr, progInstallPth)
-	}
-
-	log.Printf("%s active Xcode (Command Line Tools) path (xcode-select --print-path): %s", colorstring.Green("[OK]"), xcodeSelectPth)
-
-	if !isFullXcodeAvailable {
-		log.Warnf("No Xcode found, only the Xcode Command Line Tools are available!")
-		log.Warnf("Full Xcode is required to build, test and archive iOS apps!")
-	}
-
-	return nil
-}
-
 func checkIsBitriseToolInstalled(toolname, minVersion string, isInstall bool) error {
 	doInstall := func() error {
 		officialGithub := "https://github.com/bitrise-io/" + toolname

--- a/bitrise/dependencies.go
+++ b/bitrise/dependencies.go
@@ -100,7 +100,7 @@ func CheckIsPluginInstalled(name string, dependency PluginDependency) error {
 }
 
 // CheckIsHomebrewInstalled ...
-func CheckIsHomebrewInstalled(isFullSetupMode bool) error {
+func CheckIsHomebrewInstalled() error {
 	brewRubyInstallCmdString := `$ ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"`
 	officialSiteURL := "http://brew.sh/"
 
@@ -119,21 +119,6 @@ func CheckIsHomebrewInstalled(isFullSetupMode bool) error {
 	if err != nil {
 		log.Infof("")
 		return errors.New("Failed to get version")
-	}
-
-	if isFullSetupMode {
-		// brew doctor
-		doctorOutput := ""
-		var err error
-		progress.ShowIndicator("brew doctor", func() {
-			doctorOutput, err = command.RunCommandAndReturnCombinedStdoutAndStderr("brew", "doctor")
-		})
-		if err != nil {
-			log.Print()
-			log.Warnf("brew doctor returned an error:")
-			log.Warnf("%s", doctorOutput)
-			return errors.New("command failed: brew doctor")
-		}
 	}
 
 	verSplit := strings.Split(verStr, "\n")

--- a/bitrise/setup.go
+++ b/bitrise/setup.go
@@ -13,10 +13,10 @@ import (
 	"github.com/bitrise-io/go-utils/colorstring"
 )
 
-type SetupMode int
+type SetupMode string
 const (
-	SetupModeDefault SetupMode = iota
-	SetupModeMinimal
+	SetupModeDefault SetupMode = "default"
+	SetupModeMinimal SetupMode = "minimal"
 )
 
 const (
@@ -55,14 +55,7 @@ func RunSetupIfNeeded() error {
 func RunSetup(appVersion string, setupMode SetupMode, doCleanSetup bool) error {
 	log.Infof("Setup Bitrise tools...")
 	log.Printf("Clean before setup: %v", doCleanSetup)
-	var setupName string
-	switch setupMode {
-	case SetupModeDefault:
-		setupName = "default"
-	case SetupModeMinimal:
-		setupName = "minimal"
-	}
-	log.Printf("Setup mode: %v", setupName)
+	log.Printf("Setup mode: %s", setupMode)
 	log.Printf("System: %s/%s", runtime.GOOS, runtime.GOARCH)
 
 	if doCleanSetup {

--- a/bitrise/setup.go
+++ b/bitrise/setup.go
@@ -184,8 +184,5 @@ func doSetupOnOSX() error {
 		return errors.New(fmt.Sprint("Homebrew not installed or has some issues. Please fix these before calling setup again. Err:", err))
 	}
 
-	if err := PrintInstalledXcodeInfos(); err != nil {
-		return errors.New(fmt.Sprint("Failed to detect installed Xcode and Xcode Command Line Tools infos. Err:", err))
-	}
 	return nil
 }

--- a/bitrise/setup.go
+++ b/bitrise/setup.go
@@ -79,7 +79,7 @@ func RunSetup(appVersion string, setupMode SetupMode, doCleanSetup bool) error {
 		}
 	}
 
-	if err := doSetupBitriseCoreTools(setupMode); err != nil {
+	if err := doSetupBitriseCoreTools(); err != nil {
 		return fmt.Errorf("Failed to do common/platform independent setup, error: %s", err)
 	}
 
@@ -160,7 +160,7 @@ func doSetupPlugins() error {
 	return nil
 }
 
-func doSetupBitriseCoreTools(mode SetupMode) error {
+func doSetupBitriseCoreTools() error {
 	log.Print()
 	log.Infof("Checking Bitrise Core tools...")
 
@@ -168,10 +168,8 @@ func doSetupBitriseCoreTools(mode SetupMode) error {
 		return fmt.Errorf("Envman failed to install: %s", err)
 	}
 
-	if mode == SetupModeMinimal {
-		if err := CheckIsStepmanInstalled(minStepmanVersion); err != nil {
-			return fmt.Errorf("Stepman failed to install: %s", err)
-		}
+	if err := CheckIsStepmanInstalled(minStepmanVersion); err != nil {
+		return fmt.Errorf("Stepman failed to install: %s", err)
 	}
 
 	return nil

--- a/bitrise/setup.go
+++ b/bitrise/setup.go
@@ -78,7 +78,7 @@ func RunSetup(appVersion string, setupMode SetupMode, doCleanSetup bool) error {
 		switch runtime.GOOS {
 		case "darwin":
 			if err := doSetupOnOSX(); err != nil {
-				return fmt.Errorf("Failed to do MacOS specific setup, error: %s", err)
+				return fmt.Errorf("Failed to do macOS-specific setup, error: %s", err)
 			}
 		case "linux":
 		default:

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -91,7 +91,7 @@ func Run() {
 				return fmt.Errorf("Plugin (%s) not installed", pluginName)
 			}
 
-			if err := bitrise.RunSetupIfNeeded(version.VERSION, false); err != nil {
+			if err := bitrise.RunSetupIfNeeded(version.VERSION); err != nil {
 				failf("Setup failed, error: %s", err)
 			}
 

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -91,7 +91,7 @@ func Run() {
 				return fmt.Errorf("Plugin (%s) not installed", pluginName)
 			}
 
-			if err := bitrise.RunSetupIfNeeded(version.VERSION); err != nil {
+			if err := bitrise.RunSetupIfNeeded(); err != nil {
 				failf("Setup failed, error: %s", err)
 			}
 

--- a/cli/init.go
+++ b/cli/init.go
@@ -24,7 +24,7 @@ var initCmd = cli.Command{
 				log.Print("Running setup to install the default plugins")
 				log.Print()
 
-				if err := bitrise.RunSetup(version.VERSION, false, false); err != nil {
+				if err := bitrise.RunSetup(version.VERSION, bitrise.SetupModeDefault, false); err != nil {
 					return fmt.Errorf("Setup failed, error: %s", err)
 				}
 

--- a/cli/run.go
+++ b/cli/run.go
@@ -199,7 +199,7 @@ func (r WorkflowRunner) RunWorkflowsWithSetupAndCheckForUpdate() (int, error) {
 		tracker.Wait()
 	}()
 
-	if err := bitrise.RunSetupIfNeeded(version.VERSION, false); err != nil {
+	if err := bitrise.RunSetupIfNeeded(version.VERSION); err != nil {
 		return 1, fmt.Errorf("setup failed: %s", err)
 	}
 

--- a/cli/run.go
+++ b/cli/run.go
@@ -199,7 +199,7 @@ func (r WorkflowRunner) RunWorkflowsWithSetupAndCheckForUpdate() (int, error) {
 		tracker.Wait()
 	}()
 
-	if err := bitrise.RunSetupIfNeeded(version.VERSION); err != nil {
+	if err := bitrise.RunSetupIfNeeded(); err != nil {
 		return 1, fmt.Errorf("setup failed: %s", err)
 	}
 

--- a/cli/setup.go
+++ b/cli/setup.go
@@ -27,14 +27,23 @@ var setupCommand = cli.Command{
 			Name:  "clean",
 			Usage: "Removes bitrise's workdir before setup.",
 		},
+		cli.BoolFlag{
+			Name:  "minimal",
+			Usage: "Only installs the required tools for running in CI mode.",
+		},
 	},
 }
 
 func setup(c *cli.Context) error {
-	fullMode := c.Bool("full")
-	cleanMode := c.Bool("clean")
+	clean := c.Bool("clean")
+	minimal := c.Bool("minimal")
 
-	if err := bitrise.RunSetup(c.App.Version, fullMode, cleanMode); err != nil {
+	var setupMode = bitrise.SetupModeDefault
+	if minimal {
+		setupMode = bitrise.SetupModeMinimal
+	}
+
+	if err := bitrise.RunSetup(c.App.Version, setupMode, clean); err != nil {
 		return err
 	}
 

--- a/cli/setup.go
+++ b/cli/setup.go
@@ -38,7 +38,7 @@ func setup(c *cli.Context) error {
 	clean := c.Bool("clean")
 	minimal := c.Bool("minimal")
 
-	var setupMode = bitrise.SetupModeDefault
+	setupMode := bitrise.SetupModeDefault
 	if minimal {
 		setupMode = bitrise.SetupModeMinimal
 	}

--- a/cli/update.go
+++ b/cli/update.go
@@ -277,7 +277,7 @@ func update(c *cli.Context) error {
 		return err
 	}
 
-	return bitrise.RunSetup(versionFlag, false, false)
+	return bitrise.RunSetup(versionFlag, bitrise.SetupModeDefault, false)
 }
 
 // CopyFile ...


### PR DESCRIPTION
<!--
  Thanks for contributing to the Bitrise CLI!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [ ] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-io/bitrise/blob/master/.github/CONTRIBUTING.md)
- [ ] `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *MAJOR/MINOR/PATCH* [version update](https://semver.org/)

### Context

`bitrise setup` is triggered automatically when the CLI is upgraded to a newer version. This setup does a lot of things that are not necessary in CI, such as installing plugins meant for local work.

### Changes

- Add a new `--minimal` flag to the setup subcommand that skips installing plugins, `stepman`, and skips the system check on macOS
- Remove the `--full` setup flag. This controlled only one thing, running `brew doctor` when running on macOS

### Investigation details

Timing tests on my local machine:

Old worst case: all plugins are older than the minimum versions defined by the new CLI: 20s
Old best case: 574ms
New minimal flag: 328ms

### Decisions

<!-- Please list decisions that were made for this change. -->