### PR TITLE
Custom status report names

### DIFF
--- a/models/models.go
+++ b/models/models.go
@@ -133,10 +133,11 @@ type Container struct {
 }
 
 type AppModel struct {
-	Title        string                              `json:"title,omitempty" yaml:"title,omitempty"`
-	Summary      string                              `json:"summary,omitempty" yaml:"summary,omitempty"`
-	Description  string                              `json:"description,omitempty" yaml:"description,omitempty"`
-	Environments []envmanModels.EnvironmentItemModel `json:"envs,omitempty" yaml:"envs,omitempty"`
+	Title            string                              `json:"title,omitempty" yaml:"title,omitempty"`
+	Summary          string                              `json:"summary,omitempty" yaml:"summary,omitempty"`
+	Description      string                              `json:"description,omitempty" yaml:"description,omitempty"`
+	StatusReportName string                              `json:"status_report_name,omitempty" yaml:"status_report_name,omitempty"`
+	Environments     []envmanModels.EnvironmentItemModel `json:"envs,omitempty" yaml:"envs,omitempty"`
 }
 
 type BitriseDataModel struct {

--- a/models/models.go
+++ b/models/models.go
@@ -47,12 +47,13 @@ type StepListStepItemModel map[string]stepmanModels.StepModel
 type StepListItemModel map[string]interface{}
 
 type PipelineModel struct {
-	Title       string                             `json:"title,omitempty" yaml:"title,omitempty"`
-	Summary     string                             `json:"summary,omitempty" yaml:"summary,omitempty"`
-	Description string                             `json:"description,omitempty" yaml:"description,omitempty"`
-	Triggers    Triggers                           `json:"triggers,omitempty" yaml:"triggers,omitempty"`
-	Stages      []StageListItemModel               `json:"stages,omitempty" yaml:"stages,omitempty"`
-	Workflows   GraphPipelineWorkflowListItemModel `json:"workflows,omitempty" yaml:"workflows,omitempty"`
+	Title            string                             `json:"title,omitempty" yaml:"title,omitempty"`
+	Summary          string                             `json:"summary,omitempty" yaml:"summary,omitempty"`
+	Description      string                             `json:"description,omitempty" yaml:"description,omitempty"`
+	Triggers         Triggers                           `json:"triggers,omitempty" yaml:"triggers,omitempty"`
+	StatusReportName string                             `json:"status_report_name,omitempty" yaml:"status_report_name,omitempty"`
+	Stages           []StageListItemModel               `json:"stages,omitempty" yaml:"stages,omitempty"`
+	Workflows        GraphPipelineWorkflowListItemModel `json:"workflows,omitempty" yaml:"workflows,omitempty"`
 }
 
 type StageListItemModel map[string]StageModel
@@ -105,15 +106,16 @@ func (d *GraphPipelineAlwaysRunMode) UnmarshalYAML(unmarshal func(interface{}) e
 type WorkflowListItemModel map[string]WorkflowModel
 
 type WorkflowModel struct {
-	Title        string                              `json:"title,omitempty" yaml:"title,omitempty"`
-	Summary      string                              `json:"summary,omitempty" yaml:"summary,omitempty"`
-	Description  string                              `json:"description,omitempty" yaml:"description,omitempty"`
-	Triggers     Triggers                            `json:"triggers,omitempty" yaml:"triggers,omitempty"`
-	BeforeRun    []string                            `json:"before_run,omitempty" yaml:"before_run,omitempty"`
-	AfterRun     []string                            `json:"after_run,omitempty" yaml:"after_run,omitempty"`
-	Environments []envmanModels.EnvironmentItemModel `json:"envs,omitempty" yaml:"envs,omitempty"`
-	Steps        []StepListItemModel                 `json:"steps,omitempty" yaml:"steps,omitempty"`
-	Meta         map[string]interface{}              `json:"meta,omitempty" yaml:"meta,omitempty"`
+	Title            string                              `json:"title,omitempty" yaml:"title,omitempty"`
+	Summary          string                              `json:"summary,omitempty" yaml:"summary,omitempty"`
+	Description      string                              `json:"description,omitempty" yaml:"description,omitempty"`
+	Triggers         Triggers                            `json:"triggers,omitempty" yaml:"triggers,omitempty"`
+	StatusReportName string                              `json:"status_report_name,omitempty" yaml:"status_report_name,omitempty"`
+	BeforeRun        []string                            `json:"before_run,omitempty" yaml:"before_run,omitempty"`
+	AfterRun         []string                            `json:"after_run,omitempty" yaml:"after_run,omitempty"`
+	Environments     []envmanModels.EnvironmentItemModel `json:"envs,omitempty" yaml:"envs,omitempty"`
+	Steps            []StepListItemModel                 `json:"steps,omitempty" yaml:"steps,omitempty"`
+	Meta             map[string]interface{}              `json:"meta,omitempty" yaml:"meta,omitempty"`
 }
 
 type DockerCredentials struct {

--- a/models/models_methods.go
+++ b/models/models_methods.go
@@ -397,7 +397,7 @@ func (app *AppModel) Validate() error {
 			return err
 		}
 	}
-	return nil
+	return validateStatusReportName(app.StatusReportName)
 }
 
 func (config *BitriseDataModel) Validate() ([]string, error) {

--- a/models/models_methods.go
+++ b/models/models_methods.go
@@ -374,6 +374,20 @@ func (workflow *WorkflowModel) Validate() error {
 			return err
 		}
 	}
+
+	return validateStatusReportName(workflow.StatusReportName)
+}
+
+func validateStatusReportName(statusReportName string) error {
+	if len(statusReportName) > 100 {
+		return fmt.Errorf("status_report_name (%s) is too long, max length is 100 characters", statusReportName)
+	}
+
+	pattern := `^[a-zA-Z0-9,./():\-_ <>[\]|]*$`
+	re := regexp.MustCompile(pattern)
+	if !re.MatchString(statusReportName) {
+		return fmt.Errorf("status_report_name (%s) contains invalid characters", statusReportName)
+	}
 	return nil
 }
 
