### PR TITLE
Better logs when running implicit setup; do minimal setup only

### DIFF
--- a/bitrise/setup.go
+++ b/bitrise/setup.go
@@ -46,8 +46,13 @@ var PluginDependencyMap = map[string]PluginDependency{
 }
 
 func RunSetupIfNeeded(logger log.Logger) error {
-	if !configs.CheckIsSetupWasDoneForVersion(version.VERSION) {
-		log.Warnf("Setup was not performed for this version of bitrise, doing it now...")
+	versionMatch, setupVersion := configs.CheckIsSetupWasDoneForVersion(version.VERSION)
+	if setupVersion == "" {
+		log.Warnf("No setup was done yet, running setup now...")
+		return RunSetup(logger, version.VERSION, SetupModeDefault, false)
+	}
+	if !versionMatch {
+		log.Warnf("Setup was last performed for version %s, current version is %s. Re-running setup now...", setupVersion, version.VERSION)
 		return RunSetup(logger, version.VERSION, SetupModeDefault, false)
 	}
 	return nil

--- a/bitrise/setup.go
+++ b/bitrise/setup.go
@@ -48,11 +48,11 @@ var PluginDependencyMap = map[string]PluginDependency{
 func RunSetupIfNeeded(logger log.Logger) error {
 	versionMatch, setupVersion := configs.CheckIsSetupWasDoneForVersion(version.VERSION)
 	if setupVersion == "" {
-		log.Warnf("No setup was done yet, running setup now...")
+		log.Infof("No setup was done yet, running setup now...")
 		return RunSetup(logger, version.VERSION, SetupModeMinimal, false)
 	}
 	if !versionMatch {
-		log.Warnf("Setup was last performed for version %s, current version is %s. Re-running setup now...", setupVersion, version.VERSION)
+		log.Infof("Setup was last performed for version %s, current version is %s. Re-running setup now...", setupVersion, version.VERSION)
 		return RunSetup(logger, version.VERSION, SetupModeMinimal, false)
 	}
 	return nil

--- a/bitrise/setup.go
+++ b/bitrise/setup.go
@@ -49,11 +49,11 @@ func RunSetupIfNeeded(logger log.Logger) error {
 	versionMatch, setupVersion := configs.CheckIsSetupWasDoneForVersion(version.VERSION)
 	if setupVersion == "" {
 		log.Warnf("No setup was done yet, running setup now...")
-		return RunSetup(logger, version.VERSION, SetupModeDefault, false)
+		return RunSetup(logger, version.VERSION, SetupModeMinimal, false)
 	}
 	if !versionMatch {
 		log.Warnf("Setup was last performed for version %s, current version is %s. Re-running setup now...", setupVersion, version.VERSION)
-		return RunSetup(logger, version.VERSION, SetupModeDefault, false)
+		return RunSetup(logger, version.VERSION, SetupModeMinimal, false)
 	}
 	return nil
 }

--- a/configs/configs.go
+++ b/configs/configs.go
@@ -186,12 +186,12 @@ func SavePluginUpdateCheck(plugin string) error {
 	return saveBitriseConfig(config)
 }
 
-func CheckIsSetupWasDoneForVersion(ver string) bool {
+func CheckIsSetupWasDoneForVersion(ver string) (bool, string) {
 	config, err := loadBitriseConfig()
 	if err != nil {
-		return false
+		return false, ""
 	}
-	return (config.SetupVersion == ver)
+	return config.SetupVersion == ver, config.SetupVersion
 }
 
 func SaveSetupSuccessForVersion(ver string) error {

--- a/configs/configs_test.go
+++ b/configs/configs_test.go
@@ -18,11 +18,14 @@ func TestSetupForVersionChecks(t *testing.T) {
 
 	t.Setenv("HOME", fakeHomePth)
 
-	require.Equal(t, false, CheckIsSetupWasDoneForVersion("0.9.7"))
+	versionMatch, _ := CheckIsSetupWasDoneForVersion("0.9.7")
+	require.Equal(t, false, versionMatch)
 
 	require.Equal(t, nil, SaveSetupSuccessForVersion("0.9.7"))
 
-	require.Equal(t, true, CheckIsSetupWasDoneForVersion("0.9.7"))
+	versionMatch, _ = CheckIsSetupWasDoneForVersion("0.9.7")
+	require.Equal(t, true, versionMatch)
 
-	require.Equal(t, false, CheckIsSetupWasDoneForVersion("0.9.8"))
+	versionMatch, _ = CheckIsSetupWasDoneForVersion("0.9.8")
+	require.Equal(t, false, versionMatch)
 }


### PR DESCRIPTION
<!--
  Thanks for contributing to the Bitrise CLI!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [ ] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-io/bitrise/blob/master/.github/CONTRIBUTING.md)
- [ ] `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *MAJOR/MINOR/PATCH* [version update](https://semver.org/)

### Context

It's not clear why the implicit setup is triggered in some cases, and it's enough to run a minimal setup only (see #944)

### Changes

<!-- 
  Details are important, and help maintainers processing your PR.
  Please list additional details, for example:
  - Update dependencies
  - Make `foo` optional in `main.go`
  - `foo` now returns an `error` for better error handling
-->

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->