### PR TITLE
Refactor containerisation 2

### DIFF
--- a/_tests/integration/docker_create_bitrise.yml
+++ b/_tests/integration/docker_create_bitrise.yml
@@ -18,35 +18,43 @@ containers:
 workflows:
   docker-create-fails-invalid-port:
     title: Expected to fail on docker create, invalid port provided
-    container: invalid-port
     steps:
-    - script:
-        title: Should not run due to prev error
-        inputs:
-        - content: exit 0
+    - with:
+        container: invalid-port
+        steps:
+        - script:
+            title: Should not run due to prev error
+            inputs:
+            - content: exit 0
   docker-create-succeeds-valid-port:
     title: Expected to pass on docker create, valid port provided
-    container: valid-port
     steps:
-    - script:
-        title: Should succeed
-        inputs:
-        - content: exit 0
+    - with:
+        container: valid-port
+        steps:
+        - script:
+            title: Should succeed
+            inputs:
+            - content: exit 0
   docker-create-succeeds-with-false-unhealthy-container:
     title: Expected to log error on docker create
     description: Expected to log error on docker create, because healthchecks are wrong, however execution should continue
-    container: unhealthy-container
     steps:
-    - script:
-        title: Should succceed
-        inputs:
-        - content: exit 0
+    - with:
+        container: unhealthy-container
+        steps:
+        - script:
+            title: Should succceed
+            inputs:
+            - content: exit 0
   docker-create-fails-invalid-option:
     title: Expected to log error on docker create
     description: Expected to log error on docker create, because healthcheck are wrong, however execution should continue
-    container: invalid-option
     steps:
-    - script:
-        title: Should fail
-        inputs:
-        - content: exit 0
+    - with:
+        container: invalid-option
+        steps:
+        - script:
+            title: Should fail
+            inputs:
+            - content: exit 0

--- a/_tests/integration/docker_multiple_containers_bitrise.yml
+++ b/_tests/integration/docker_multiple_containers_bitrise.yml
@@ -68,14 +68,14 @@ workflows:
         title: setup mock registry for step execution container
         inputs:
         - content: |-
-            mkdir auth
-            docker run --entrypoint htpasswd httpd:2 -Bbn $USR $PASS > auth/htpasswd
+            mkdir auth_$PORT
+            docker run --entrypoint htpasswd httpd:2 -Bbn $USR $PASS > auth_$PORT/htpasswd
             docker pull --platform linux/amd64 registry:latest
             docker run -d -p $PORT:5000 --restart always --name registry_$PORT \
-              -v "$(pwd)"/auth:/auth \
+              -v "$(pwd)"/auth_$PORT:/auth_$PORT \
               -e "REGISTRY_AUTH=htpasswd" \
               -e "REGISTRY_AUTH_HTPASSWD_REALM=Registry Realm" \
-              -e REGISTRY_AUTH_HTPASSWD_PATH=/auth/htpasswd \
+              -e REGISTRY_AUTH_HTPASSWD_PATH=/auth_$PORT/htpasswd \
               registry
             docker login localhost:$PORT -u $USR -p $PASS
             docker build -t healthy-image -f ${SRC_DIR_IN_GOPATH}/_tests/integration/docker_test.Dockerfile.healthy-container .

--- a/_tests/integration/docker_multiple_containers_bitrise.yml
+++ b/_tests/integration/docker_multiple_containers_bitrise.yml
@@ -1,0 +1,82 @@
+format_version: 1.3.0
+default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
+containers:
+  step_execution_container:
+    image: localhost:5001/frolvlad/alpine-bash:latest
+    credentials:
+      username: $DOCKER_USR_STEP_EXECUTION_CONTAINER
+      password: $DOCKER_PW_STEP_EXECUTION_CONTAINER
+services:
+  service_1_container:
+    image: localhost:5002/frolvlad/alpine-bash:latest
+    credentials:
+      username: $DOCKER_USR_SERVICE_1_CONTAINER
+      password: $DOCKER_PW_SERVICE_1_CONTAINER
+  service_2_container:
+    image: localhost:5003/frolvlad/alpine-bash:latest
+    credentials:
+      username: $DOCKER_USR_SERVICE_2_CONTAINER
+      password: $DOCKER_PW_SERVICE_2_CONTAINER
+workflows:
+  docker-login-multiple-containers:
+    before_run:
+    - _start_mock_registry_for_step_execution_container
+    - _start_mock_registry_for_service_1_container
+    - _start_mock_registry_for_service_2_container
+    after_run:
+    - _cleanup_mock_registry
+    title: Expected to pass docker login
+    steps:
+    - with:
+        container: step_execution_container
+        services:
+        - service_1_container
+        - service_2_container
+        steps:
+        - script:
+            title: Should pass
+            inputs:
+            - content: exit 0
+  _start_mock_registry_for_step_execution_container:
+    envs:
+    - PORT: 5001
+    - USR: $DOCKER_USR_STEP_EXECUTION_CONTAINER
+    - PASS: $DOCKER_PW_STEP_EXECUTION_CONTAINER
+    after_run:
+    - _start_mock_registry
+  _start_mock_registry_for_service_1_container:
+    envs:
+    - PORT: 5002
+    - USR: $DOCKER_USR_SERVICE_1_CONTAINER
+    - PASS: $DOCKER_PW_SERVICE_1_CONTAINER
+    after_run:
+    - _start_mock_registry
+  _start_mock_registry_for_service_2_container:
+    envs:
+    - PORT: 5003
+    - USR: $DOCKER_USR_SERVICE_2_CONTAINER
+    - PASS: $DOCKER_PW_SERVICE_2_CONTAINER
+    after_run:
+    - _start_mock_registry
+  _start_mock_registry:
+    steps:
+    - script:
+        title: setup mock registry for step execution container
+        inputs:
+        - content: |-
+            docker pull --platform linux/amd64 registry:latest
+            docker run -d -p $PORT:5000 --restart always --name registry_$PORT registry
+            docker pull --platform linux/amd64 frolvlad/alpine-bash:latest
+            docker login localhost:$PORT -u $USR -p $PASS
+            docker tag frolvlad/alpine-bash:latest localhost:$PORT/frolvlad/alpine-bash:latest
+            docker push localhost:$PORT/frolvlad/alpine-bash:latest
+            docker logout localhost:$PORT
+  _cleanup_mock_registry:
+    steps:
+    - script:
+        is_always_run: true
+        title: cleanup mock registry
+        inputs:
+        - content: |-
+            docker stop registry
+            docker rm registry

--- a/_tests/integration/docker_multiple_containers_bitrise.yml
+++ b/_tests/integration/docker_multiple_containers_bitrise.yml
@@ -70,10 +70,10 @@ workflows:
         - content: |-
             docker pull --platform linux/amd64 registry:latest
             docker run -d -p $PORT:5000 --restart always --name registry_$PORT registry
-            docker pull --platform linux/amd64 frolvlad/alpine-bash:latest
             docker login localhost:$PORT -u $USR -p $PASS
-            docker tag frolvlad/alpine-bash:latest localhost:$PORT/frolvlad/alpine-bash:latest
-            docker push localhost:$PORT/frolvlad/alpine-bash:latest
+            docker build -t healthy-image -f ${SRC_DIR_IN_GOPATH}/_tests/integration/docker_test.Dockerfile.healthy-container .
+            docker tag healthy-image localhost:$PORT/healthy-image
+            docker push localhost:$PORT/healthy-image
             docker logout localhost:$PORT
   _cleanup_mock_registry_for_step_execution_container:
     envs:

--- a/_tests/integration/docker_multiple_containers_bitrise.yml
+++ b/_tests/integration/docker_multiple_containers_bitrise.yml
@@ -12,11 +12,13 @@ services:
     credentials:
       username: $DOCKER_USR_SERVICE_1_CONTAINER
       password: $DOCKER_PW_SERVICE_1_CONTAINER
+    options: --health-cmd "stat /ready || exit 1" --health-interval 1s --health-timeout 3s --health-retries 3
   service_2_container:
     image: localhost:5003/frolvlad/alpine-bash:latest
     credentials:
       username: $DOCKER_USR_SERVICE_2_CONTAINER
       password: $DOCKER_PW_SERVICE_2_CONTAINER
+    options: --health-cmd "stat /ready || exit 1" --health-interval 1s --health-timeout 3s --health-retries 3
 workflows:
   docker-login-multiple-containers:
     before_run:
@@ -24,7 +26,9 @@ workflows:
     - _start_mock_registry_for_service_1_container
     - _start_mock_registry_for_service_2_container
     after_run:
-    - _cleanup_mock_registry
+    - _cleanup_mock_registry_for_step_execution_container
+    - _cleanup_mock_registry_for_service_1_container
+    - _cleanup_mock_registry_for_service_2_container
     title: Expected to pass docker login
     steps:
     - with:
@@ -71,6 +75,21 @@ workflows:
             docker tag frolvlad/alpine-bash:latest localhost:$PORT/frolvlad/alpine-bash:latest
             docker push localhost:$PORT/frolvlad/alpine-bash:latest
             docker logout localhost:$PORT
+  _cleanup_mock_registry_for_step_execution_container:
+    envs:
+    - PORT: 5001
+    after_run:
+    - _cleanup_mock_registry
+  _cleanup_mock_registry_for_service_1_container:
+    envs:
+    - PORT: 5002
+    after_run:
+    - _cleanup_mock_registry
+  _cleanup_mock_registry_for_service_2_container:
+    envs:
+    - PORT: 5003
+    after_run:
+    - _cleanup_mock_registry
   _cleanup_mock_registry:
     steps:
     - script:
@@ -78,5 +97,5 @@ workflows:
         title: cleanup mock registry
         inputs:
         - content: |-
-            docker stop registry
-            docker rm registry
+            docker stop registry_$PORT
+            docker rm registry_$PORT

--- a/_tests/integration/docker_multiple_containers_bitrise.yml
+++ b/_tests/integration/docker_multiple_containers_bitrise.yml
@@ -2,19 +2,19 @@ format_version: 1.3.0
 default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
 containers:
   step_execution_container:
-    image: localhost:5001/frolvlad/alpine-bash:latest
+    image: localhost:5001/healthy-image
     credentials:
       username: $DOCKER_USR_STEP_EXECUTION_CONTAINER
       password: $DOCKER_PW_STEP_EXECUTION_CONTAINER
 services:
   service_1_container:
-    image: localhost:5002/frolvlad/alpine-bash:latest
+    image: localhost:5002/healthy-image
     credentials:
       username: $DOCKER_USR_SERVICE_1_CONTAINER
       password: $DOCKER_PW_SERVICE_1_CONTAINER
     options: --health-cmd "stat /ready || exit 1" --health-interval 1s --health-timeout 3s --health-retries 3
   service_2_container:
-    image: localhost:5003/frolvlad/alpine-bash:latest
+    image: localhost:5003/healthy-image
     credentials:
       username: $DOCKER_USR_SERVICE_2_CONTAINER
       password: $DOCKER_PW_SERVICE_2_CONTAINER

--- a/_tests/integration/docker_multiple_containers_bitrise.yml
+++ b/_tests/integration/docker_multiple_containers_bitrise.yml
@@ -68,8 +68,15 @@ workflows:
         title: setup mock registry for step execution container
         inputs:
         - content: |-
