### PR TITLE
[CI-2937] CLI command logging

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/bitrise-io/bitrise/analytics"
 	"github.com/bitrise-io/bitrise/bitrise"
 	"github.com/bitrise-io/bitrise/configs"
 	"github.com/bitrise-io/bitrise/log"
@@ -16,6 +17,8 @@ import (
 	"github.com/bitrise-io/bitrise/version"
 	"github.com/urfave/cli"
 )
+
+var globalTracker analytics.Tracker
 
 // Run ...
 func Run() {
@@ -80,6 +83,14 @@ func Run() {
 	app.Flags = flags
 	app.Commands = commands
 
+	globalTracker = analytics.NewDefaultTracker()
+	defer func() {
+		globalTracker.Wait()
+	}()
+
+	command, subcommand, flags := commandExecutionInfo(os.Args[1:])
+	globalTracker.SendCommandInfo(command, subcommand, flags)
+
 	app.Action = func(c *cli.Context) error {
 		pluginName, pluginArgs, isPlugin := plugins.ParseArgs(c.Args())
 		if isPlugin {
@@ -111,6 +122,46 @@ func Run() {
 	if err := app.Run(os.Args); err != nil {
 		failf(err.Error())
 	}
+}
+
+func commandExecutionInfo(args []string) (string, string, []string) {
+	if len(args) == 0 {
+		return "", "", nil
+	}
+
+	command := args[0]
+	commandFlags := collectFlags(args)
+	isPluginCommand := strings.HasPrefix(command, ":")
+
+	if isPluginCommand && len(args) > 1 {
+		return command, args[1], commandFlags
+	}
+
+	return command, "", commandFlags
+}
+
+func collectFlags(args []string) []string {
+	var commandFlags []string
+	for _, arg := range args {
+		if !strings.HasPrefix(arg, "-") && !strings.HasPrefix(arg, "--") {
+			continue
+		}
+
+		components := strings.Split(arg, "=")
+		if len(components) < 1 {
+			continue
+		}
+
+		components = strings.Split(components[0], " ")
+		if len(components) < 1 {
+			continue
+		}
+
+		trimmedFlag := strings.TrimPrefix(strings.TrimPrefix(components[0], "--"), "-")
+		commandFlags = append(commandFlags, trimmedFlag)
+	}
+
+	return commandFlags
 }
 
 func loggerParameters(arguments []string) (isRunCommand bool, outputFormat log.LoggerType, isDebug bool) {

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -7,6 +7,54 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestCommandInfo(t *testing.T) {
+	tests := []struct {
+		name           string
+		args           []string
+		wantCommand    string
+		wantSubcommand string
+		wantFlags      []string
+	}{
+		{
+			name:           "Empty command",
+			args:           []string{},
+			wantCommand:    "",
+			wantSubcommand: "",
+			wantFlags:      nil,
+		},
+		{
+			name:           "CLI command",
+			args:           []string{"run", "e2e"},
+			wantCommand:    "run",
+			wantSubcommand: "",
+			wantFlags:      nil,
+		},
+		{
+			name:           "Plugin command",
+			args:           []string{":plugin", "do", "something"},
+			wantCommand:    ":plugin",
+			wantSubcommand: "do",
+			wantFlags:      nil,
+		},
+		{
+			name:           "Flags",
+			args:           []string{"run", "--A", "-a", "--B=true", "-b false", "--C /path/to/something"},
+			wantCommand:    "run",
+			wantSubcommand: "",
+			wantFlags:      []string{"A", "a", "B", "b", "C"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			command, subcommand, flags := commandExecutionInfo(tt.args)
+			assert.Equalf(t, tt.wantCommand, command, "commandExecutionInfo(%v)", tt.args)
+			assert.Equalf(t, tt.wantSubcommand, subcommand, "commandExecutionInfo(%v)", tt.args)
+			assert.Equalf(t, tt.wantFlags, flags, "commandExecutionInfo(%v)", tt.args)
+		})
+	}
+}
+
 func Test_loggerParameters(t *testing.T) {
 	tests := []struct {
 		name             string

--- a/cli/run.go
+++ b/cli/run.go
@@ -192,11 +192,6 @@ func (r WorkflowRunner) RunWorkflowsWithSetupAndCheckForUpdate() (int, error) {
 		return 1, fmt.Errorf("specified Workflow (%s) does not exist", r.config.Workflow)
 	}
 
-	tracker := analytics.NewDefaultTracker()
-	defer func() {
-		tracker.Wait()
-	}()
-
 	if err := bitrise.RunSetupIfNeeded(); err != nil {
 		return 1, fmt.Errorf("setup failed: %s", err)
 	}
@@ -218,7 +213,7 @@ func (r WorkflowRunner) RunWorkflowsWithSetupAndCheckForUpdate() (int, error) {
 		}()
 	}
 
-	if buildRunResults, err := r.runWorkflows(tracker); err != nil {
+	if buildRunResults, err := r.runWorkflows(globalTracker); err != nil {
 		return 1, fmt.Errorf("failed to run workflow: %s", err)
 	} else if buildRunResults.IsBuildFailed() {
 		return buildRunResults.ExitCode(), errWorkflowRunFailed

--- a/cli/run_test.go
+++ b/cli/run_test.go
@@ -1731,5 +1731,6 @@ func (n noOpTracker) SendCLIWarning(string)                                     
 func (n noOpTracker) SendWorkflowStarted(analytics.Properties, string, string)            {}
 func (n noOpTracker) SendWorkflowFinished(analytics.Properties, bool)                     {}
 func (n noOpTracker) SendToolVersionSnapshot(string, string)                              {}
+func (n noOpTracker) SendCommandInfo(string, string, []string)                            {}
 func (n noOpTracker) Wait()                                                               {}
 func (n noOpTracker) IsTracking() bool                                                    { return false }


### PR DESCRIPTION
<!--
  Thanks for contributing to the Bitrise CLI!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [ ] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-io/bitrise/blob/master/.github/CONTRIBUTING.md)
- [ ] `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *MINOR* [version update](https://semver.org/)

### Context

We want to better understand how our users are using the CLI so we will be collecting what commands are executed and which flags are used. 

### Implementation

I have extended the existing logger with a new event. 

At the moment the run command was initialising the tracker and it was the only user of it. This was not good because we need to log the command info much earlier. So I moved the tracker initialisation where the CLI execution starts. With this there was a new problem with how to share this tracker with the run command. 

We are using the urfave cli package to parse and execute the tasks. This package has a `Context` (not the same as the Go `Context` one) struct which will trickle down to the commands. But you can only add strings to it. So the simplest solution seemed to put the tracker into a global variable and inject that into the execution flow.