@@ -535,6 +549,10 @@ func validatePipelines(config *BitriseDataModel) ([]string, error) {
 			return pipelineWarnings, err
 		}
 
+		if err := validateStatusReportName(pipeline.StatusReportName); err != nil {
+			return pipelineWarnings, err
+		}
+
 		hasStages := len(pipeline.Stages) > 0
 		hasWorkflows := len(pipeline.Workflows) > 0
 
@@ -552,7 +570,6 @@ func validatePipelines(config *BitriseDataModel) ([]string, error) {
 		if hasWorkflows {
 			return pipelineWarnings, validateDAGPipeline(pipelineID, &pipeline, config)
 		}
-
 	}
 
 	return pipelineWarnings, nil

--- a/models/models_methods.go
+++ b/models/models_methods.go
@@ -378,15 +378,16 @@ func (workflow *WorkflowModel) Validate() error {
 	return validateStatusReportName(workflow.StatusReportName)
 }
 
+const statusReportNameRegex = `^[a-zA-Z0-9,./():\-_ <>[\]|]*$`
+
 func validateStatusReportName(statusReportName string) error {
 	if len(statusReportName) > 100 {
 		return fmt.Errorf("status_report_name (%s) is too long, max length is 100 characters", statusReportName)
 	}
 
-	pattern := `^[a-zA-Z0-9,./():\-_ <>[\]|]*$`
-	re := regexp.MustCompile(pattern)
+	re := regexp.MustCompile(statusReportNameRegex)
 	if !re.MatchString(statusReportName) {
-		return fmt.Errorf("status_report_name (%s) contains invalid characters", statusReportName)
+		return fmt.Errorf("status_report_name (%s) contains invalid characters, should match the '%s' regex", statusReportName, statusReportNameRegex)
 	}
 	return nil
 }

