### PR TITLE
Add missing deploy step to run_docker_integration_tests step bundle

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -323,6 +323,7 @@ step_bundles:
             mkdir -p "${test_results_dir}"
             cp "${ORIG_BITRISE_DEPLOY_DIR}/${linux_only_test_log_file_name}.xml" "${test_results_dir}/${linux_only_test_log_file_name}.xml"
             echo "${linux_only_test_name_json}" > "${test_results_dir}/test-info.json"
+    - deploy-to-bitrise-io@2: { }
 
   test_binary_build:
     steps:


### PR DESCRIPTION
### Checklist

- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-io/bitrise/blob/master/.github/CONTRIBUTING.md)
- [x] `README.md` is updated with the changes (if needed)

### Version

Requires a *NO* [version update](https://semver.org/)

### Context

This PR adds a deploy step to the run_docker_integration_tests, to report test results status.
