### PR TITLE
Fix triggr item duplicatin check

### DIFF
--- a/models/trigger_map_item.go
+++ b/models/trigger_map_item.go
@@ -450,7 +450,7 @@ func (item TriggerMapItemModel) conditionsString() string {
 		field := rt.Field(i)
 		tag := field.Tag.Get("yaml")
 		tag = strings.TrimSuffix(tag, ",omitempty")
-		if tag == "pipeline" || tag == "workflow" || tag == "enabled" || tag == "type" {
+		if tag == "pipeline" || tag == "workflow" || tag == "type" || tag == "enabled" {
 			continue
 		}
 
@@ -466,12 +466,6 @@ func (item TriggerMapItemModel) conditionsString() string {
 					continue
 				}
 				value = *boolPtrValue
-			}
-		}
-
-		if itemType, ok := value.(TriggerItemType); ok {
-			if itemType == "" {
-				continue
 			}
 		}
 

--- a/models/trigger_map_item_test.go
+++ b/models/trigger_map_item_test.go
@@ -350,7 +350,7 @@ func TestTriggerMapItemModel_String(t *testing.T) {
 				PushBranch: "master",
 				PipelineID: "pipeline-1",
 			},
-			want: "push_branch: master",
+			want: "type: push & push_branch: master",
 		},
 		{
 			name: "push event",
@@ -358,7 +358,7 @@ func TestTriggerMapItemModel_String(t *testing.T) {
 				PushBranch: "master",
 				WorkflowID: "ci",
 			},
-			want: "push_branch: master",
+			want: "type: push & push_branch: master",
 		},
 		{
 			name: "push event - type only",
@@ -374,7 +374,7 @@ func TestTriggerMapItemModel_String(t *testing.T) {
 				PullRequestSourceBranch: "develop",
 				WorkflowID:              "ci",
 			},
-			want: "pull_request_source_branch: develop",
+			want: "type: pull_request & pull_request_source_branch: develop",
 		},
 		{
 			name: "pull request event - pr target branch",
@@ -382,7 +382,7 @@ func TestTriggerMapItemModel_String(t *testing.T) {
 				PullRequestTargetBranch: "master",
 				WorkflowID:              "ci",
 			},
-			want: "pull_request_target_branch: master",
+			want: "type: pull_request & pull_request_target_branch: master",
 		},
 		{
 			name: "pull request event - pr target and source branch",
@@ -391,7 +391,7 @@ func TestTriggerMapItemModel_String(t *testing.T) {
 				PullRequestTargetBranch: "master",
 				WorkflowID:              "ci",
 			},
-			want: "pull_request_source_branch: develop & pull_request_target_branch: master",
+			want: "type: pull_request & pull_request_source_branch: develop & pull_request_target_branch: master",
 		},
 		{
 			name: "pull request event - pr target and source branch and disable draft prs",
@@ -401,7 +401,7 @@ func TestTriggerMapItemModel_String(t *testing.T) {
 				DraftPullRequestEnabled: pointers.NewBoolPtr(false),
 				WorkflowID:              "ci",
 			},
-			want: "pull_request_source_branch: develop & pull_request_target_branch: master & draft_pull_request_enabled: false",
+			want: "type: pull_request & pull_request_source_branch: develop & pull_request_target_branch: master & draft_pull_request_enabled: false",
 		},
 		{
 			name: "tag event",
@@ -409,7 +409,7 @@ func TestTriggerMapItemModel_String(t *testing.T) {
 				Tag:        "0.9.0",
 				WorkflowID: "release",
 			},
-			want: "tag: 0.9.0",
+			want: "type: tag & tag: 0.9.0",
 		},
 		{
 			name: "deprecated type - pr disabled",
@@ -440,7 +440,7 @@ func TestTriggerMapItemModel_String(t *testing.T) {
 				IsPullRequestAllowed:    true,
 				WorkflowID:              "ci",
 			},
-			want: "push_branch: master & tag: 0.9.0 & pull_request_source_branch: develop & pull_request_target_branch: master & pattern: * & is_pull_request_allowed: true",
+			want: "type: push & push_branch: master & tag: 0.9.0 & pull_request_source_branch: develop & pull_request_target_branch: master & pattern: * & is_pull_request_allowed: true",
 		},
 		{
 			name: "pr event - all conditions",
@@ -452,7 +452,7 @@ func TestTriggerMapItemModel_String(t *testing.T) {
 				CommitMessage:      "my commit",
 				ChangedFiles:       "my file",
 			},
-			want: "commit_message: my commit & changed_files: my file & pull_request_label: my label & pull_request_comment: my comment",
+			want: "type: pull_request & commit_message: my commit & changed_files: my file & pull_request_label: my label & pull_request_comment: my comment",
 		},
 		{
 			name: "push event - all conditions",
@@ -462,7 +462,7 @@ func TestTriggerMapItemModel_String(t *testing.T) {
 				CommitMessage: "my commit",
 				ChangedFiles:  "my file",
 			},
-			want: "commit_message: my commit & changed_files: my file",
+			want: "type: push & commit_message: my commit & changed_files: my file",
 		},
 	}
 	for _, tt := range tests {

--- a/models/trigger_map_test.go
+++ b/models/trigger_map_test.go
@@ -51,6 +51,54 @@ func TestTriggerMapModel_Validate(t *testing.T) {
 			workflows: []string{"ci", "release"},
 		},
 		{
+			name: "Pull Request trigger items",
+			triggerMap: TriggerMapModel{
+				TriggerMapItemModel{
+					PullRequestSourceBranch: "feature*",
+					WorkflowID:              "ci",
+				},
+				TriggerMapItemModel{
+					PullRequestSourceBranch: "master",
+					WorkflowID:              "release",
+				},
+			},
+			workflows: []string{"ci", "release"},
+		},
+		{
+			name: "Pull Request trigger items - different draft pr enabled",
+			triggerMap: TriggerMapModel{
+				TriggerMapItemModel{
+					PullRequestSourceBranch: "develop",
+					PullRequestTargetBranch: "master",
+					DraftPullRequestEnabled: pointers.NewBoolPtr(false),
+					WorkflowID:              "release",
+				},
+				TriggerMapItemModel{
+					PullRequestSourceBranch: "develop",
+					PullRequestTargetBranch: "master",
+					DraftPullRequestEnabled: pointers.NewBoolPtr(true),
+					WorkflowID:              "ci",
+				},
+			},
+			workflows: []string{"ci", "release"},
+		},
+		{
+			name: "Trigger items with same conditions but different type",
+			triggerMap: TriggerMapModel{
+				TriggerMapItemModel{
+					Type:         PullRequestType,
+					ChangedFiles: "*.md",
+					WorkflowID:   "ci",
+				},
+				TriggerMapItemModel{
+					Type:         CodePushType,
+					ChangedFiles: "*.md",
+					WorkflowID:   "release",
+				},
+			},
+			workflows: []string{"ci", "release"},
+		},
+		{
 			name: "Push trigger items - duplication",
 			triggerMap: TriggerMapModel{
 				TriggerMapItemModel{
@@ -64,20 +112,6 @@ func TestTriggerMapModel_Validate(t *testing.T) {
 			},
 			workflows: []string{"ci", "release"},
 			wantErr:   "the 2. trigger item duplicates the 1. trigger item",
-		},
-		{
-			name: "Pull Request trigger items",
-			triggerMap: TriggerMapModel{
-				TriggerMapItemModel{
-					PullRequestSourceBranch: "feature*",
-					WorkflowID:              "ci",
-				},
-				TriggerMapItemModel{
-					PullRequestSourceBranch: "master",
-					WorkflowID:              "release",
-				},
-			},
-			workflows: []string{"ci", "release"},
 		},
 		{
 			name: "Pull Request trigger items - duplicated (source branch)",
@@ -127,24 +161,6 @@ func TestTriggerMapModel_Validate(t *testing.T) {
 			wantErr:   "the 2. trigger item duplicates the 1. trigger item",
 		},
 		{
-			name: "Pull Request trigger items - different draft pr enabled",
-			triggerMap: TriggerMapModel{
-				TriggerMapItemModel{
-					PullRequestSourceBranch: "develop",
-					PullRequestTargetBranch: "master",
-					DraftPullRequestEnabled: pointers.NewBoolPtr(false),
-					WorkflowID:              "release",
-				},
-				TriggerMapItemModel{
-					PullRequestSourceBranch: "develop",
-					PullRequestTargetBranch: "master",
-					DraftPullRequestEnabled: pointers.NewBoolPtr(true),
-					WorkflowID:              "ci",
-				},
-			},
-			workflows: []string{"ci", "release"},
-		},
-		{
 			name: "Tag trigger items - duplicated",
 			triggerMap: TriggerMapModel{
 				TriggerMapItemModel{
@@ -153,6 +169,22 @@ func TestTriggerMapModel_Validate(t *testing.T) {
 				},
 				TriggerMapItemModel{
 					Tag:        "0.9.0",
+					WorkflowID: "release",
+				},
+			},
+			workflows: []string{"ci", "release"},
+			wantErr:   "the 2. trigger item duplicates the 1. trigger item",
+		},
+		{
+			name: "Same conditions considered as a duplicate",
+			triggerMap: TriggerMapModel{
+				TriggerMapItemModel{
+					Type:       CodePushType,
+					PushBranch: "*",
+					WorkflowID: "ci",
+				},
+				TriggerMapItemModel{
+					PushBranch: "*",
 					WorkflowID: "release",
 				},
 			},


### PR DESCRIPTION
### Checklist

- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-io/bitrise/blob/master/.github/CONTRIBUTING.md)
- [x] `README.md` is updated with the changes (if needed)

### Version

Requires a *PATCH* [version update](https://semver.org/)

### Context

This PR fixes an issue with trigger map validation. The validation process considered trigger map items with the same conditions, but different types as duplicates.

For example, `bitrise validate` thrown a `the 2. trigger item duplicates the 1. trigger item` error fr the following trigger map:

```
trigger_map:
- type: pull_request
  changed_files: "*.md"
  workflow: check
- type: push
  changed_files: "*.md"
  workflow: check
```

<!-- Please link the issue that the PR fixes.
Resolves: #GITHUB_ISSUE_ID or https://link_to_the_issue_on_discuss.bitrise.io.
-->

### Changes

- Consider the type of the trigger item, when duplication is tested.
