### PR TITLE
Update Bitrise CLI and log format versions

### DIFF
--- a/cli/run.go
+++ b/cli/run.go
@@ -632,7 +632,7 @@ func createWorkflowRunPlan(
 
 	return models.WorkflowRunPlan{
 		Version:                 cliVersion,
-		LogFormatVersion:        "1",
+		LogFormatVersion:        models.LogFormatVersion,
 		CIMode:                  modes.CIMode,
 		PRMode:                  modes.PRMode,
 		DebugMode:               modes.DebugMode,

--- a/models/workflow_run_plan.go
+++ b/models/workflow_run_plan.go
@@ -7,6 +7,8 @@ import (
 	stepmanModels "github.com/bitrise-io/stepman/models"
 )
 
+const LogFormatVersion = "2"
+
 type WorkflowRunModes struct {
 	CIMode                  bool
 	PRMode                  bool

--- a/version/build.go
+++ b/version/build.go
@@ -1,7 +1,7 @@
 package version
 
 // VERSION is the main CLI version number. It's defined at build time using -ldflags
-var VERSION = "2.19.0"
+var VERSION = "2.20.0"
 
 // BuildNumber is the CI build number that creates the release. It's defined at build time using -ldflags
 var BuildNumber = ""


### PR DESCRIPTION
### Checklist

- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-io/bitrise/blob/master/.github/CONTRIBUTING.md)
- [x] `README.md` is updated with the changes (if needed)

### Version

Requires a *MAJOR/MINOR/PATCH* [version update](https://semver.org/)

### Context

This PR updates the Bitrise CLI version from 2.19.0 to 2.20.0 and also updates the log format version from 1 to 2.