### PR TITLE
Bump version to 2.24.0

### DIFF
--- a/version/build.go
+++ b/version/build.go
@@ -1,7 +1,7 @@
 package version
 
 // VERSION is the main CLI version number. It's defined at build time using -ldflags
-var VERSION = "2.23.0"
+var VERSION = "2.24.0"
 
 // BuildNumber is the CI build number that creates the release. It's defined at build time using -ldflags
 var BuildNumber = ""


### PR DESCRIPTION
### Checklist

- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-io/bitrise/blob/master/.github/CONTRIBUTING.md)
- [x] `README.md` is updated with the changes (if needed)

### Context

This PR bumps Bitrise CLI version from 2.23.0 to 2.24.0, to release:
- https://github.com/bitrise-io/bitrise/pull/1013