+            mkdir auth
+            docker run --entrypoint htpasswd httpd:2 -Bbn $USR $PASS > auth/htpasswd
             docker pull --platform linux/amd64 registry:latest
-            docker run -d -p $PORT:5000 --restart always --name registry_$PORT registry
+            docker run -d -p $PORT:5000 --restart always --name registry_$PORT \
+              -v "$(pwd)"/auth:/auth \
+              -e "REGISTRY_AUTH=htpasswd" \
+              -e "REGISTRY_AUTH_HTPASSWD_REALM=Registry Realm" \
+              -e REGISTRY_AUTH_HTPASSWD_PATH=/auth/htpasswd \
+              registry
             docker login localhost:$PORT -u $USR -p $PASS
             docker build -t healthy-image -f ${SRC_DIR_IN_GOPATH}/_tests/integration/docker_test.Dockerfile.healthy-container .
             docker tag healthy-image localhost:$PORT/healthy-image

--- a/_tests/integration/docker_multiple_containers_secrets.yml
+++ b/_tests/integration/docker_multiple_containers_secrets.yml
@@ -1,7 +1,8 @@
 envs:
-- DOCKER_USR_STEP_EXECUTION_CONTAINER: test
-- DOCKER_PW_STEP_EXECUTION_CONTAINER: test
-- DOCKER_USR_SERVICE_1_CONTAINER: test
-- DOCKER_PW_SERVICE_1_CONTAINER: test
-- DOCKER_USR_SERVICE_2_CONTAINER: test
-- DOCKER_PW_SERVICE_2_CONTAINER: test
+- DOCKER_USR_STEP_EXECUTION_CONTAINER: test_usr_step_execution_container
+- DOCKER_PW_STEP_EXECUTION_CONTAINER: test_pwd_step_execution_container
+- DOCKER_USR_SERVICE_1_CONTAINER: test_usr_service_1_container
+- DOCKER_PW_SERVICE_1_CONTAINER: test_pwd_service_1_container
+- DOCKER_USR_SERVICE_2_CONTAINER: test_usr_service_2_container
+- DOCKER_PW_SERVICE_2_CONTAINER: test_pwd_service_2_container
+

--- a/_tests/integration/docker_multiple_containers_secrets.yml
+++ b/_tests/integration/docker_multiple_containers_secrets.yml
@@ -1,7 +1,7 @@
 envs:
-- DOCKER_USR_STEP_EXECUTION_CONTAINER: test_usr_step_execution_container
-- DOCKER_PW_STEP_EXECUTION_CONTAINER: test_pwd_step_execution_container
-- DOCKER_USR_SERVICE_1_CONTAINER: test_usr_service_1_container
-- DOCKER_PW_SERVICE_1_CONTAINER: test_pwd_service_1_container
-- DOCKER_USR_SERVICE_2_CONTAINER: test_usr_service_2_container
-- DOCKER_PW_SERVICE_2_CONTAINER: test_pwd_service_2_container
+- DOCKER_USR_STEP_EXECUTION_CONTAINER: test
+- DOCKER_PW_STEP_EXECUTION_CONTAINER: test
+- DOCKER_USR_SERVICE_1_CONTAINER: test
+- DOCKER_PW_SERVICE_1_CONTAINER: test
+- DOCKER_USR_SERVICE_2_CONTAINER: test
+- DOCKER_PW_SERVICE_2_CONTAINER: test

--- a/_tests/integration/docker_multiple_containers_secrets.yml
+++ b/_tests/integration/docker_multiple_containers_secrets.yml
@@ -5,4 +5,3 @@ envs:
 - DOCKER_PW_SERVICE_1_CONTAINER: test_pwd_service_1_container
 - DOCKER_USR_SERVICE_2_CONTAINER: test_usr_service_2_container
 - DOCKER_PW_SERVICE_2_CONTAINER: test_pwd_service_2_container
-

--- a/_tests/integration/docker_multiple_containers_secrets.yml
+++ b/_tests/integration/docker_multiple_containers_secrets.yml
@@ -1,0 +1,7 @@
+envs:
+- DOCKER_USR_STEP_EXECUTION_CONTAINER: test_usr_step_execution_container
+- DOCKER_PW_STEP_EXECUTION_CONTAINER: test_pwd_step_execution_container
+- DOCKER_USR_SERVICE_1_CONTAINER: test_usr_service_1_container
+- DOCKER_PW_SERVICE_1_CONTAINER: test_pwd_service_1_container
+- DOCKER_USR_SERVICE_2_CONTAINER: test_usr_service_2_container
+- DOCKER_PW_SERVICE_2_CONTAINER: test_pwd_service_2_container

--- a/_tests/integration/docker_pull_bitrise.yml
+++ b/_tests/integration/docker_pull_bitrise.yml
@@ -18,40 +18,48 @@ containers:
 workflows:
   docker-pull-success:
     title: Expected to pass docker pull
-    container: success
     steps:
-    - script:
-        title: Should pass
-        inputs:
-        - content: exit 0
+    - with:
+        container: success
+        steps:
+        - script:
+            title: Should pass
+            inputs:
+            - content: exit 0
   docker-pull-fails-404:
     title: Expected to fail docker pull
-    container: fails-404
     steps:
-    - script:
-        title: Should fail
-        inputs:
-        - content: exit 0
+    - with:
+        container: fails-404
+        steps:
+        - script:
+            title: Should fail
+            inputs:
+            - content: exit 0
   docker-login-fail:
     title: Expected to fail on docker login
-    container: login-fail
     steps:
-    - script:
-        title: Should fail
-        inputs:
-        - content: exit 0
+    - with:
+        container: login-fail
+        steps:
+        - script:
+            title: Should fail
+            inputs:
+            - content: exit 0
   docker-login-success:
     before_run:
     - _start_mock_registry
     after_run:
     - _cleanup_mock_registry
     title: Expected to pass docker login
-    container: login-success
     steps:
-    - script:
-        title: Should pass
-        inputs:
-        - content: exit 0
+    - with:
+        container: login-success
+        steps:
+        - script:
+            title: Should pass
+            inputs:
+            - content: exit 0
   _start_mock_registry:
     steps:
     - script:

--- a/_tests/integration/docker_service_bitrise.yml
+++ b/_tests/integration/docker_service_bitrise.yml
@@ -10,24 +10,27 @@ workflows:
   docker-service-start-fails:
     before_run:
     - _build-failing-image
-    services:
-    - failing-service
     steps:
-    - script:
-        title: Should succeed, but services related errors are logged
-        inputs:
-        - content: exit 0
+    - with:
+        services:
+        - failing-service
+        steps:
+        - script:
+            title: Should succeed, but services related errors are logged
+            inputs:
+            - content: exit 0
   docker-service-start-succeeds-after-retries:
     before_run:
     - _build-slow-starting-image
-    services:
-    - slow-booting-service
     steps:
-    - script:
-        title: Should succeed, but services related errors are logged
-        inputs:
-        - content: exit 0
-
+    - with:
+        services:
+        - slow-booting-service
+        steps:
+        - script:
+            title: Should succeed, but services related errors are logged
+            inputs:
+            - content: exit 0
   _build-failing-image:
     steps:
     - script:

--- a/_tests/integration/docker_start_fails_bitrise.yml
+++ b/_tests/integration/docker_start_fails_bitrise.yml
@@ -8,12 +8,14 @@ workflows:
     before_run:
     - _build-failing-image
     title: Expected to fail on docker start, failing image is used
-    container: failing-image
     steps:
-    - script:
-        title: Should not run due to prev error
-        inputs:
-        - content: exit 0
+    - with:
+        container: failing-image
+        steps:
+        - script:
+            title: Should not run due to prev error
+            inputs:
+            - content: exit 0
   _build-failing-image:
     steps:
     - script:

--- a/_tests/integration/docker_test.Dockerfile.healthy-container
+++ b/_tests/integration/docker_test.Dockerfile.healthy-container
@@ -1,0 +1,2 @@
+FROM frolvlad/alpine-bash:latest
+CMD ["bash", "-c", "sleep 3; touch /ready; echo 'Im healthy now'; sleep infinity"]

--- a/_tests/integration/docker_test.go
+++ b/_tests/integration/docker_test.go
@@ -123,7 +123,9 @@ func Test_Docker(t *testing.T) {
 			inventoryPath: "docker_multiple_containers_secrets.yml",
 			requireErr:    false,
 			requireLogs: []string{
-				"Waiting for container (slow-booting-service) to be healthy",
+				"Container (service_1_container) is healthy...",
+				"Container (service_2_container) is healthy...",
+				"Step is running in container: localhost:5001/healthy-image",
 			},
 		},
 	}

--- a/_tests/integration/docker_test.go
+++ b/_tests/integration/docker_test.go
@@ -117,6 +117,15 @@ func Test_Docker(t *testing.T) {
 				"Waiting for container (slow-booting-service) to be healthy",
 			},
 		},
+		"docker start container and services with credentials": {
+			configPath:    "docker_multiple_containers_bitrise.yml",
+			workflowName:  "docker-login-multiple-containers",
+			inventoryPath: "docker_multiple_containers_secrets.yml",
+			requireErr:    false,
+			requireLogs: []string{
+				"Waiting for container (slow-booting-service) to be healthy",
+			},
+		},
 	}
 
 	for testName, testCase := range testCases {

--- a/_tests/integration/docker_test.go
+++ b/_tests/integration/docker_test.go
@@ -136,8 +136,8 @@ func Test_Docker(t *testing.T) {
 				require.Contains(t, out, log)
 			}
 			for _, logPattern := range testCase.requiredLogPatterns {
-				contains := glob.Glob(logPattern, log)
-				require.True(t, contains, log)
+				contains := glob.Glob(logPattern, out)
+				require.True(t, contains, out)
 			}
 		})
 	}

