### PR TITLE
Fix CI; pin Go version explicitly

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-golang 1.21
+golang 1.21.13

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -34,10 +34,12 @@ stages:
 workflows:
   run_lint:
     steps:
+    - bundle::setup_repo: { }
     - bundle::run_lint: { }
 
   run_unit_tests_macos:
     steps:
+    - bundle::setup_repo: { }
     - bundle::setup_go_junit_report: { }
     - bundle::run_unit_tests: { }
     meta:
@@ -47,11 +49,13 @@ workflows:
 
   run_unit_tests_linux:
     steps:
+    - bundle::setup_repo: { }
     - bundle::setup_go_junit_report: { }
     - bundle::run_unit_tests: { }
 
   run_integration_tests_macos:
     steps:
+    - bundle::setup_repo: { }
     - bundle::setup_go_junit_report: { }
     - bundle::run_integration_tests: { }
     meta:
@@ -61,22 +65,25 @@ workflows:
 
   run_integration_tests_linux:
     steps:
+    - bundle::setup_repo: { }
     - bundle::setup_go_junit_report: { }
     - bundle::run_integration_tests: { }
 
   run_docker_integration_tests_linux:
     steps:
+    - bundle::setup_repo: { }
     - bundle::setup_go_junit_report: { }
     - bundle::run_docker_integration_tests:
         envs:
         - SRC_DIR_IN_GOPATH: $BITRISE_SOURCE_DIR
     meta:
       bitrise.io:
-        machine_type_id: elite-xl
+        machine_type_id: g2.linux.x-large
         stack: linux-docker-android-20.04  # TODO: Docker tests are failing on Ubuntu 22.04
 
   test_binary_build_macos:
     steps:
+    - bundle::setup_repo: { }
     - bundle::setup_goreleaser: { }
     - bundle::test_binary_build: { }
     meta:
@@ -86,6 +93,7 @@ workflows:
 
   test_binary_build_linux:
     steps:
+    - bundle::setup_repo: { }
     - bundle::setup_goreleaser: { }
     - bundle::test_binary_build: { }
 
@@ -168,9 +176,6 @@ workflows:
 step_bundles:
   run_lint:
     steps:
-    - git-clone@8:
-        inputs:
-        - fetch_tags: "yes"
     - git::https://github.com/bitrise-steplib/steps-check.git:
         inputs:
         - workflow: lint
@@ -179,9 +184,6 @@ step_bundles:
 
   run_unit_tests:
     steps:
-    - git-clone@8:
-        inputs:
-        - fetch_tags: "yes"
     - script@1:
         title: Run unit tests
         inputs:
@@ -218,9 +220,6 @@ step_bundles:
 
   run_integration_tests:
     steps:
-    - git-clone@8:
-        inputs:
-        - fetch_tags: "yes"
     - script@1:
         title: Run integration tests
         inputs:
@@ -268,9 +267,6 @@ step_bundles:
 
   run_docker_integration_tests:
     steps:
-    - git-clone@8:
-        inputs:
-        - fetch_tags: "yes"
     - script@1:
         title: Run integration tests
         inputs:
@@ -309,13 +305,17 @@ step_bundles:
             mkdir -p "${test_results_dir}"
             cp "${ORIG_BITRISE_DEPLOY_DIR}/${linux_only_test_log_file_name}.xml" "${test_results_dir}/${linux_only_test_log_file_name}.xml"
             echo "${linux_only_test_name_json}" > "${test_results_dir}/test-info.json"
+    - script:
+        # The Go + ASDF situation is messed up on the Ubuntu 20 stack. Even though this workflow starts by installing
+        # the correct Go version with ASDF, the first non-Bash-toolkit step (deploy-to-bitrise-io) will fail,
+        # probably because the CLI process (which runs the steps) is already running by the time the Go version is set.
+        title: Ubuntu 20 Go hackery  # TODO: remove this once the workflow is migrated to the Ubuntu 22 stack
+        inputs:
+        - content: rm ~/.asdf/shims/go
     - deploy-to-bitrise-io@2: { }
 
   test_binary_build:
     steps:
-    - git-clone@8:
-        inputs:
-        - fetch_tags: "yes"
     - script@1:
         title: Create snapshot binaries
         deps:
@@ -329,6 +329,21 @@ step_bundles:
             goreleaser release --snapshot --rm-dist
     - deploy-to-bitrise-io@2: { }
 
+  setup_repo:
+    steps:
+    - git-clone@8:
+        inputs:
+        - fetch_tags: "yes"
+    - script:
+        title: Setup Go version
+        inputs:
+        - content: |-
+            #!/bin/bash
+            set -ex
+
+            asdf plugin add golang || true # TODO: can be removed once all workflows are migrated to Ubuntu 22
+            asdf install golang
+
   setup_go_junit_report:
     steps:
     - script@1:
@@ -338,7 +353,7 @@ step_bundles:
             #!/usr/bin/env bash
             set -ex
             go install github.com/jstemmer/go-junit-report/v2@latest
-            asdf reshim golang || true
+            asdf reshim golang
 
   setup_goreleaser:
     steps:
@@ -353,9 +368,10 @@ step_bundles:
               sudo dpkg -i /tmp/goreleaser.deb
             else
               go install github.com/goreleaser/goreleaser@latest
+              asdf reshim golang
             fi
 
 meta:
   bitrise.io:
-    machine_type_id: elite-xl
+    machine_type_id: g2.linux.x-large
     stack: linux-docker-android-22.04


### PR DESCRIPTION
<!--
  Thanks for contributing to the Bitrise CLI!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [ ] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-io/bitrise/blob/master/.github/CONTRIBUTING.md)
- [ ] `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *MAJOR/MINOR/PATCH* [version update](https://semver.org/)

### Context

Go 1.21 is no longer available on the edge stack, builds started to fail.

### Changes

<!-- 
  Details are important, and help maintainers processing your PR.
  Please list additional details, for example:
  - Update dependencies
  - Make `foo` optional in `main.go`
  - `foo` now returns an `error` for better error handling
-->

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->