### PR TITLE
[CI-3190] Improve parameter logging

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -90,6 +90,8 @@ func Run() {
 	app.Action = func(c *cli.Context) error {
 		pluginName, pluginArgs, isPlugin := plugins.ParseArgs(c.Args())
 		if isPlugin {
+			logPluginCommandParameters(pluginName, pluginArgs)
+
 			plugin, found, err := plugins.LoadPlugin(pluginName)
 			if err != nil {
 				return fmt.Errorf("Failed to get plugin (%s), error: %s", pluginName, err)

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -7,54 +7,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestCommandInfo(t *testing.T) {
-	tests := []struct {
-		name           string
-		args           []string
-		wantCommand    string
-		wantSubcommand string
-		wantFlags      []string
-	}{
-		{
-			name:           "Empty command",
-			args:           []string{},
-			wantCommand:    "",
-			wantSubcommand: "",
-			wantFlags:      nil,
-		},
-		{
-			name:           "CLI command",
-			args:           []string{"run", "e2e"},
-			wantCommand:    "run",
-			wantSubcommand: "",
-			wantFlags:      nil,
-		},
-		{
-			name:           "Plugin command",
-			args:           []string{":plugin", "do", "something"},
-			wantCommand:    ":plugin",
-			wantSubcommand: "do",
-			wantFlags:      nil,
-		},
-		{
-			name:           "Flags",
-			args:           []string{"run", "--A", "-a", "--B=true", "-b false", "--C /path/to/something"},
-			wantCommand:    "run",
-			wantSubcommand: "",
-			wantFlags:      []string{"A", "a", "B", "b", "C"},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			command, subcommand, flags := commandExecutionInfo(tt.args)
-			assert.Equalf(t, tt.wantCommand, command, "commandExecutionInfo(%v)", tt.args)
-			assert.Equalf(t, tt.wantSubcommand, subcommand, "commandExecutionInfo(%v)", tt.args)
-			assert.Equalf(t, tt.wantFlags, flags, "commandExecutionInfo(%v)", tt.args)
-		})
-	}
-}
-
 func Test_loggerParameters(t *testing.T) {
 	tests := []struct {
 		name             string

--- a/cli/command_analytics.go
+++ b/cli/command_analytics.go
@@ -48,14 +48,14 @@ func logCommandParameters(c *cli.Context) {
 func collectFlags(c *cli.Context) []string {
 	var flags []string
 
-	for _, flag := range c.FlagNames() {
-		if isSet := c.IsSet(flag); isSet {
+	for _, flag := range c.GlobalFlagNames() {
+		if isSet := c.GlobalIsSet(flag); isSet {
 			flags = append(flags, flag)
 		}
 	}
 
-	for _, flag := range c.GlobalFlagNames() {
-		if isSet := c.GlobalIsSet(flag); isSet {
+	for _, flag := range c.FlagNames() {
+		if isSet := c.IsSet(flag); isSet {
 			flags = append(flags, flag)
 		}
 	}

--- a/cli/command_analytics.go
+++ b/cli/command_analytics.go
@@ -64,7 +64,5 @@ func collectFlags(c *cli.Context) []string {
 }
 
 func sendCommandInfo(command, subcommand string, flags []string) {
-	//fmt.Printf("Command name: %s, subcommand: %s, flags: %s\n", command, subcommand, flags)
-
 	globalTracker.SendCommandInfo(command, subcommand, flags)
 }

--- a/cli/command_analytics.go
+++ b/cli/command_analytics.go
@@ -24,9 +24,7 @@ func logCommandParameters(c *cli.Context) {
 
 	commandName := "unknown"
 	subcommandName := ""
-
-	fmt.Println(c.Command.FullName())
-
+	
 	if names := strings.Split(c.Command.FullName(), " "); 0 < len(names) {
 		commandName = names[0]
 		if 1 < len(names) {

--- a/cli/command_analytics.go
+++ b/cli/command_analytics.go
@@ -17,32 +17,26 @@ func logPluginCommandParameters(name string, _ []string) {
 	sendCommandInfo(fmt.Sprintf(":%s", name), "", []string{})
 }
 
-func logSubcommandParameters(c *cli.Context) {
-	if c == nil {
-		return
-	}
-
-	commandName := "unknown"
-	subcommandName := "unknown"
-
-	if names := strings.Split(c.Command.FullName(), " "); len(names) == 2 {
-		commandName = names[0]
-		subcommandName = names[1]
-	}
-
-	flags := collectFlags(c)
-
-	sendCommandInfo(commandName, subcommandName, flags)
-}
-
 func logCommandParameters(c *cli.Context) {
 	if c == nil {
 		return
 	}
 
+	commandName := "unknown"
+	subcommandName := ""
+
+	fmt.Println(c.Command.FullName())
+
+	if names := strings.Split(c.Command.FullName(), " "); 0 < len(names) {
+		commandName = names[0]
+		if 1 < len(names) {
+			subcommandName = names[1]
+		}
+	}
+
 	flags := collectFlags(c)
 
-	sendCommandInfo(c.Command.Name, "", flags)
+	sendCommandInfo(commandName, subcommandName, flags)
 }
 
 func collectFlags(c *cli.Context) []string {

--- a/cli/command_analytics.go
+++ b/cli/command_analytics.go
@@ -1,0 +1,70 @@
+package cli
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/bitrise-io/bitrise/analytics"
+	"github.com/urfave/cli"
+)
+
+var globalTracker analytics.Tracker
+
+func logPluginCommandParameters(name string, _ []string) {
+	// Plugin command parameters are routed into the function but are not processed yet because it is complex to correctly
+	// parse the arguments without knowing the structure. If we notice that our users do use plugins, then we can add
+	// plugin specific argument parsers.
+	sendCommandInfo(fmt.Sprintf(":%s", name), "", []string{})
+}
+
+func logSubcommandParameters(c *cli.Context) {
+	if c == nil {
+		return
+	}
+
+	commandName := "unknown"
+	subcommandName := "unknown"
+
+	if names := strings.Split(c.Command.FullName(), " "); len(names) == 2 {
+		commandName = names[0]
+		subcommandName = names[1]
+	}
+
+	flags := collectFlags(c)
+
+	sendCommandInfo(commandName, subcommandName, flags)
+}
+
+func logCommandParameters(c *cli.Context) {
+	if c == nil {
+		return
+	}
+
+	flags := collectFlags(c)
+
+	sendCommandInfo(c.Command.Name, "", flags)
+}
+
+func collectFlags(c *cli.Context) []string {
+	var flags []string
+
+	for _, flag := range c.FlagNames() {
+		if isSet := c.IsSet(flag); isSet {
+			flags = append(flags, flag)
+		}
+	}
+
+	for _, flag := range c.GlobalFlagNames() {
+		if isSet := c.GlobalIsSet(flag); isSet {
+			flags = append(flags, flag)
+		}
+	}
+
+	return flags
+}
+
+func sendCommandInfo(command, subcommand string, flags []string) {
+	//fmt.Printf("Command name: %s, subcommand: %s, flags: %s\n", command, subcommand, flags)
+
+	globalTracker.SendCommandInfo(command, subcommand, flags)
+}

--- a/cli/init.go
+++ b/cli/init.go
@@ -15,6 +15,8 @@ var initCmd = cli.Command{
 	Aliases: []string{"i"},
 	Usage:   "Init bitrise config.",
 	Action: func(c *cli.Context) error {
+		logCommandParameters(c)
+
 		logger := log.NewLogger(log.GetGlobalLoggerOpts())
 		if err := initConfig(c); err != nil {
 

--- a/cli/merge.go
+++ b/cli/merge.go
@@ -27,6 +27,8 @@ var mergeConfigCommand = cli.Command{
 }
 
 func mergeConfig(c *cli.Context) error {
+	logCommandParameters(c)
+
 	var configPth string
 	if c.Args().Present() {
 		configPth = c.Args().First()

--- a/cli/plugin_delete.go
+++ b/cli/plugin_delete.go
@@ -14,6 +14,8 @@ var pluginDeleteCommand = cli.Command{
 	Name:  "delete",
 	Usage: "Delete bitrise plugin.",
 	Action: func(c *cli.Context) error {
+		logSubcommandParameters(c)
+
 		if err := pluginDelete(c); err != nil {
 			log.Errorf("Plugin delete failed, error: %s", err)
 			os.Exit(1)

--- a/cli/plugin_delete.go
+++ b/cli/plugin_delete.go
@@ -14,7 +14,7 @@ var pluginDeleteCommand = cli.Command{
 	Name:  "delete",
 	Usage: "Delete bitrise plugin.",
 	Action: func(c *cli.Context) error {
-		logSubcommandParameters(c)
+		logCommandParameters(c)
 
 		if err := pluginDelete(c); err != nil {
 			log.Errorf("Plugin delete failed, error: %s", err)

--- a/cli/plugin_info.go
+++ b/cli/plugin_info.go
@@ -15,6 +15,8 @@ var pluginInfoCommand = cli.Command{
 	Name:  "info",
 	Usage: "Installed bitrise plugin's info",
 	Action: func(c *cli.Context) error {
+		logSubcommandParameters(c)
+
 		if err := pluginInfo(c); err != nil {
 			log.Errorf("Plugin info failed, error: %s", err)
 			os.Exit(1)

--- a/cli/plugin_info.go
+++ b/cli/plugin_info.go
@@ -15,7 +15,7 @@ var pluginInfoCommand = cli.Command{
 	Name:  "info",
 	Usage: "Installed bitrise plugin's info",
 	Action: func(c *cli.Context) error {
-		logSubcommandParameters(c)
+		logCommandParameters(c)
 
 		if err := pluginInfo(c); err != nil {
 			log.Errorf("Plugin info failed, error: %s", err)

--- a/cli/plugin_install.go
+++ b/cli/plugin_install.go
@@ -13,6 +13,8 @@ var pluginInstallCommand = cli.Command{
 	Name:  "install",
 	Usage: "Install bitrise plugin.",
 	Action: func(c *cli.Context) error {
+		logSubcommandParameters(c)
+
 		if err := pluginInstall(c); err != nil {
 			log.Errorf("Plugin install failed, error: %s", err)
 			os.Exit(1)

--- a/cli/plugin_install.go
+++ b/cli/plugin_install.go
@@ -13,7 +13,7 @@ var pluginInstallCommand = cli.Command{
 	Name:  "install",
 	Usage: "Install bitrise plugin.",
 	Action: func(c *cli.Context) error {
-		logSubcommandParameters(c)
+		logCommandParameters(c)
 
 		if err := pluginInstall(c); err != nil {
 			log.Errorf("Plugin install failed, error: %s", err)

--- a/cli/plugin_list.go
+++ b/cli/plugin_list.go
@@ -14,6 +14,8 @@ var pluginListCommand = cli.Command{
 	Name:  "list",
 	Usage: "List installed bitrise plugins.",
 	Action: func(c *cli.Context) error {
+		logSubcommandParameters(c)
+
 		if err := pluginList(c); err != nil {
 			log.Errorf("Plugin list failed, error: %s", err)
 			os.Exit(1)

--- a/cli/plugin_list.go
+++ b/cli/plugin_list.go
@@ -14,7 +14,7 @@ var pluginListCommand = cli.Command{
 	Name:  "list",
 	Usage: "List installed bitrise plugins.",
 	Action: func(c *cli.Context) error {
-		logSubcommandParameters(c)
+		logCommandParameters(c)
 
 		if err := pluginList(c); err != nil {
 			log.Errorf("Plugin list failed, error: %s", err)

--- a/cli/plugin_update.go
+++ b/cli/plugin_update.go
@@ -14,7 +14,7 @@ var pluginUpdateCommand = cli.Command{
 	Name:  "update",
 	Usage: "Update bitrise plugin. If <plugin_name> not specified, every plugin will be updated.",
 	Action: func(c *cli.Context) error {
-		logSubcommandParameters(c)
+		logCommandParameters(c)
 
 		if err := pluginUpdate(c); err != nil {
 			log.Errorf("Plugin update failed, error: %s", err)

--- a/cli/plugin_update.go
+++ b/cli/plugin_update.go
@@ -14,6 +14,8 @@ var pluginUpdateCommand = cli.Command{
 	Name:  "update",
 	Usage: "Update bitrise plugin. If <plugin_name> not specified, every plugin will be updated.",
 	Action: func(c *cli.Context) error {
+		logSubcommandParameters(c)
+
 		if err := pluginUpdate(c); err != nil {
 			log.Errorf("Plugin update failed, error: %s", err)
 			os.Exit(1)

--- a/cli/preload_steps.go
+++ b/cli/preload_steps.go
@@ -24,7 +24,7 @@ var stepsCommand = cli.Command{
 			Name:  "list-cached",
 			Usage: "List all the cached steps",
 			Action: func(c *cli.Context) error {
-				logSubcommandParameters(c)
+				logCommandParameters(c)
 
 				return listCachedSteps(c)
 			},
@@ -46,7 +46,7 @@ var stepsCommand = cli.Command{
 			Usage:     "Makes sure that Bitrise CLI can be used in offline mode by preloading Bitrise maintaned Steps.",
 			UsageText: fmt.Sprintf("Use the %s env var to test after preloading steps.", configs.IsSteplibOfflineModeEnvKey),
 			Action: func(c *cli.Context) error {
-				logSubcommandParameters(c)
+				logCommandParameters(c)
 
 				if err := preloadSteps(c); err != nil {
 					log.Errorf("Preload failed: %s", err)

--- a/cli/preload_steps.go
+++ b/cli/preload_steps.go
@@ -24,6 +24,8 @@ var stepsCommand = cli.Command{
 			Name:  "list-cached",
 			Usage: "List all the cached steps",
 			Action: func(c *cli.Context) error {
+				logSubcommandParameters(c)
+
 				return listCachedSteps(c)
 			},
 			Flags: []cli.Flag{
@@ -44,6 +46,8 @@ var stepsCommand = cli.Command{
 			Usage:     "Makes sure that Bitrise CLI can be used in offline mode by preloading Bitrise maintaned Steps.",
 			UsageText: fmt.Sprintf("Use the %s env var to test after preloading steps.", configs.IsSteplibOfflineModeEnvKey),
 			Action: func(c *cli.Context) error {
+				logSubcommandParameters(c)
+
 				if err := preloadSteps(c); err != nil {
 					log.Errorf("Preload failed: %s", err)
 					os.Exit(1)

--- a/cli/run.go
+++ b/cli/run.go
@@ -73,6 +73,8 @@ var runCommand = cli.Command{
 }
 
 func run(c *cli.Context) error {
+	logCommandParameters(c)
+
 	signalInterruptChan := make(chan os.Signal, 1)
 	signal.Notify(signalInterruptChan, syscall.SIGINT, syscall.SIGTERM)
 

--- a/cli/setup.go
+++ b/cli/setup.go
@@ -12,6 +12,8 @@ var setupCommand = cli.Command{
 	Name:  "setup",
 	Usage: "Setup the current host. Install every required tool to run Workflows.",
 	Action: func(c *cli.Context) error {
+		logSubcommandParameters(c)
+
 		if err := setup(c); err != nil {
 			log.Errorf("Setup failed, error: %s", err)
 			os.Exit(1)

--- a/cli/setup.go
+++ b/cli/setup.go
@@ -12,7 +12,7 @@ var setupCommand = cli.Command{
 	Name:  "setup",
 	Usage: "Setup the current host. Install every required tool to run Workflows.",
 	Action: func(c *cli.Context) error {
-		logSubcommandParameters(c)
+		logCommandParameters(c)
 
 		if err := setup(c); err != nil {
 			log.Errorf("Setup failed, error: %s", err)

--- a/cli/share.go
+++ b/cli/share.go
@@ -6,6 +6,8 @@ import (
 )
 
 func share(c *cli.Context) error {
+	logCommandParameters(c)
+
 	if err := tools.StepmanShare(); err != nil {
 		failf("Bitrise share failed, error: %s", err)
 	}

--- a/cli/share_audit.go
+++ b/cli/share_audit.go
@@ -6,7 +6,7 @@ import (
 )
 
 func shareAudit(c *cli.Context) error {
-	logSubcommandParameters(c)
+	logCommandParameters(c)
 
 	if err := tools.StepmanShareAudit(); err != nil {
 		failf("Bitrise share audit failed, error: %s", err)

--- a/cli/share_audit.go
+++ b/cli/share_audit.go
@@ -5,7 +5,9 @@ import (
 	"github.com/urfave/cli"
 )
 
-func shareAudit(_ *cli.Context) error {
+func shareAudit(c *cli.Context) error {
+	logSubcommandParameters(c)
+
 	if err := tools.StepmanShareAudit(); err != nil {
 		failf("Bitrise share audit failed, error: %s", err)
 	}

--- a/cli/share_create.go
+++ b/cli/share_create.go
@@ -6,7 +6,7 @@ import (
 )
 
 func create(c *cli.Context) error {
-	logSubcommandParameters(c)
+	logCommandParameters(c)
 
 	// Input validation
 	tag := c.String(TagKey)

--- a/cli/share_create.go
+++ b/cli/share_create.go
@@ -6,6 +6,8 @@ import (
 )
 
 func create(c *cli.Context) error {
+	logSubcommandParameters(c)
+
 	// Input validation
 	tag := c.String(TagKey)
 	if tag == "" {

--- a/cli/share_finish.go
+++ b/cli/share_finish.go
@@ -5,7 +5,9 @@ import (
 	"github.com/urfave/cli"
 )
 
-func finish(_ *cli.Context) error {
+func finish(c *cli.Context) error {
+	logSubcommandParameters(c)
+
 	if err := tools.StepmanShareFinish(); err != nil {
 		failf("Bitrise share finish failed, error: %s", err)
 	}

--- a/cli/share_finish.go
+++ b/cli/share_finish.go
@@ -6,7 +6,7 @@ import (
 )
 
 func finish(c *cli.Context) error {
-	logSubcommandParameters(c)
+	logCommandParameters(c)
 
 	if err := tools.StepmanShareFinish(); err != nil {
 		failf("Bitrise share finish failed, error: %s", err)

--- a/cli/share_start.go
+++ b/cli/share_start.go
@@ -6,7 +6,7 @@ import (
 )
 
 func start(c *cli.Context) error {
-	logSubcommandParameters(c)
+	logCommandParameters(c)
 
 	// Input validation
 	collectionURI := c.String(CollectionKey)

--- a/cli/share_start.go
+++ b/cli/share_start.go
@@ -6,6 +6,8 @@ import (
 )
 
 func start(c *cli.Context) error {
+	logSubcommandParameters(c)
+
 	// Input validation
 	collectionURI := c.String(CollectionKey)
 	if collectionURI == "" {

--- a/cli/tools.go
+++ b/cli/tools.go
@@ -12,6 +12,8 @@ var envmanCommand = cli.Command{
 	Usage:           "Runs an envman command.",
 	SkipFlagParsing: true,
 	Action: func(c *cli.Context) error {
+		logCommandParameters(c)
+
 		if err := runCommandWith("envman", c); err != nil {
 			failf("Command failed, error: %s", err)
 		}

--- a/cli/trigger.go
+++ b/cli/trigger.go
@@ -65,6 +65,8 @@ func printAvailableTriggerFilters(triggerMap []models.TriggerMapItemModel) {
 }
 
 func trigger(c *cli.Context) error {
+	logCommandParameters(c)
+
 	// Expand cli.Context
 	var prGlobalFlagPtr *bool
 	if c.GlobalIsSet(PRKey) {

--- a/cli/trigger_check.go
+++ b/cli/trigger_check.go
@@ -73,6 +73,8 @@ func getPipelineAndWorkflowIDByParamsInCompatibleMode(triggerMap models.TriggerM
 // --------------------
 
 func triggerCheck(c *cli.Context) error {
+	logCommandParameters(c)
+
 	warnings := []string{}
 
 	//

--- a/cli/update.go
+++ b/cli/update.go
@@ -31,6 +31,8 @@ var updateCommand = cli.Command{
 	Name:  "update",
 	Usage: "Updates the Bitrise CLI.",
 	Action: func(c *cli.Context) error {
+		logCommandParameters(c)
+
 		if err := update(c); err != nil {
 			log.Errorf("Update Bitrise CLI failed, error: %s", err)
 			os.Exit(1)

--- a/cli/validate.go
+++ b/cli/validate.go
@@ -218,6 +218,8 @@ func runValidate(bitriseConfigPath string, bitriseConfigBase64Data string, inven
 }
 
 func validate(c *cli.Context) error {
+	logCommandParameters(c)
+
 	// Expand cli.Context
 	bitriseConfigBase64Data := c.String(ConfigBase64Key)
 	bitriseConfigPath := c.String(ConfigKey)

--- a/cli/version.go
+++ b/cli/version.go
@@ -22,6 +22,8 @@ type VersionOutputModel struct {
 }
 
 func printVersionCmd(c *cli.Context) error {
+	logCommandParameters(c)
+
 	fullVersion := c.Bool("full")
 
 	if err := output.ConfigureOutputFormat(c); err != nil {

--- a/cli/workflow_list.go
+++ b/cli/workflow_list.go
@@ -17,6 +17,8 @@ var workflowListCommand = cli.Command{
 	Name:  "workflows",
 	Usage: "List of available workflows in config.",
 	Action: func(c *cli.Context) error {
+		logCommandParameters(c)
+
 		if err := workflowList(c); err != nil {
 			log.Errorf("List of available workflows in config failed, error: %s", err)
 			os.Exit(1)


### PR DESCRIPTION
<!--
  Thanks for contributing to the Bitrise CLI!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [ ] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-io/bitrise/blob/master/.github/CONTRIBUTING.md)
- [ ] `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *PATCH* [version update](https://semver.org/)

### Context

The previous command line parser was not handling all the edge cases and was logging incorrect data. For example, us and the users are calling the CLI with not a fix parameter type order. 

In this iteration I am relying on the `urfave/cli` package to get access to the parameter list. It already knows the correct parameters for a given command / subcommand so by the time the action starts we can have access to a correct parameter list.