--- a/_tests/integration/docker_test.go
+++ b/_tests/integration/docker_test.go
@@ -79,7 +79,7 @@ func Test_Docker(t *testing.T) {
 				"Step is running in container: frolvlad/alpine-bash:latest",
 			},
 			requiredLogPatterns: []string{
-				"Container (bitrise-workflow-*) is unhealthy...",
+				"*Container (bitrise-workflow-*) is unhealthy...*",
 			},
 		},
 		"docker create fails when invalid option is provided": {

--- a/_tests/integration/docker_test.go
+++ b/_tests/integration/docker_test.go
@@ -40,7 +40,7 @@ func Test_Docker(t *testing.T) {
 			workflowName: "docker-login-fail",
 			requireErr:   true,
 			requireLogs: []string{
-				"workflow has docker credentials provided, but the authentication failed",
+				"docker credentials provided, but the authentication failed",
 			},
 		},
 		"docker login succeeds when correct credentials are provided": {

--- a/cli/docker/container_manager.go
+++ b/cli/docker/container_manager.go
@@ -146,14 +146,14 @@ func (cm *ContainerManager) Login(container models.Container, envs map[string]st
 	return nil
 }
 
-func (cm *ContainerManager) StartWorkflowContainer(
+func (cm *ContainerManager) StartContainerFroStepGroup(
 	container models.Container,
-	workflowID string,
+	groupID string,
 	envs map[string]string,
 ) (*RunningContainer, error) {
 	cm.mu.Lock()
 	defer cm.mu.Unlock()
-	containerName := fmt.Sprintf("bitrise-workflow-%s", workflowID)
+	containerName := fmt.Sprintf("bitrise-workflow-%s", groupID)
 
 	// TODO: handle default mounts if BITRISE_DOCKER_MOUNT_OVERRIDES is not provided
 	dockerMountOverrides := strings.Split(os.Getenv("BITRISE_DOCKER_MOUNT_OVERRIDES"), ",")
@@ -168,7 +168,7 @@ func (cm *ContainerManager) StartWorkflowContainer(
 
 	// Even on failure we save the reference to make sure containers will be cleaned up
 	if runningContainer != nil {
-		cm.workflowContainers[workflowID] = runningContainer
+		cm.workflowContainers[groupID] = runningContainer
 	}
 
 	if err != nil {
@@ -182,9 +182,9 @@ func (cm *ContainerManager) StartWorkflowContainer(
 	return runningContainer, nil
 }
 
-func (cm *ContainerManager) StartServiceContainers(
+func (cm *ContainerManager) StartServiceContainersFroStepGroup(
 	services map[string]models.Container,
-	workflowID string,
+	groupID string,
 	envs map[string]string,
 ) ([]*RunningContainer, error) {
 	var containers []*RunningContainer
@@ -204,7 +204,7 @@ func (cm *ContainerManager) StartServiceContainers(
 		}
 	}
 	// Even on failure we save the references to make sure containers will be cleaned up
-	cm.serviceContainers[workflowID] = append(cm.serviceContainers[workflowID], containers...)
+	cm.serviceContainers[groupID] = append(cm.serviceContainers[groupID], containers...)
 
 	if len(failedServices) != 0 {
 		errServices := fmt.Errorf("failed to start services")
@@ -224,12 +224,12 @@ func (cm *ContainerManager) StartServiceContainers(
 	return containers, nil
 }
 
-func (cm *ContainerManager) GetWorkflowContainer(workflowID string) *RunningContainer {
-	return cm.workflowContainers[workflowID]
+func (cm *ContainerManager) GetContainerFroStepGroup(groupID string) *RunningContainer {
+	return cm.workflowContainers[groupID]
 }
 
-func (cm *ContainerManager) GetServiceContainers(workflowID string) []*RunningContainer {
-	return cm.serviceContainers[workflowID]
+func (cm *ContainerManager) GetServiceContainersFroStepGroup(groupID string) []*RunningContainer {
+	return cm.serviceContainers[groupID]
 }
 
 func (cm *ContainerManager) DestroyAllContainers() error {

--- a/cli/docker/container_manager.go
+++ b/cli/docker/container_manager.go
@@ -122,31 +122,6 @@ func NewContainerManager(logger log.Logger, secrets []string) *ContainerManager 
 	}
 }
 
-func (cm *ContainerManager) login(container models.Container, envs map[string]string) error {
-	if container.Credentials.Username != "" && container.Credentials.Password != "" {
-		cm.logger.Infof("ℹ️ Logging into docker registry: %s", container.Image)
-
-		resolvedPassword := resolveEnvVariable(container.Credentials.Password, envs)
-		resolvedUsername := resolveEnvVariable(container.Credentials.Username, envs)
-		args := []string{"login", "--username", resolvedUsername, "--password", resolvedPassword}
-
-		if container.Credentials.Server != "" {
-			args = append(args, container.Credentials.Server)
-		} else {
-			args = append(args, container.Image)
-		}
-
-		cm.logger.Infof("ℹ️ Running command: docker %s", strings.Join(args, " "))
-
-		out, err := command.New("docker", args...).RunAndReturnTrimmedCombinedOutput()
-		if err != nil {
-			cm.logger.Errorf(out)
-			return fmt.Errorf("run docker login: %w", err)
-		}
-	}
-	return nil
-}
-
 func (cm *ContainerManager) StartContainerForStepGroup(
 	container models.Container,
 	groupID string,
@@ -271,6 +246,31 @@ func (cm *ContainerManager) DestroyAllContainers() error {
 		}
 	}
 
+	return nil
+}
+
+func (cm *ContainerManager) login(container models.Container, envs map[string]string) error {
+	if container.Credentials.Username != "" && container.Credentials.Password != "" {
+		cm.logger.Infof("ℹ️ Logging into docker registry: %s", container.Image)
+
+		resolvedPassword := resolveEnvVariable(container.Credentials.Password, envs)
+		resolvedUsername := resolveEnvVariable(container.Credentials.Username, envs)
+		args := []string{"login", "--username", resolvedUsername, "--password", resolvedPassword}
+
+		if container.Credentials.Server != "" {
+			args = append(args, container.Credentials.Server)
+		} else {
+			args = append(args, container.Image)
+		}
+
+		cm.logger.Infof("ℹ️ Running command: docker %s", strings.Join(args, " "))
+
+		out, err := command.New("docker", args...).RunAndReturnTrimmedCombinedOutput()
+		if err != nil {
+			cm.logger.Errorf(out)
+			return fmt.Errorf("run docker login: %w", err)
+		}
+	}
 	return nil
 }
 

--- a/cli/docker/container_manager.go
+++ b/cli/docker/container_manager.go
@@ -146,7 +146,7 @@ func (cm *ContainerManager) Login(container models.Container, envs map[string]st
 	return nil
 }
 
-func (cm *ContainerManager) StartContainerFroStepGroup(
+func (cm *ContainerManager) StartContainerForStepGroup(
 	container models.Container,
 	groupID string,
 	envs map[string]string,
@@ -182,7 +182,7 @@ func (cm *ContainerManager) StartContainerFroStepGroup(
 	return runningContainer, nil
 }
 
-func (cm *ContainerManager) StartServiceContainersFroStepGroup(
+func (cm *ContainerManager) StartServiceContainersForStepGroup(
 	services map[string]models.Container,
 	groupID string,
 	envs map[string]string,
@@ -224,11 +224,11 @@ func (cm *ContainerManager) StartServiceContainersFroStepGroup(
 	return containers, nil
 }
 
-func (cm *ContainerManager) GetContainerFroStepGroup(groupID string) *RunningContainer {
+func (cm *ContainerManager) GetContainerForStepGroup(groupID string) *RunningContainer {
 	return cm.workflowContainers[groupID]
 }
 
-func (cm *ContainerManager) GetServiceContainersFroStepGroup(groupID string) []*RunningContainer {
+func (cm *ContainerManager) GetServiceContainersForStepGroup(groupID string) []*RunningContainer {
 	return cm.serviceContainers[groupID]
 }
 

--- a/cli/docker/container_manager.go
+++ b/cli/docker/container_manager.go
@@ -127,7 +127,8 @@ func (cm *ContainerManager) login(container models.Container, envs map[string]st
 		cm.logger.Infof("ℹ️ Logging into docker registry: %s", container.Image)
 
 		resolvedPassword := resolveEnvVariable(container.Credentials.Password, envs)
-		args := []string{"login", "--username", container.Credentials.Username, "--password", resolvedPassword}
+		resolvedUsername := resolveEnvVariable(container.Credentials.Username, envs)
+		args := []string{"login", "--username", resolvedUsername, "--password", resolvedPassword}
 
 		if container.Credentials.Server != "" {
 			args = append(args, container.Credentials.Server)

--- a/cli/run.go
+++ b/cli/run.go
@@ -165,7 +165,6 @@ func setupAgentConfig() (*configs.AgentConfig, error) {
 }
 
 type DockerManager interface {
-	Login(models.Container, map[string]string) error
 	StartContainerForStepGroup(models.Container, string, map[string]string) (*docker.RunningContainer, error)
 	StartServiceContainersForStepGroup(services map[string]models.Container, workflowID string, envs map[string]string) ([]*docker.RunningContainer, error)
 	GetContainerForStepGroup(string) *docker.RunningContainer

--- a/cli/run.go
+++ b/cli/run.go
@@ -166,10 +166,10 @@ func setupAgentConfig() (*configs.AgentConfig, error) {
 
 type DockerManager interface {
 	Login(models.Container, map[string]string) error
-	StartContainerFroStepGroup(models.Container, string, map[string]string) (*docker.RunningContainer, error)
-	StartServiceContainersFroStepGroup(services map[string]models.Container, workflowID string, envs map[string]string) ([]*docker.RunningContainer, error)
-	GetContainerFroStepGroup(string) *docker.RunningContainer
-	GetServiceContainersFroStepGroup(string) []*docker.RunningContainer
+	StartContainerForStepGroup(models.Container, string, map[string]string) (*docker.RunningContainer, error)
+	StartServiceContainersForStepGroup(services map[string]models.Container, workflowID string, envs map[string]string) ([]*docker.RunningContainer, error)
+	GetContainerForStepGroup(string) *docker.RunningContainer
+	GetServiceContainersForStepGroup(string) []*docker.RunningContainer
 	DestroyAllContainers() error
 }
 

--- a/cli/run.go
+++ b/cli/run.go
@@ -494,7 +494,8 @@ func createWorkflowRunPlan(modes models.WorkflowRunModes, targetWorkflow string,
 
 		var stepPlan []models.StepExecutionPlan
 		for _, stepItem := range workflow.Steps {
-			stepID, _ := stepItem.GetStepIDAndStep()
+			// TODO: handle with
+			stepID, _, _ := stepItem.GetStepIDAndStep()
 			stepPlan = append(stepPlan, models.StepExecutionPlan{
 				UUID:   uuidProvider(),
 				StepID: stepID,

--- a/cli/run.go
+++ b/cli/run.go
@@ -530,7 +530,7 @@ func createWorkflowRunPlan(modes models.WorkflowRunModes, targetWorkflow string,
 				stepPlan = append(stepPlan, models.StepExecutionPlan{
 					UUID:   uuidProvider(),
 					StepID: stepID,
-					Step:   step, // TODO: Step shouldn't be a pointer
+					Step:   step,
 				})
 			}
 		}

--- a/cli/run.go
+++ b/cli/run.go
@@ -30,11 +30,9 @@ import (
 )
 
 const (
-	// DefaultBitriseConfigFileName ...
 	DefaultBitriseConfigFileName = "bitrise.yml"
-	// DefaultSecretsFileName ...
-	DefaultSecretsFileName = ".bitrise.secrets.yml"
-	OutputFormatKey        = "output-format"
+	DefaultSecretsFileName       = ".bitrise.secrets.yml"
+	OutputFormatKey              = "output-format"
 
 	depManagerBrew      = "brew"
 	secretFilteringFlag = "secret-filtering"

--- a/cli/run.go
+++ b/cli/run.go
@@ -168,10 +168,10 @@ func setupAgentConfig() (*configs.AgentConfig, error) {
 
 type DockerManager interface {
 	Login(models.Container, map[string]string) error
-	StartWorkflowContainer(models.Container, string, map[string]string) (*docker.RunningContainer, error)
-	StartServiceContainers(services map[string]models.Container, workflowID string, envs map[string]string) ([]*docker.RunningContainer, error)
-	GetWorkflowContainer(string) *docker.RunningContainer
-	GetServiceContainers(string) []*docker.RunningContainer
+	StartContainerFroStepGroup(models.Container, string, map[string]string) (*docker.RunningContainer, error)
+	StartServiceContainersFroStepGroup(services map[string]models.Container, workflowID string, envs map[string]string) ([]*docker.RunningContainer, error)
+	GetContainerFroStepGroup(string) *docker.RunningContainer
+	GetServiceContainersFroStepGroup(string) []*docker.RunningContainer
 	DestroyAllContainers() error
 }
 
@@ -511,6 +511,8 @@ func createWorkflowRunPlan(modes models.WorkflowRunModes, targetWorkflow string,
 			}
 
 			if key == models.StepListItemWithKey {
+				groupID := uuidProvider()
+
 				for _, stepListStepItem := range with.Steps {
 					stepID, step, err := stepListStepItem.GetStepIDAndStep()
 					if err != nil {
@@ -521,6 +523,7 @@ func createWorkflowRunPlan(modes models.WorkflowRunModes, targetWorkflow string,
 						UUID:        uuidProvider(),
 						StepID:      stepID,
 						Step:        step,
+						GroupID:     groupID,
 						ContainerID: with.ContainerID,
 						ServiceIDs:  with.ServiceIDs,
 					})

--- a/cli/run.go
+++ b/cli/run.go
@@ -166,6 +166,15 @@ func setupAgentConfig() (*configs.AgentConfig, error) {
 	return &config, nil
 }
 
+type DockerManager interface {
+	Login(models.Container, map[string]string) error
+	StartWorkflowContainer(models.Container, string, map[string]string) (*docker.RunningContainer, error)
+	StartServiceContainers(services map[string]models.Container, workflowID string, envs map[string]string) ([]*docker.RunningContainer, error)
+	GetWorkflowContainer(string) *docker.RunningContainer
+	GetServiceContainers(string) []*docker.RunningContainer
+	DestroyAllContainers() error
+}
+
 type WorkflowRunner struct {
 	config RunConfig
 
@@ -236,7 +245,7 @@ func (r WorkflowRunner) runWorkflows(tracker analytics.Tracker) (models.BuildRun
 
 	// Register run modes
 	if err := registerRunModes(r.config.Modes); err != nil {
-		return models.BuildRunResultsModel{}, fmt.Errorf("failed to register workflow run modes: %s", err)
+		return models.BuildRunResultsModel{}, fmt.Errorf("failed to register workflow run modes: %w", err)
 	}
 
 	targetWorkflow := r.config.Config.Workflows[r.config.Workflow]
@@ -246,25 +255,25 @@ func (r WorkflowRunner) runWorkflows(tracker analytics.Tracker) (models.BuildRun
 
 	// Envman setup
 	if err := os.Setenv(configs.EnvstorePathEnvKey, configs.OutputEnvstorePath); err != nil {
-		return models.BuildRunResultsModel{}, fmt.Errorf("failed to add env, err: %s", err)
+		return models.BuildRunResultsModel{}, fmt.Errorf("failed to set %s env: %w", configs.EnvstorePathEnvKey, err)
 	}
 
 	if err := os.Setenv(configs.FormattedOutputPathEnvKey, configs.FormattedOutputPath); err != nil {
-		return models.BuildRunResultsModel{}, fmt.Errorf("failed to add env, err: %s", err)
+		return models.BuildRunResultsModel{}, fmt.Errorf("failed to set %s env: %w", configs.FormattedOutputPathEnvKey, err)
 	}
 
 	if err := tools.EnvmanInit(configs.OutputEnvstorePath, false); err != nil {
-		return models.BuildRunResultsModel{}, fmt.Errorf("failed to run envman init: %s", err)
+		return models.BuildRunResultsModel{}, fmt.Errorf("failed to run envman init: %w", err)
 	}
 
 	// App level environment
 	environments := append(r.config.Secrets, r.config.Config.App.Environments...)
 
 	if err := os.Setenv("BITRISE_TRIGGERED_WORKFLOW_ID", r.config.Workflow); err != nil {
-		return models.BuildRunResultsModel{}, fmt.Errorf("failed to set BITRISE_TRIGGERED_WORKFLOW_ID env: %s", err)
+		return models.BuildRunResultsModel{}, fmt.Errorf("failed to set BITRISE_TRIGGERED_WORKFLOW_ID env: %w", err)
 	}
 	if err := os.Setenv("BITRISE_TRIGGERED_WORKFLOW_TITLE", targetWorkflow.Title); err != nil {
-		return models.BuildRunResultsModel{}, fmt.Errorf("failed to set BITRISE_TRIGGERED_WORKFLOW_TITLE env: %s", err)
+		return models.BuildRunResultsModel{}, fmt.Errorf("failed to set BITRISE_TRIGGERED_WORKFLOW_TITLE env: %w", err)
 	}
 
 	environments = append(environments, targetWorkflow.Environments...)
@@ -277,8 +286,7 @@ func (r WorkflowRunner) runWorkflows(tracker analytics.Tracker) (models.BuildRun
 			// the toolkit's `PrepareForStepRun` can bootstrap for itself later if required
 			// or if the system installed version is not sufficient
 			if err := aToolkit.Bootstrap(); err != nil {
-				return models.BuildRunResultsModel{}, fmt.Errorf("failed to bootstrap the required toolkit for the step (%s), error: %s",
-					toolkitName, err)
+				return models.BuildRunResultsModel{}, fmt.Errorf("failed to bootstrap %s toolkit: %w", toolkitName, err)
 			}
 		}
 	}
@@ -290,7 +298,7 @@ func (r WorkflowRunner) runWorkflows(tracker analytics.Tracker) (models.BuildRun
 		ProjectType: r.config.Config.ProjectType,
 	}
 	if err := plugins.TriggerEvent(plugins.WillStartRun, buildRunStartModel); err != nil {
-		log.Warnf("Failed to trigger WillStartRun, error: %s", err)
+		log.Warnf("Failed to trigger WillStartRun: %s", err)
 	}
 
 	// Prepare workflow run parameters
@@ -301,7 +309,10 @@ func (r WorkflowRunner) runWorkflows(tracker analytics.Tracker) (models.BuildRun
 		ProjectType:    r.config.Config.ProjectType,
 	}
 
-	plan := createWorkflowRunPlan(r.config.Modes, r.config.Workflow, r.config.Config.Workflows, func() string { return uuid.Must(uuid.NewV4()).String() })
+	plan, err := createWorkflowRunPlan(r.config.Modes, r.config.Workflow, r.config.Config.Workflows, func() string { return uuid.Must(uuid.NewV4()).String() })
+	if err != nil {
+		return models.BuildRunResultsModel{}, fmt.Errorf("failed to create workflow execution plan: %w", err)
+	}
 	if len(plan.ExecutionPlan) < 1 {
 		return models.BuildRunResultsModel{}, fmt.Errorf("execution plan doesn't have any workflow to run")
 	}
@@ -322,10 +333,8 @@ func (r WorkflowRunner) runWorkflows(tracker analytics.Tracker) (models.BuildRun
 	for i, workflowRunPlan := range plan.ExecutionPlan {
 		isLastWorkflow := i == len(plan.ExecutionPlan)-1
 		workflowToRun := r.config.Config.Workflows[workflowRunPlan.WorkflowID]
-		if workflowToRun.Title == "" {
-			workflowToRun.Title = workflowRunPlan.WorkflowID
-		}
-		buildRunResults = r.runWorkflow(workflowRunPlan, workflowRunPlan.WorkflowID, workflowToRun, r.config.Config.DefaultStepLibSource, buildRunResults, &environments, r.config.Secrets, isLastWorkflow, tracker, buildIDProperties)
+		environments = append(environments, workflowToRun.Environments...)
+		buildRunResults = r.runWorkflow(workflowRunPlan, r.config.Config.DefaultStepLibSource, buildRunResults, &environments, r.config.Secrets, isLastWorkflow, tracker, buildIDProperties)
 	}
 
 	// Build finished
@@ -334,7 +343,7 @@ func (r WorkflowRunner) runWorkflows(tracker analytics.Tracker) (models.BuildRun
 	// Trigger WorkflowRunDidFinish
 	buildRunResults.EventName = string(plugins.DidFinishRun)
 	if err := plugins.TriggerEvent(plugins.DidFinishRun, buildRunResults); err != nil {
-		log.Warnf("Failed to trigger WorkflowRunDidFinish, error: %s", err)
+		log.Warnf("Failed to trigger WorkflowRunDidFinish: %s", err)
 	}
 
 	return buildRunResults, nil
@@ -486,26 +495,57 @@ func registerRunModes(modes models.WorkflowRunModes) error {
 	return nil
 }
 
-func createWorkflowRunPlan(modes models.WorkflowRunModes, targetWorkflow string, workflows map[string]models.WorkflowModel, uuidProvider func() string) models.WorkflowRunPlan {
+func createWorkflowRunPlan(modes models.WorkflowRunModes, targetWorkflow string, workflows map[string]models.WorkflowModel, uuidProvider func() string) (models.WorkflowRunPlan, error) {
 	var executionPlan []models.WorkflowExecutionPlan
+
 	workflowList := walkWorkflows(targetWorkflow, workflows, nil)
 	for _, workflowID := range workflowList {
 		workflow := workflows[workflowID]
 
 		var stepPlan []models.StepExecutionPlan
-		for _, stepItem := range workflow.Steps {
-			// TODO: handle with
-			stepID, _, _ := stepItem.GetStepIDAndStep()
-			stepPlan = append(stepPlan, models.StepExecutionPlan{
-				UUID:   uuidProvider(),
-				StepID: stepID,
-			})
+
+		for _, stepListItem := range workflow.Steps {
+			key, step, with, err := stepListItem.GetStepListItemKeyAndValue()
+			if err != nil {
+				return models.WorkflowRunPlan{}, err
+			}
+
+			if key == "with" {
+				for _, stepListStepItem := range with.Steps {
+					stepID, step, err := stepListStepItem.GetStepIDAndStep()
+					if err != nil {
+						return models.WorkflowRunPlan{}, err
+					}
+
+					stepPlan = append(stepPlan, models.StepExecutionPlan{
+						UUID:        uuidProvider(),
+						StepID:      stepID,
+						Step:        step,
+						ContainerID: with.ContainerID,
+						ServiceIDs:  with.ServiceIDs,
+					})
+				}
+			} else {
+				stepID := key
+				stepPlan = append(stepPlan, models.StepExecutionPlan{
+					UUID:   uuidProvider(),
+					StepID: stepID,
+					Step:   *step, // TODO: Step shouldn't be a pointer
+				})
+			}
+		}
+
+		workflowTitle := workflow.Title
+		if workflowTitle == "" {
+			workflowTitle = workflowID
 		}
 
 		executionPlan = append(executionPlan, models.WorkflowExecutionPlan{
 			UUID:       uuidProvider(),
 			WorkflowID: workflowID,
 			Steps:      stepPlan,
+
+			WorkflowTitle: workflowTitle,
 		})
 	}
 
@@ -524,7 +564,7 @@ func createWorkflowRunPlan(modes models.WorkflowRunModes, targetWorkflow string,
 		SecretFilteringMode:     modes.SecretFilteringMode,
 		SecretEnvsFilteringMode: modes.SecretEnvsFilteringMode,
 		ExecutionPlan:           executionPlan,
-	}
+	}, nil
 }
 
 func walkWorkflows(workflowID string, workflows map[string]models.WorkflowModel, workflowStack []string) []string {

--- a/cli/run.go
+++ b/cli/run.go
@@ -510,7 +510,7 @@ func createWorkflowRunPlan(modes models.WorkflowRunModes, targetWorkflow string,
 				return models.WorkflowRunPlan{}, err
 			}
 
-			if key == "with" {
+			if key == models.StepListItemWithKey {
 				for _, stepListStepItem := range with.Steps {
 					stepID, step, err := stepListStepItem.GetStepIDAndStep()
 					if err != nil {
@@ -530,7 +530,7 @@ func createWorkflowRunPlan(modes models.WorkflowRunModes, targetWorkflow string,
 				stepPlan = append(stepPlan, models.StepExecutionPlan{
 					UUID:   uuidProvider(),
 					StepID: stepID,
-					Step:   *step, // TODO: Step shouldn't be a pointer
+					Step:   step, // TODO: Step shouldn't be a pointer
 				})
 			}
 		}

--- a/cli/run_util.go
+++ b/cli/run_util.go
@@ -582,11 +582,6 @@ func (r WorkflowRunner) startContainersForStepGroup(containerID string, serviceI
 		if containerDef != nil {
 			log.Infof("ℹ️ Running workflow in docker container: %s", containerDef.Image)
 
-			// TODO: Why only login for step execution containers?
-			if err := r.dockerManager.Login(*containerDef, envList); err != nil {
-				log.Errorf("%s workflow has docker credentials provided, but the authentication failed.", workflowTitle)
-			}
-
 			_, err := r.dockerManager.StartContainerForStepGroup(*containerDef, groupID, envList)
 			if err != nil {
 				log.Errorf("Could not start the specified docker image for workflow: %s", workflowTitle)

--- a/cli/run_util.go
+++ b/cli/run_util.go
@@ -168,7 +168,6 @@ func isDirEmpty(path string) (bool, error) {
 	return len(entries) == 0, nil
 }
 
-// GetBitriseConfigFromBase64Data ...
 func GetBitriseConfigFromBase64Data(configBase64Str string) (models.BitriseDataModel, []string, error) {
 	configBase64Bytes, err := base64.StdEncoding.DecodeString(configBase64Str)
 	if err != nil {
@@ -183,7 +182,6 @@ func GetBitriseConfigFromBase64Data(configBase64Str string) (models.BitriseDataM
 	return config, warnings, nil
 }
 
-// GetBitriseConfigFilePath ...
 func GetBitriseConfigFilePath(bitriseConfigPath string) (string, error) {
 	if bitriseConfigPath == "" {
 		bitriseConfigPath = filepath.Join(configs.CurrentDir, DefaultBitriseConfigFileName)
@@ -198,7 +196,6 @@ func GetBitriseConfigFilePath(bitriseConfigPath string) (string, error) {
 	return bitriseConfigPath, nil
 }
 
-// CreateBitriseConfigFromCLIParams ...
 func CreateBitriseConfigFromCLIParams(bitriseConfigBase64Data, bitriseConfigPath string) (models.BitriseDataModel, []string, error) {
 	bitriseConfig := models.BitriseDataModel{}
 	warnings := []string{}
@@ -238,7 +235,6 @@ func CreateBitriseConfigFromCLIParams(bitriseConfigBase64Data, bitriseConfigPath
 	return bitriseConfig, warnings, nil
 }
 
-// GetInventoryFromBase64Data ...
 func GetInventoryFromBase64Data(inventoryBase64Str string) ([]envmanModels.EnvironmentItemModel, error) {
 	inventoryBase64Bytes, err := base64.StdEncoding.DecodeString(inventoryBase64Str)
 	if err != nil {
@@ -253,7 +249,6 @@ func GetInventoryFromBase64Data(inventoryBase64Str string) ([]envmanModels.Envir
 	return inventory.Envs, nil
 }
 
-// GetInventoryFilePath ...
 func GetInventoryFilePath(inventoryPath string) (string, error) {
 	if inventoryPath == "" {
 		log.Debug("[BITRISE_CLI] - Inventory path not defined, searching for " + DefaultSecretsFileName + " in current folder...")
@@ -269,7 +264,6 @@ func GetInventoryFilePath(inventoryPath string) (string, error) {
 	return inventoryPath, nil
 }
 
-// CreateInventoryFromCLIParams ...
 func CreateInventoryFromCLIParams(inventoryBase64Data, inventoryPath string) ([]envmanModels.EnvironmentItemModel, error) {
 	inventoryEnvironments := []envmanModels.EnvironmentItemModel{}
 

--- a/cli/run_util.go
+++ b/cli/run_util.go
@@ -438,7 +438,7 @@ func (r WorkflowRunner) executeStep(
 		}
 
 		name = "docker"
-		runningContainer := r.dockerManager.GetContainerFroStepGroup(groupID)
+		runningContainer := r.dockerManager.GetContainerForStepGroup(groupID)
 		if runningContainer == nil {
 			return 1, fmt.Errorf("Docker container does not exist")
 		}
@@ -587,7 +587,7 @@ func (r WorkflowRunner) startContainersForStepGroup(containerID string, serviceI
 				log.Errorf("%s workflow has docker credentials provided, but the authentication failed.", workflowTitle)
 			}
 
-			_, err := r.dockerManager.StartContainerFroStepGroup(*containerDef, groupID, envList)
+			_, err := r.dockerManager.StartContainerForStepGroup(*containerDef, groupID, envList)
 			if err != nil {
 				log.Errorf("Could not start the specified docker image for workflow: %s", workflowTitle)
 			}
@@ -596,7 +596,7 @@ func (r WorkflowRunner) startContainersForStepGroup(containerID string, serviceI
 
 	if len(serviceIDs) > 0 {
 		servicesDefs := r.ServiceDefinitions(serviceIDs...)
-		_, err := r.dockerManager.StartServiceContainersFroStepGroup(servicesDefs, groupID, envList)
+		_, err := r.dockerManager.StartServiceContainersForStepGroup(servicesDefs, groupID, envList)
 		if err != nil {
 			log.Errorf("❌ Some services failed to start properly!")
 		}
@@ -604,14 +604,14 @@ func (r WorkflowRunner) startContainersForStepGroup(containerID string, serviceI
 }
 
 func (r WorkflowRunner) stopContainersForStepGroup(groupID, workflowTitle string) {
-	if container := r.dockerManager.GetContainerFroStepGroup(groupID); container != nil {
+	if container := r.dockerManager.GetContainerForStepGroup(groupID); container != nil {
 		// TODO: Feature idea, make this configurable, so that we can keep the container for debugging purposes.
 		if err := container.Destroy(); err != nil {
 			log.Errorf("Attempted to stop the docker container for workflow: %s: %s", workflowTitle, err)
 		}
 	}
 
-	if services := r.dockerManager.GetServiceContainersFroStepGroup(groupID); services != nil {
+	if services := r.dockerManager.GetServiceContainersForStepGroup(groupID); services != nil {
 		for _, container := range services {
 			if err := container.Destroy(); err != nil {
 				log.Errorf("Attempted to stop the docker container for service: %s: %s", container.Name, err)

--- a/cli/run_util.go
+++ b/cli/run_util.go
@@ -481,7 +481,7 @@ func (r WorkflowRunner) runStep(
 	environments []envmanModels.EnvironmentItemModel,
 	secrets []string,
 	containerID string,
-	workflowID string,
+	groupID string,
 ) (int, []envmanModels.EnvironmentItemModel, error) {
 	log.Debugf("[BITRISE_CLI] - Try running step: %s (%s)", stepIDData.IDorURI, stepIDData.Version)
 
@@ -519,7 +519,7 @@ func (r WorkflowRunner) runStep(
 		bitriseSourceDir = configs.CurrentDir
 	}
 
-	if exit, err := r.executeStep(stepUUID, step, stepIDData, stepDir, bitriseSourceDir, secrets, containerID, workflowID); err != nil {
+	if exit, err := r.executeStep(stepUUID, step, stepIDData, stepDir, bitriseSourceDir, secrets, containerID, groupID); err != nil {
 		stepOutputs, envErr := bitrise.CollectEnvironmentsFromFile(configs.OutputEnvstorePath)
 		if envErr != nil {
 			return 1, []envmanModels.EnvironmentItemModel{}, envErr
@@ -923,7 +923,7 @@ func (r WorkflowRunner) activateAndRunSteps(
 
 			tracker.SendStepStartedEvent(stepStartedProperties, prepareAnalyticsStepInfo(mergedStep, stepInfoPtr), redactedInputsWithType, redactedOriginalInputs)
 
-			exit, outEnvironments, err := r.runStep(stepExecutionID, mergedStep, stepIDData, stepDir, stepDeclaredEnvironments, stepSecretValues, stepPlan.ContainerID, plan.WorkflowID)
+			exit, outEnvironments, err := r.runStep(stepExecutionID, mergedStep, stepIDData, stepDir, stepDeclaredEnvironments, stepSecretValues, stepPlan.ContainerID, stepPlan.GroupID)
 
 			if stepTestDir != "" {
 				if err := addTestMetadata(stepTestDir, models.TestResultStepInfo{Number: idx, Title: *mergedStep.Title, ID: stepIDData.IDorURI, Version: stepIDData.Version}); err != nil {

--- a/cli/run_util.go
+++ b/cli/run_util.go
@@ -693,7 +693,9 @@ func (r WorkflowRunner) activateAndRunSteps(
 		}
 
 		// Get step id & version data
-		compositeStepIDStr, workflowStep, err := models.GetStepIDStepDataPair(stepListItm)
+		// TODO: handle with
+		compositeStepIDStr, workflowStepPtr, _, err := models.GetStepIDStepDataPair(stepListItm)
+		workflowStep := *workflowStepPtr
 		if err != nil {
 			runResultCollector.registerStepRunResults(&buildRunResults, stepExecutionID, stepStartTime, stepmanModels.StepModel{}, stepInfoPtr, stepIdxPtr,
 				models.StepRunStatusCodePreparationFailed, 1, err, isLastStep, true, map[string]string{}, stepStartedProperties)

--- a/models/models.go
+++ b/models/models.go
@@ -10,28 +10,22 @@ import (
 )
 
 const (
-	// FormatVersion ...
 	FormatVersion       = "14"
 	StepListItemWithKey = "with"
 )
 
-// WithModel ...
 type WithModel struct {
 	ContainerID string                  `json:"container,omitempty" yaml:"container,omitempty"`
 	ServiceIDs  []string                `json:"services,omitempty" yaml:"services,omitempty"`
 	Steps       []StepListStepItemModel `json:"steps,omitempty" yaml:"steps,omitempty"`
 }
 
-// StepListWithItemModel ..
 type StepListWithItemModel map[string]WithModel
 
-// StepListStepItemModel ...
 type StepListStepItemModel map[string]stepmanModels.StepModel
 
-// StepListItemModel ...
 type StepListItemModel map[string]interface{}
 
-// PipelineModel ...
 type PipelineModel struct {
 	Title       string               `json:"title,omitempty" yaml:"title,omitempty"`
 	Summary     string               `json:"summary,omitempty" yaml:"summary,omitempty"`
@@ -39,10 +33,8 @@ type PipelineModel struct {
 	Stages      []StageListItemModel `json:"stages,omitempty" yaml:"stages,omitempty"`
 }
 
-// StageListItemModel ...
 type StageListItemModel map[string]StageModel
 
-// StageModel ...
 type StageModel struct {
 	Title           string                       `json:"title,omitempty" yaml:"title,omitempty"`
 	Summary         string                       `json:"summary,omitempty" yaml:"summary,omitempty"`
@@ -53,18 +45,14 @@ type StageModel struct {
 	Workflows       []StageWorkflowListItemModel `json:"workflows,omitempty" yaml:"workflows,omitempty"`
 }
 
-// StageWorkflowListItemModel ...
 type StageWorkflowListItemModel map[string]StageWorkflowModel
 
-// StageWorkflowModel ...
 type StageWorkflowModel struct {
 	RunIf string `json:"run_if,omitempty" yaml:"run_if,omitempty"`
 }
 
-// WorkflowListItemModel ...
 type WorkflowListItemModel map[string]WorkflowModel
 
-// WorkflowModel ...
 type WorkflowModel struct {
 	Title        string                              `json:"title,omitempty" yaml:"title,omitempty"`
 	Summary      string                              `json:"summary,omitempty" yaml:"summary,omitempty"`
@@ -90,7 +78,6 @@ type Container struct {
 	Options     string                              `json:"options,omitempty" yaml:"options,omitempty"`
 }
 
-// AppModel ...
 type AppModel struct {
 	Title        string                              `json:"title,omitempty" yaml:"title,omitempty"`
 	Summary      string                              `json:"summary,omitempty" yaml:"summary,omitempty"`
@@ -98,7 +85,6 @@ type AppModel struct {
 	Environments []envmanModels.EnvironmentItemModel `json:"envs,omitempty" yaml:"envs,omitempty"`
 }
 
-// BitriseDataModel ...
 type BitriseDataModel struct {
 	FormatVersion        string `json:"format_version" yaml:"format_version"`
 	DefaultStepLibSource string `json:"default_step_lib_source,omitempty" yaml:"default_step_lib_source,omitempty"`
@@ -118,14 +104,12 @@ type BitriseDataModel struct {
 	Workflows  map[string]WorkflowModel `json:"workflows,omitempty" yaml:"workflows,omitempty"`
 }
 
-// BuildRunStartModel ...
 type BuildRunStartModel struct {
 	EventName   string    `json:"event_name" yaml:"event_name"`
 	ProjectType string    `json:"project_type" yaml:"project_type"`
 	StartTime   time.Time `json:"start_time" yaml:"start_time"`
 }
 
-// BuildRunResultsModel ...
 type BuildRunResultsModel struct {
 	WorkflowID           string                `json:"workflow_id" yaml:"workflow_id"`
 	EventName            string                `json:"event_name" yaml:"event_name"`
@@ -138,7 +122,6 @@ type BuildRunResultsModel struct {
 	SkippedSteps         []StepRunResultsModel `json:"skipped_steps" yaml:"skipped_steps"`
 }
 
-// StepRunResultsModel ...
 type StepRunResultsModel struct {
 	StepInfo   stepmanModels.StepInfoModel `json:"step_info" yaml:"step_info"`
 	StepInputs map[string]string           `json:"step_inputs" yaml:"step_inputs"`
@@ -153,7 +136,6 @@ type StepRunResultsModel struct {
 	NoOutputTimeout time.Duration `json:"-"`
 }
 
-// StepError ...
 type StepError struct {
 	Code    int    `json:"code"`
 	Message string `json:"message"`
@@ -252,7 +234,6 @@ func formatStatusReasonTimeInterval(timeInterval time.Duration) string {
 	return formattedTimeInterval
 }
 
-// TestResultStepInfo ...
 type TestResultStepInfo struct {
 	ID      string `json:"id" yaml:"id"`
 	Version string `json:"version" yaml:"version"`

--- a/models/models.go
+++ b/models/models.go
@@ -65,8 +65,6 @@ type WorkflowListItemModel map[string]WorkflowModel
 
 // WorkflowModel ...
 type WorkflowModel struct {
-	ContainerID  string                              `json:"container,omitempty" yaml:"container,omitempty"`
-	ServiceIDs   []string                            `json:"services,omitempty" yaml:"services,omitempty"`
 	Title        string                              `json:"title,omitempty" yaml:"title,omitempty"`
 	Summary      string                              `json:"summary,omitempty" yaml:"summary,omitempty"`
 	Description  string                              `json:"description,omitempty" yaml:"description,omitempty"`

--- a/models/models.go
+++ b/models/models.go
@@ -14,47 +14,21 @@ const (
 	FormatVersion = "14"
 )
 
-// TODO: rename these structs
-type WithStepListItem struct{}
+// WithModel ...
+type WithModel struct {
+	ContainerID string                  `json:"container,omitempty" yaml:"container,omitempty"`
+	ServiceIDs  []string                `json:"services,omitempty" yaml:"services,omitempty"`
+	Steps       []StepListStepItemModel `json:"steps,omitempty" yaml:"steps,omitempty"`
+}
 
-type WithStepListItemModel map[string]WithStepListItem
+// StepListWithItemModel ..
+type StepListWithItemModel map[string]WithModel
 
-type StepStepListItemModel map[string]stepmanModels.StepModel
+// StepListStepItemModel ...
+type StepListStepItemModel map[string]stepmanModels.StepModel
 
 // StepListItemModel ...
 type StepListItemModel map[string]interface{}
-
-func (stepListItem *StepListItemModel) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	var stepItem StepStepListItemModel
-	if err := unmarshal(&stepItem); err == nil {
-		var key string
-		for k := range stepItem {
-			key = k
-			break
-		}
-
-		item := map[string]interface{}{}
-		item[key] = stepItem[key]
-		*stepListItem = item
-		return nil
-	}
-
-	var withItem WithStepListItemModel
-	if err := unmarshal(&withItem); err != nil {
-		return err
-	}
-
-	var key string
-	for k := range withItem {
-		key = k
-		break
-	}
-
-	item := map[string]interface{}{}
-	item[key] = withItem[key]
-	*stepListItem = item
-	return nil
-}
 
 // PipelineModel ...
 type PipelineModel struct {

--- a/models/models.go
+++ b/models/models.go
@@ -14,8 +14,47 @@ const (
 	FormatVersion = "14"
 )
 
+// TODO: rename these structs
+type WithStepListItem struct{}
+
+type WithStepListItemModel map[string]WithStepListItem
+
+type StepStepListItemModel map[string]stepmanModels.StepModel
+
 // StepListItemModel ...
-type StepListItemModel map[string]stepmanModels.StepModel
+type StepListItemModel map[string]interface{}
+
+func (stepListItem *StepListItemModel) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var stepItem StepStepListItemModel
+	if err := unmarshal(&stepItem); err == nil {
+		var key string
+		for k := range stepItem {
+			key = k
+			break
+		}
+
+		item := map[string]interface{}{}
+		item[key] = stepItem[key]
+		*stepListItem = item
+		return nil
+	}
+
+	var withItem WithStepListItemModel
+	if err := unmarshal(&withItem); err != nil {
+		return err
+	}
+
+	var key string
+	for k := range withItem {
+		key = k
+		break
+	}
+
+	item := map[string]interface{}{}
+	item[key] = withItem[key]
+	*stepListItem = item
+	return nil
+}
 
 // PipelineModel ...
 type PipelineModel struct {

--- a/models/models.go
+++ b/models/models.go
@@ -11,7 +11,8 @@ import (
 
 const (
 	// FormatVersion ...
-	FormatVersion = "14"
+	FormatVersion       = "14"
+	StepListItemWithKey = "with"
 )
 
 // WithModel ...

--- a/models/models_methods.go
+++ b/models/models_methods.go
@@ -124,9 +124,10 @@ func (workflow *WorkflowModel) Normalize() error {
 			}
 			stepListItem[stepID] = step
 		}
-		if with != nil {
-			// TODO: Normalize with
-		}
+		// TODO: Normalize with
+		//if with != nil {
+		//
+		//}
 	}
 
 	return nil
@@ -214,9 +215,10 @@ func (workflow *WorkflowModel) Validate() ([]string, error) {
 			stepListItem[stepID] = step
 		}
 
-		if with != nil {
-			// TODO: validate with
-		}
+		// TODO: validate with
+		//if with != nil {
+		//
+		//}
 	}
 
 	return warnings, nil

--- a/models/models_methods.go
+++ b/models/models_methods.go
@@ -105,7 +105,6 @@ func (config *BitriseDataModel) getPipelineIDs() []string {
 // ----------------------------
 // --- Normalize
 
-// Normalize ...
 func (workflow *WorkflowModel) Normalize() error {
 	for _, env := range workflow.Environments {
 		if err := env.Normalize(); err != nil {
@@ -129,7 +128,6 @@ func (workflow *WorkflowModel) Normalize() error {
 	return nil
 }
 
-// Normalize ...
 func (app *AppModel) Normalize() error {
 	for _, env := range app.Environments {
 		if err := env.Normalize(); err != nil {
@@ -139,7 +137,6 @@ func (app *AppModel) Normalize() error {
 	return nil
 }
 
-// Normalize ...
 func (config *BitriseDataModel) Normalize() error {
 	if err := config.App.Normalize(); err != nil {
 		return err
@@ -206,7 +203,6 @@ func (with WithModel) Validate(workflowID string, containers, services map[strin
 
 }
 
-// Validate ...
 func (workflow *WorkflowModel) Validate() ([]string, error) {
 	var warnings []string
 
@@ -266,7 +262,6 @@ func validateStep(stepID string, step stepmanModels.StepModel) ([]string, error)
 	return warnings, nil
 }
 
-// Validate ...
 func (app *AppModel) Validate() error {
 	for _, env := range app.Environments {
 		if err := env.Validate(); err != nil {
@@ -276,7 +271,6 @@ func (app *AppModel) Validate() error {
 	return nil
 }
 
-// Validate ...
 func (config *BitriseDataModel) Validate() ([]string, error) {
 	var warnings []string
 
@@ -485,7 +479,6 @@ func validateID(id, modelType string) (string, error) {
 // ----------------------------
 // --- FillMissingDefaults
 
-// FillMissingDefaults ...
 func (workflow *WorkflowModel) FillMissingDefaults(title string) error {
 	// Don't call step.FillMissingDefaults()
 	// StepLib versions of steps (which are the default versions),
@@ -506,7 +499,6 @@ func (workflow *WorkflowModel) FillMissingDefaults(title string) error {
 	return nil
 }
 
-// FillMissingDefaults ...
 func (app *AppModel) FillMissingDefaults() error {
 	for _, env := range app.Environments {
 		if err := env.FillMissingDefaults(); err != nil {
@@ -516,7 +508,6 @@ func (app *AppModel) FillMissingDefaults() error {
 	return nil
 }
 
-// FillMissingDefaults ...
 func (config *BitriseDataModel) FillMissingDefaults() error {
 	if err := config.App.FillMissingDefaults(); err != nil {
 		return err
@@ -652,7 +643,6 @@ func (app *AppModel) removeRedundantFields() error {
 	return nil
 }
 
-// RemoveRedundantFields ...
 func (config *BitriseDataModel) RemoveRedundantFields() error {
 	if err := config.App.removeRedundantFields(); err != nil {
 		return err
@@ -668,7 +658,6 @@ func (config *BitriseDataModel) RemoveRedundantFields() error {
 // ----------------------------
 // --- Merge
 
-// MergeEnvironmentWith ...
 func MergeEnvironmentWith(env *envmanModels.EnvironmentItemModel, otherEnv envmanModels.EnvironmentItemModel) error {
 	// merge key-value
 	key, _, err := env.GetKeyValuePair()
@@ -764,7 +753,6 @@ func getOutputByKey(step stepmanModels.StepModel, key string) (envmanModels.Envi
 	return envmanModels.EnvironmentItemModel{}, false
 }
 
-// MergeStepWith ...
 func MergeStepWith(step, otherStep stepmanModels.StepModel) (stepmanModels.StepModel, error) {
 	if otherStep.Title != nil {
 		step.Title = pointers.NewStringPtr(*otherStep.Title)

--- a/models/models_methods.go
+++ b/models/models_methods.go
@@ -188,10 +188,8 @@ func (workflow *WorkflowModel) Validate() ([]string, error) {
 		}
 
 		if step != nil {
-			if ver, src := getStepVersion(stepID), getStepSource(stepID); len(ver) > 0 && isStepLibSource(src) {
-				if _, err := stepmanModels.ParseRequiredVersion(ver); err != nil {
-					return warnings, fmt.Errorf("invalid version format (%s) specified for step ID: %s", ver, stepID)
-				}
+			if err := stepid.Validate(stepID); err != nil {
+				return warnings, err
 			}
 
 			if err := step.ValidateInputAndOutputEnvs(false); err != nil {
@@ -929,126 +927,6 @@ func GetStepIDStepDataPair(stepListItem StepListItemModel) (string, *stepmanMode
 	}
 	stepID, step, with := stepListItem.GetStepIDAndStep()
 	return stepID, step, with, nil
-}
-
-// detaches source from the step node
-// e.g.: "git::git@github.com:bitrise-steplib/steps-script.git@master" -> "git"
-func getStepSource(compositeVersionStr string) string {
-	if s := strings.SplitN(string(compositeVersionStr), "::", 2); len(s) == 2 {
-		if src := s[0]; len(src) > 0 {
-			return src
-		}
-	}
-	return ""
-}
-
-// detaches step id and version composite from the step node
-// e.g.: "git::git@github.com:bitrise-steplib/steps-script.git@master" -> "git@github.com:bitrise-steplib/steps-script.git@master"
-func getStepComposite(compositeVersionStr string) string {
-	if s := strings.SplitN(compositeVersionStr, "::", 2); len(s) == 2 {
-		return s[1]
-	}
-	return compositeVersionStr
-}
-
-// splits step node composite into it's parts by taking care of extra "@" when using SSH git URL
-// e.g.: "git::git@github.com:bitrise-steplib/steps-script.git@master" -> ["git@github.com:bitrise-steplib/steps-script.git" "master"]
-func splitCompositeComponents(composite string) []string {
-	s := strings.Split(composite, "@")
-	if item := s[0]; item == "git" {
-		s = s[1:]
-		s[0] = item + "@" + s[0]
-	}
-	return s
-}
-
-// returns step version from compositeString
-// e.g.: "git::https://github.com/bitrise-steplib/steps-script.git@master" -> "master"
-func getStepVersion(compositeVersionStr string) string {
-	composite := getStepComposite(compositeVersionStr)
-
-	if s := splitCompositeComponents(composite); len(s) > 1 {
-		return s[len(s)-1]
-	}
-
-	return ""
-}
-
-// returns step ID from compositeString
-// e.g.: "git::https://github.com/bitrise-steplib/steps-script.git@master" -> "https://github.com/bitrise-steplib/steps-script.git"
-func getStepID(compositeVersionStr string) string {
-	composite := getStepComposite(compositeVersionStr)
-	return splitCompositeComponents(composite)[0]
-}
-
-// returns true if step source is StepLib
-func isStepLibSource(source string) bool {
-	switch source {
-	case "path", "git", "_", "":
-		return false
-	default:
-		return true
-	}
-}
-
-// CreateStepIDDataFromString ...
-// compositeVersionStr examples:
-//   - local path:
-//   - path::~/path/to/step/dir
-//   - direct git url and branch or tag:
-//   - git::https://github.com/bitrise-io/steps-timestamp.git@master
-//   - Steplib independent step:
-//   - _::https://github.com/bitrise-io/steps-bash-script.git@2.0.0:
-//   - full ID with steplib, stepid and version:
-//   - https://github.com/bitrise-io/bitrise-steplib.git::script@2.0.0
-//   - only stepid and version (requires a default steplib source to be provided):
-//   - script@2.0.0
-//   - only stepid, latest version will be used (requires a default steplib source to be provided):
-//   - script
-func CreateStepIDDataFromString(compositeVersionStr, defaultStepLibSource string) (StepIDData, error) {
-	src := getStepSource(compositeVersionStr)
-	if src == "" {
-		if defaultStepLibSource == "" {
-			return StepIDData{}, errors.New("No default StepLib source, in this case the composite ID should contain the source, separated with a '::' separator from the step ID (" + compositeVersionStr + ")")
-		}
-		src = defaultStepLibSource
-	}
-
-	id := getStepID(compositeVersionStr)
-	if id == "" {
-		return StepIDData{}, errors.New("No ID found at all (" + compositeVersionStr + ")")
-	}
-
-	version := getStepVersion(compositeVersionStr)
-
-	return StepIDData{
-		IDorURI:       id,
-		SteplibSource: string(src),
-		Version:       version,
-	}, nil
-}
-
-// IsUniqueResourceID : true if this ID is a unique resource ID, which is true
-// if the ID refers to the exact same step code/data every time.
-// Practically, this is only true for steps from StepLibrary collections,
-// a local path or direct git step ID is never guaranteed to identify the
-// same resource every time, the step's behaviour can change at every execution!
-//
-// __If the ID is a Unique Resource ID then the step can be cached (locally)__,
-// as it won't change between subsequent step execution.
-func (sIDData StepIDData) IsUniqueResourceID() bool {
-	if !isStepLibSource(sIDData.SteplibSource) {
-		return false
-	}
-
-	// in any other case, it's a StepLib URL
-	// but it's only unique if StepID and Step Version are all defined!
-	if len(sIDData.IDorURI) > 0 && len(sIDData.Version) > 0 {
-		return true
-	}
-
-	// in every other case, it's not unique, not even if it's from a StepLib
-	return false
 }
 
 // ----------------------------

--- a/models/models_methods.go
+++ b/models/models_methods.go
@@ -908,24 +908,39 @@ func getStageID(stageListItem StageListItemModel) (string, error) {
 // --- StepIDData
 
 func (stepListItem *StepListItemModel) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	var stepItem StepListStepItemModel
-	if err := unmarshal(&stepItem); err == nil {
+	var raw map[string]interface{}
+	if err := unmarshal(&raw); err != nil {
+		return err
+	}
+
+	var key string
+	for k := range raw {
+		key = k
+		break
+	}
+
+	if key == "with" {
+		var withItem StepListWithItemModel
+		if err := unmarshal(&withItem); err != nil {
+			return err
+		}
+
+		*stepListItem = map[string]interface{}{}
+		for k, v := range withItem {
+			(*stepListItem)[k] = v
+		}
+	} else {
+		var stepItem StepListStepItemModel
+		if err := unmarshal(&stepItem); err != nil {
+			return err
+		}
+
 		*stepListItem = map[string]interface{}{}
 		for k, v := range stepItem {
 			(*stepListItem)[k] = v
 		}
-		return nil
 	}
 
-	var withItem StepListWithItemModel
-	if err := unmarshal(&withItem); err != nil {
-		return err
-	}
-
-	*stepListItem = map[string]interface{}{}
-	for k, v := range withItem {
-		(*stepListItem)[k] = v
-	}
 	return nil
 }
 

--- a/models/models_methods.go
+++ b/models/models_methods.go
@@ -114,7 +114,7 @@ func (workflow *WorkflowModel) Normalize() error {
 	}
 
 	for _, stepListItem := range workflow.Steps {
-		stepID, step, with, err := GetStepIDStepDataPair(stepListItem)
+		stepID, step, _, err := GetStepIDStepDataPair(stepListItem)
 		if err != nil {
 			return err
 		}
@@ -182,7 +182,7 @@ func (workflow *WorkflowModel) Validate() ([]string, error) {
 
 	var warnings []string
 	for _, stepListItem := range workflow.Steps {
-		stepID, step, with, err := GetStepIDStepDataPair(stepListItem)
+		stepID, step, _, err := GetStepIDStepDataPair(stepListItem)
 		if err != nil {
 			return warnings, err
 		}

--- a/models/models_methods.go
+++ b/models/models_methods.go
@@ -124,7 +124,6 @@ func (workflow *WorkflowModel) Normalize() error {
 			}
 			stepListItem[key] = step
 		}
-		// TODO: check if Normalize is needed for 'with'
 	}
 
 	return nil

--- a/models/models_methods_test.go
+++ b/models/models_methods_test.go
@@ -76,6 +76,58 @@ workflows:
   test:
   check:`,
 		},
+		{
+			name: "Containers are normalized",
+			config: `
+format_version: '11'
+default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
+services:
+  postgres:
+    image: postgres:13
+    envs:
+    - POSTGRES_PASSWORD: password
+    ports:
+    - 5435:5432
+    options: >-
+      --health-cmd pg_isready
+      --health-interval 10s
+      --health-timeout 5s
+      --health-retries 5
+containers:
+  ruby:
+    image: ruby:3.2
+workflows:
+  test:
+    steps:
+    - with:
+        container: ruby
+        services:
+        - postgres
+        steps:
+        - script:
+            title: Setup DB
+            inputs:
+            - content: bundle exec rails db:setup
+        - script:
+            title: Run tests
+            inputs:
+            - content: bundle exec rspec
+  test_features:
+    steps:
+    - with:
+        container: ruby
+        services:
+        - postgres
+        steps:
+        - script:
+            title: Setup DB
+            inputs:
+            - content: bundle exec rails db:setup
+        - script:
+            title: Run tests
+            inputs:
+            - content: bundle exec rspec spec/features/`,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/models/models_methods_test.go
+++ b/models/models_methods_test.go
@@ -1080,7 +1080,7 @@ func TestGetStepIDStepDataPair(t *testing.T) {
 			"step1": stepData,
 		}
 
-		id, _, err := GetStepIDStepDataPair(stepListItem)
+		id, _, _, err := GetStepIDStepDataPair(stepListItem)
 		require.NoError(t, err)
 		require.Equal(t, "step1", id)
 	}
@@ -1092,7 +1092,7 @@ func TestGetStepIDStepDataPair(t *testing.T) {
 			"step2": stepData,
 		}
 
-		id, _, err := GetStepIDStepDataPair(stepListItem)
+		id, _, _, err := GetStepIDStepDataPair(stepListItem)
 		require.Error(t, err)
 		require.Equal(t, "", id)
 	}
@@ -1101,7 +1101,7 @@ func TestGetStepIDStepDataPair(t *testing.T) {
 	{
 		stepListItem := StepListItemModel{}
 
-		id, _, err := GetStepIDStepDataPair(stepListItem)
+		id, _, _, err := GetStepIDStepDataPair(stepListItem)
 		require.Error(t, err)
 		require.Equal(t, "", id)
 	}
@@ -1298,7 +1298,7 @@ workflows:
 		}
 
 		for _, stepListItem := range workflow.Steps {
-			_, step, err := GetStepIDStepDataPair(stepListItem)
+			_, step, _, err := GetStepIDStepDataPair(stepListItem)
 			require.NoError(t, err)
 
 			require.Nil(t, step.Title)

--- a/models/models_methods_test.go
+++ b/models/models_methods_test.go
@@ -419,31 +419,35 @@ containers:
     image: ruby:3.2
 workflows:
   test:
-    container: ruby
-    services:
-    - postgres
     steps:
-    - script:
-        title: Setup DB
-        inputs:
-        - content: bundle exec rails db:setup
-    - script:
-        title: Run tests
-        inputs:
-        - content: bundle exec rspec
+    - with:
+        container: ruby
+        services:
+        - postgres
+        steps:
+        - script:
+            title: Setup DB
+            inputs:
+            - content: bundle exec rails db:setup
+        - script:
+            title: Run tests
+            inputs:
+            - content: bundle exec rspec
   test_features:
-    container: ruby
-    services:
-    - postgres
     steps:
-    - script:
-        title: Setup DB
-        inputs:
-        - content: bundle exec rails db:setup
-    - script:
-        title: Run tests
-        inputs:
-        - content: bundle exec rspec spec/features/`),
+    - with:
+        container: ruby
+        services:
+        - postgres
+        steps:
+        - script:
+            title: Setup DB
+            inputs:
+            - content: bundle exec rails db:setup
+        - script:
+            title: Run tests
+            inputs:
+            - content: bundle exec rspec spec/features/`),
 		},
 		{
 			name: "Invalid bitrise.yml: missing service id",
@@ -515,7 +519,9 @@ containers:
     image: ruby:3.2
 workflows:
   primary:
-    container: ruby_3_2`),
+    steps:
+    - with:
+        container: ruby_3_2`),
 			wantErr: "container (ruby_3_2) referenced in workflow (primary), but this container is not defined",
 		},
 		{
@@ -528,8 +534,10 @@ services:
     image: postgres:13
 workflows:
   primary:
-    services:
-    - postgres_13`),
+    steps:
+    - with:
+        services:
+        - postgres_13`),
 			wantErr: "service (postgres_13) referenced in workflow (primary), but this service is not defined",
 		},
 		{
@@ -542,9 +550,11 @@ services:
     image: postgres:13
 workflows:
   primary:
-    services:
-    - postgres
-    - postgres`),
+    steps:
+    - with:
+        services:
+        - postgres
+        - postgres`),
 			wantErr: "service (postgres) specified multiple times for workflow (primary)",
 		},
 	}

--- a/models/models_methods_test.go
+++ b/models/models_methods_test.go
@@ -624,12 +624,6 @@ workflows:
 	}
 }
 
-func createConfig(t *testing.T, yamlContent string) BitriseDataModel {
-	config := BitriseDataModel{}
-	require.NoError(t, yaml.Unmarshal([]byte(yamlContent), &config))
-	return config
-}
-
 // Workflow
 func TestValidateWorkflow(t *testing.T) {
 	t.Log("before-after test")
@@ -825,8 +819,7 @@ workflows:
   _deps-update:
 `
 
-		config, err := configModelFromYAMLBytes([]byte(configStr))
-		require.NoError(t, err)
+		config := createConfig(t, configStr)
 
 		warnings, err := config.Validate()
 		require.NoError(t, err)
@@ -857,10 +850,9 @@ workflows:
   ci:
 `
 
-		config, err := configModelFromYAMLBytes([]byte(configStr))
-		require.NoError(t, err)
+		config := createConfig(t, configStr)
 
-		_, err = config.Validate()
+		_, err := config.Validate()
 		require.EqualError(t, err, "trigger item #1: non-existent pipeline defined as trigger target: release")
 	}
 
@@ -878,10 +870,9 @@ workflows:
   ci:
 `
 
-		config, err := configModelFromYAMLBytes([]byte(configStr))
-		require.NoError(t, err)
+		config := createConfig(t, configStr)
 
-		_, err = config.Validate()
+		_, err := config.Validate()
 		require.EqualError(t, err, "trigger item #1: non-existent workflow defined as trigger target: release")
 	}
 }
@@ -1283,13 +1274,6 @@ func TestRemoveEnvironmentRedundantFields(t *testing.T) {
 	}
 }
 
-func configModelFromYAMLBytes(configBytes []byte) (bitriseData BitriseDataModel, err error) {
-	if err = yaml.Unmarshal(configBytes, &bitriseData); err != nil {
-		return
-	}
-	return
-}
-
 func TestRemoveWorkflowRedundantFields(t *testing.T) {
 	configStr := `format_version: 2
 default_step_lib_source: "https://github.com/bitrise-io/bitrise-steplib.git"
@@ -1314,10 +1298,9 @@ workflows:
         description: test
 `
 
-	config, err := configModelFromYAMLBytes([]byte(configStr))
-	require.NoError(t, err)
+	config := createConfig(t, configStr)
 
-	err = config.RemoveRedundantFields()
+	err := config.RemoveRedundantFields()
 	require.NoError(t, err)
 
 	require.Equal(t, "2", config.FormatVersion)
@@ -1416,4 +1399,10 @@ func TestBitriseDataModelValidateWorkflowsCircularDependency(t *testing.T) {
 
 	require.Equal(t, "0", os.Getenv("BITRISE_BUILD_STATUS"))
 	require.Equal(t, "0", os.Getenv("STEPLIB_BUILD_STATUS"))
+}
+
+func createConfig(t *testing.T, yamlContent string) BitriseDataModel {
+	config := BitriseDataModel{}
+	require.NoError(t, yaml.Unmarshal([]byte(yamlContent), &config))
+	return config
 }

--- a/models/models_methods_test.go
+++ b/models/models_methods_test.go
@@ -1080,7 +1080,7 @@ func TestGetStepIDStepDataPair(t *testing.T) {
 			"step1": stepData,
 		}
 
-		id, _, _, err := GetStepIDStepDataPair(stepListItem)
+		id, _, _, err := stepListItem.GetStepListItemKeyAndValue()
 		require.NoError(t, err)
 		require.Equal(t, "step1", id)
 	}
@@ -1092,7 +1092,7 @@ func TestGetStepIDStepDataPair(t *testing.T) {
 			"step2": stepData,
 		}
 
-		id, _, _, err := GetStepIDStepDataPair(stepListItem)
+		id, _, _, err := stepListItem.GetStepListItemKeyAndValue()
 		require.Error(t, err)
 		require.Equal(t, "", id)
 	}
@@ -1101,7 +1101,7 @@ func TestGetStepIDStepDataPair(t *testing.T) {
 	{
 		stepListItem := StepListItemModel{}
 
-		id, _, _, err := GetStepIDStepDataPair(stepListItem)
+		id, _, _, err := stepListItem.GetStepListItemKeyAndValue()
 		require.Error(t, err)
 		require.Equal(t, "", id)
 	}
@@ -1298,7 +1298,7 @@ workflows:
 		}
 
 		for _, stepListItem := range workflow.Steps {
-			_, step, _, err := GetStepIDStepDataPair(stepListItem)
+			_, step, _, err := stepListItem.GetStepListItemKeyAndValue()
 			require.NoError(t, err)
 
 			require.Nil(t, step.Title)

--- a/models/workflow_run_plan.go
+++ b/models/workflow_run_plan.go
@@ -1,6 +1,10 @@
 package models
 
-import "time"
+import (
+	"time"
+
+	stepmanModels "github.com/bitrise-io/stepman/models"
+)
 
 type WorkflowRunModes struct {
 	CIMode                  bool
@@ -11,15 +15,22 @@ type WorkflowRunModes struct {
 	NoOutputTimeout         time.Duration
 }
 
+// TODO: dispatch Plans from JSON event logging and actual workflow execution
 type StepExecutionPlan struct {
 	UUID   string `json:"uuid"`
 	StepID string `json:"step_id"`
+
+	Step        stepmanModels.StepModel `json:"-"`
+	ContainerID string                  `json:"-"`
+	ServiceIDs  []string                `json:"-"`
 }
 
 type WorkflowExecutionPlan struct {
 	UUID       string              `json:"uuid"`
 	WorkflowID string              `json:"workflow_id"`
 	Steps      []StepExecutionPlan `json:"steps"`
+
+	WorkflowTitle string `json:"-"`
 }
 
 type WorkflowRunPlan struct {

--- a/models/workflow_run_plan.go
+++ b/models/workflow_run_plan.go
@@ -21,6 +21,7 @@ type StepExecutionPlan struct {
 	StepID string `json:"step_id"`
 
 	Step        stepmanModels.StepModel `json:"-"`
+	GroupID     string                  `json:"-"`
 	ContainerID string                  `json:"-"`
 	ServiceIDs  []string                `json:"-"`
 }


### PR DESCRIPTION
### Checklist

- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-io/bitrise/blob/master/.github/CONTRIBUTING.md)
- [x] `README.md` is updated with the changes (if needed)

### Version

Requires a *MAJOR/MINOR/PATCH* [version update](https://semver.org/)

### Context

Containerization-related configuration is getting refactored:

1, Moving service and container configuration to new top-level entities (services and containers): https://github.com/bitrise-io/bitrise/pull/952

2, Step grouping mechanism with a new step list item (`with`)

From this:

```
workflows:
  _setup:
    steps:
    - activate-ssh-key: { }
    - git-clone: {}

  test:
    before_run:
    - _setup
    container: ruby
    services:
    - postgres
    steps:
    - script:
        title: Setup DB
        inputs:
        - content: bundle exec rails db:setup
    - script:
        title: Run tests
        inputs:
        - content: bundle exec rspec
```

to this:

```
workflows:
  test:
    steps:
    - activate-ssh-key@4: { }
    - git-clone@8: {}
    - with:
        container: ruby
        services:
        - postgres
        steps:
        - script:
            title: Setup DB
            inputs:
            - content: bundle exec rails db:setup
        - script:
            title: Run tests
            inputs:
            - content: bundle exec rspec
```

The two changes will be introduced in separate PRs to the `refactor-containerisation` branch.

This PR implements the second change: Step grouping mechanism with a new step list item (`with`)

### Changes

bitrise.yml model changes:
- New `with` step list item under `<workflow_id>.steps`, which allows setting step execution and service containers for a group of steps
- Step execution and service containers removed from the workflows

Workflow run changes:
- The list of steps to be executed within the workflow is now controlled by the extended WorkflowRunPlan, rather than the actual workflow
- WorkflowRunPlan contains a homogenous list of steps, for steps within a `with` group the required container and services along the group ID are stored in the StepExecutionPlan
- These new StepExecutionPlan properties control the lifecycle of containers through the execution of the given step list

Docker container manager changes:
- The lifecycle of containers is tight to the lifecycle of `with` step groups, the with group's uuid is used to reference the related running containers
- The container name has changes: `bitrise-workflow-<workflow_id>` -> `bitrise-workflow-<group_uuid>`