--- a/models/models_methods_test.go
+++ b/models/models_methods_test.go
@@ -332,7 +332,7 @@ func TestValidateConfig(t *testing.T) {
 
 		bitriseData.App.StatusReportName += "*"
 		_, err = bitriseData.Validate()
-		require.EqualError(t, err, "status_report_name ("+bitriseData.App.StatusReportName+") contains invalid characters")
+		require.EqualError(t, err, "status_report_name ("+bitriseData.App.StatusReportName+") contains invalid characters, should match the '"+statusReportNameRegex+"' regex")
 	}
 
 	t.Log("Invalid bitriseData - pipeline ID empty")
@@ -634,7 +634,7 @@ func TestValidateConfig(t *testing.T) {
 		pipeline.StatusReportName += "*"
 		bitriseData.Pipelines["pipeline1"] = pipeline
 		_, err = bitriseData.Validate()
-		require.EqualError(t, err, "status_report_name ("+pipeline.StatusReportName+") contains invalid characters")
+		require.EqualError(t, err, "status_report_name ("+pipeline.StatusReportName+") contains invalid characters, should match the '"+statusReportNameRegex+"' regex")
 	}
 }
 
@@ -1006,7 +1006,7 @@ workflows:
 		require.NoError(t, workflow.Validate())
 
 		workflow.StatusReportName += "*"
-		require.EqualError(t, workflow.Validate(), "status_report_name ("+workflow.StatusReportName+") contains invalid characters")
+		require.EqualError(t, workflow.Validate(), "status_report_name ("+workflow.StatusReportName+") contains invalid characters, should match the '"+statusReportNameRegex+"' regex")
 	}
 }
 

--- a/models/models_methods_test.go
+++ b/models/models_methods_test.go
@@ -305,6 +305,36 @@ func TestValidateConfig(t *testing.T) {
 		require.Equal(t, 0, len(warnings))
 	}
 
+	t.Log("validate app status report name - max length")
+	{
+		bitriseData := BitriseDataModel{
+			FormatVersion: "1.4.0",
+		}
+
+		bitriseData.App.StatusReportName = strings.Repeat("a", 100)
+		_, err := bitriseData.Validate()
+		require.NoError(t, err)
+
+		bitriseData.App.StatusReportName += "a"
+		_, err = bitriseData.Validate()
+		require.EqualError(t, err, "status_report_name ("+bitriseData.App.StatusReportName+") is too long, max length is 100 characters")
+	}
+
+	t.Log("validate app status report name - allowed characters")
+	{
+		bitriseData := BitriseDataModel{
+			FormatVersion: "1.4.0",
+		}
+
+		bitriseData.App.StatusReportName = "aA0,./():-_< >[]|"
+		_, err := bitriseData.Validate()
+		require.NoError(t, err)
+
+		bitriseData.App.StatusReportName += "*"
+		_, err = bitriseData.Validate()
+		require.EqualError(t, err, "status_report_name ("+bitriseData.App.StatusReportName+") contains invalid characters")
+	}
+
 	t.Log("Invalid bitriseData - pipeline ID empty")
 	{
 		bitriseData := BitriseDataModel{


### PR DESCRIPTION
### Checklist

- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-io/bitrise/blob/master/.github/CONTRIBUTING.md)
- [x] `README.md` is updated with the changes (if needed)

### Version

Requires a *MINOR* [version update](https://semver.org/)

### Context

This PR introduces support for configuring custom build status report names in the bitrise.yml configuration file.

By default, Bitrise uses the `ci/bitrise/<project_slug>/<event_type>` status report name (or simply `Bitrise` for legacy GitHub Checks enabled projects).

The default value can be overwritten at App level and Workflow and Pipeline level too:

```
---
format_version: '13'
app:
  status_report_name: "ci/bitrise/<project_slug>/<target_id>/<event_type>"

pipelines:
  pipeline:
    status_report_name: "Custom status name for a pipeline"

workflows:
  primary:
    status_report_name: "Custom status name for a workflow"
```

The custom status name must be a maximum of 100 chars long and must match the `^[a-zA-Z0-9,./():\-_ <>[\]|]*$` regex. 