### PR TITLE
Understand workflow variants when validating the pipeline [CI-4035]

### DIFF
--- a/cli/agent.go
+++ b/cli/agent.go
@@ -114,7 +114,7 @@ func cleanupDirs(dirs []string) error {
 		if err := os.RemoveAll(absPath); err != nil {
 			return fmt.Errorf("cleaning up %s: %w", dir, err)
 		}
-		log.Donef("- Cleaned %s", colorstring.Cyan(expandedPath))
+		log.Donef("- Cleaned %s", colorstring.Cyan("%s", expandedPath))
 	}
 
 	return nil

--- a/cli/docker/container_manager.go
+++ b/cli/docker/container_manager.go
@@ -11,13 +11,14 @@ import (
 	"sync"
 	"time"
 
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/client"
+
 	"github.com/bitrise-io/bitrise/log"
 	"github.com/bitrise-io/bitrise/models"
 	"github.com/bitrise-io/go-utils/command"
 	"github.com/bitrise-io/go-utils/v2/redactwriter"
-	"github.com/docker/docker/api/types"
-	"github.com/docker/docker/api/types/filters"
-	"github.com/docker/docker/client"
 )
 
 type RunningContainer struct {
@@ -267,7 +268,7 @@ func (cm *ContainerManager) login(container models.Container, envs map[string]st
 
 		out, err := command.New("docker", args...).RunAndReturnTrimmedCombinedOutput()
 		if err != nil {
-			cm.logger.Errorf(out)
+			cm.logger.Errorf("%s", out)
 			return fmt.Errorf("run docker login: %w", err)
 		}
 	}
@@ -328,7 +329,7 @@ func (cm *ContainerManager) startContainer(options containerCreateOptions) (*Run
 	cm.logger.Infof("ℹ️ Running command: docker start %s", options.name)
 	out, err := command.New("docker", "start", options.name).RunAndReturnTrimmedCombinedOutput()
 	if err != nil {
-		cm.logger.Errorf(out)
+		cm.logger.Errorf("%s", out)
 		return runningContainer, fmt.Errorf("start docker container (%s): %w", options.name, err)
 	}
 
@@ -349,7 +350,8 @@ func (cm *ContainerManager) createContainer(
 	options containerCreateOptions,
 	envs map[string]string,
 ) error {
-	dockerRunArgs := []string{"create",
+	dockerRunArgs := []string{
+		"create",
 		"--platform", "linux/amd64",
 		fmt.Sprintf("--network=%s", bitriseNetwork),
 	}
@@ -406,7 +408,7 @@ func (cm *ContainerManager) createContainer(
 
 	out, err := command.New("docker", dockerRunArgs...).RunAndReturnTrimmedCombinedOutput()
 	if err != nil {
-		cm.logger.Errorf(out)
+		cm.logger.Errorf("%s", out)
 		return fmt.Errorf("create container (%s): %w", options.name, err)
 	}
 
@@ -460,7 +462,7 @@ func (cm *ContainerManager) pullImage(container models.Container) error {
 	cm.logger.Infof("ℹ️ Running command: docker %s", strings.Join(dockerRunArgs, " "))
 	out, err := command.New("docker", dockerRunArgs...).RunAndReturnTrimmedCombinedOutput()
 	if err != nil {
-		cm.logger.Errorf(out)
+		cm.logger.Errorf("%s", out)
 		return fmt.Errorf("pull container (%s): %w", container.Image, err)
 	}
 	return nil
@@ -495,7 +497,6 @@ func (cm *ContainerManager) getRunningContainer(ctx context.Context, name string
 		return &containers[0], fmt.Errorf("container (%s) is not running", name)
 	}
 	return &containers[0], nil
-
 }
 
 func (cm *ContainerManager) healthCheckContainer(ctx context.Context, container *RunningContainer) error {

--- a/cli/run_util_pipeline_test.go
+++ b/cli/run_util_pipeline_test.go
@@ -41,7 +41,7 @@ pipelines:
   dag:
     workflows:
       a: {}
-      a1: { source: a, inputs: [key: value] }
+      a1: { uses: a, inputs: [key: value] }
       b: { depends_on: [a] }
       c: { depends_on: [a] }
       d: { depends_on: [a] }
@@ -109,7 +109,7 @@ pipelines:
   dag:
     workflows:
       a: {}
-      b: { source: c }
+      b: { uses: c }
 workflows:
   a: {}
 `
@@ -120,7 +120,7 @@ pipelines:
   dag:
     workflows:
       a: {}
-      b: { source: c }
+      b: { uses: c }
 workflows:
   a: {}
   b: {}

--- a/cli/run_util_pipeline_test.go
+++ b/cli/run_util_pipeline_test.go
@@ -112,7 +112,19 @@ pipelines:
       b: { source: c }
 workflows:
   a: {}
+`
+
+const workflowVariantHasTheSameNameAsAnExistingWorkflowForDAGPipeline = `
+format_version: '13'
+pipelines:
+  dag:
+    workflows:
+      a: {}
+      b: { source: c }
+workflows:
+  a: {}
   b: {}
+  c: {}
 `
 
 const duplicatedDependencyDAGPipeline = `
@@ -186,7 +198,12 @@ func TestValidation(t *testing.T) {
 		{
 			name:    "Workflow is missing from the Workflow Variant definition",
 			config:  missingWorkflowInWorkflowVariantDefinitionForDAGPipeline,
-			wantErr: "failed to get Bitrise config (bitrise.yml) from base 64 data: Failed to parse bitrise config, error: workflow (c) defined in pipeline (dag) is not found in the workflow definitions",
+			wantErr: "failed to get Bitrise config (bitrise.yml) from base 64 data: Failed to parse bitrise config, error: workflow (c) referenced in pipeline (dag) in workflow variant (b) is not found in the workflow definitions",
+		},
+		{
+			name:    "Workflow variant has the same name as an existing workflow",
+			config:  workflowVariantHasTheSameNameAsAnExistingWorkflowForDAGPipeline,
+			wantErr: "failed to get Bitrise config (bitrise.yml) from base 64 data: Failed to parse bitrise config, error: workflow (b) defined in pipeline (dag) is a variant of another workflow, but it is also defined as a workflow",
 		},
 		{
 			name:    "Utility workflow is referenced in the DAG pipeline",

--- a/cli/run_util_pipeline_test.go
+++ b/cli/run_util_pipeline_test.go
@@ -41,6 +41,7 @@ pipelines:
   dag:
     workflows:
       a: {}
+      a1: { source: a, inputs: [key: value] }
       b: { depends_on: [a] }
       c: { depends_on: [a] }
       d: { depends_on: [a] }
@@ -97,6 +98,18 @@ pipelines:
       a: {}
       b: { depends_on: [c] }
       c: {}
+workflows:
+  a: {}
+  b: {}
+`
+
+const missingWorkflowInWorkflowVariantDefinitionForDAGPipeline = `
+format_version: '13'
+pipelines:
+  dag:
+    workflows:
+      a: {}
+      b: { source: c }
 workflows:
   a: {}
   b: {}
@@ -168,6 +181,11 @@ func TestValidation(t *testing.T) {
 		{
 			name:    "Workflow is missing from the Workflow definition",
 			config:  missingWorkflowInWorkflowDefinitionForDAGPipeline,
+			wantErr: "failed to get Bitrise config (bitrise.yml) from base 64 data: Failed to parse bitrise config, error: workflow (c) defined in pipeline (dag) is not found in the workflow definitions",
+		},
+		{
+			name:    "Workflow is missing from the Workflow Variant definition",
+			config:  missingWorkflowInWorkflowVariantDefinitionForDAGPipeline,
 			wantErr: "failed to get Bitrise config (bitrise.yml) from base 64 data: Failed to parse bitrise config, error: workflow (c) defined in pipeline (dag) is not found in the workflow definitions",
 		},
 		{

--- a/log/log.go
+++ b/log/log.go
@@ -145,8 +145,8 @@ func (m *defaultLogger) PrintBitriseStartedEvent(plan models.WorkflowRunPlan) {
 		})
 	} else {
 		m.Print()
-		m.Printf("Invocation started at %s", colorstring.Cyan(m.opts.TimeProvider().Format(consoleTimeLayout)))
-		m.Printf("Bitrise CLI version: %s", colorstring.Cyan(plan.Version))
+		m.Printf("Invocation started at %s", colorstring.Cyan("%s", m.opts.TimeProvider().Format(consoleTimeLayout)))
+		m.Printf("Bitrise CLI version: %s", colorstring.Cyan("%s", plan.Version))
 		m.Print()
 		m.Infof("Run modes:")
 		m.Printf("CI mode: %v", colorstring.Cyan("%v", plan.CIMode))
@@ -169,7 +169,7 @@ func (m *defaultLogger) PrintBitriseStartedEvent(plan models.WorkflowRunPlan) {
 			prefix = "Running workflows"
 		}
 
-		m.Printf("%s: %s", prefix, colorstring.Cyan(strings.Join(workflowIDs, " → ")))
+		m.Printf("%s: %s", prefix, colorstring.Cyan("%s", strings.Join(workflowIDs, " → ")))
 	}
 }
 

--- a/models/models.go
+++ b/models/models.go
@@ -82,8 +82,7 @@ type GraphPipelineWorkflowModel struct {
 	AbortOnFail     bool                       `json:"abort_on_fail,omitempty" yaml:"abort_on_fail,omitempty"`
 	RunIf           GraphPipelineRunIfModel    `json:"run_if,omitempty" yaml:"run_if,omitempty"`
 	ShouldAlwaysRun GraphPipelineAlwaysRunMode `json:"should_always_run,omitempty" yaml:"should_always_run,omitempty"`
-	// TODO: the name is not final
-	Source string `json:"source,omitempty" yaml:"source,omitempty"`
+	Uses            string                     `json:"uses,omitempty" yaml:"uses,omitempty"`
 }
 
 type GraphPipelineRunIfModel struct {

--- a/models/models.go
+++ b/models/models.go
@@ -82,6 +82,8 @@ type GraphPipelineWorkflowModel struct {
 	AbortOnFail     bool                       `json:"abort_on_fail,omitempty" yaml:"abort_on_fail,omitempty"`
 	RunIf           GraphPipelineRunIfModel    `json:"run_if,omitempty" yaml:"run_if,omitempty"`
 	ShouldAlwaysRun GraphPipelineAlwaysRunMode `json:"should_always_run,omitempty" yaml:"should_always_run,omitempty"`
+	// TODO: the name is not final
+	Source string `json:"source,omitempty" yaml:"source,omitempty"`
 }
 
 type GraphPipelineRunIfModel struct {
@@ -289,14 +291,14 @@ func (s StepRunResultsModel) error() []StepError {
 }
 
 func formatStatusReasonTimeInterval(timeInterval time.Duration) string {
-	var remaining = int(timeInterval / time.Second)
+	remaining := int(timeInterval / time.Second)
 	h := int(remaining / 3600)
 	remaining = remaining - h*3600
 	m := int(remaining / 60)
 	remaining = remaining - m*60
 	s := remaining
 
-	var formattedTimeInterval = ""
+	formattedTimeInterval := ""
 	if h > 0 {
 		formattedTimeInterval += fmt.Sprintf("%dh ", h)
 	}

--- a/models/models_methods.go
+++ b/models/models_methods.go
@@ -905,7 +905,7 @@ func removeEnvironmentRedundantFields(env *envmanModels.EnvironmentItemModel) er
 			hasOptions = true
 		}
 	}
-	if options.ValueOptions != nil && len(options.ValueOptions) > 0 {
+	if len(options.ValueOptions) > 0 {
 		hasOptions = true
 	}
 	if options.IsRequired != nil {
@@ -929,7 +929,7 @@ func removeEnvironmentRedundantFields(env *envmanModels.EnvironmentItemModel) er
 			hasOptions = true
 		}
 	}
-	if options.Meta != nil && len(options.Meta) > 0 {
+	if len(options.Meta) > 0 {
 		hasOptions = true
 	}
 

--- a/models/models_methods.go
+++ b/models/models_methods.go
@@ -604,10 +604,10 @@ func validateDAGPipeline(pipelineID string, pipeline *PipelineModel, config *Bit
 			return fmt.Errorf("workflow (%s) defined in pipeline (%s) is a utility workflow", pipelineWorkflowID, pipelineID)
 		}
 
-		isWorkflowVariant := pipelineWorkflow.Source != ""
+		isWorkflowVariant := pipelineWorkflow.Uses != ""
 		if isWorkflowVariant {
-			if _, ok := config.Workflows[pipelineWorkflow.Source]; !ok {
-				return fmt.Errorf("workflow (%s) referenced in pipeline (%s) in workflow variant (%s) is not found in the workflow definitions", pipelineWorkflow.Source, pipelineID, pipelineWorkflowID)
+			if _, ok := config.Workflows[pipelineWorkflow.Uses]; !ok {
+				return fmt.Errorf("workflow (%s) referenced in pipeline (%s) in workflow variant (%s) is not found in the workflow definitions", pipelineWorkflow.Uses, pipelineID, pipelineWorkflowID)
 			}
 
 			if _, ok := config.Workflows[pipelineWorkflowID]; ok {

--- a/models/models_methods.go
+++ b/models/models_methods.go
@@ -605,13 +605,18 @@ func validateDAGPipeline(pipelineID string, pipeline *PipelineModel, config *Bit
 		}
 
 		isWorkflowVariant := pipelineWorkflow.Source != ""
-		workflowDefinitionToCheck := pipelineWorkflowID
 		if isWorkflowVariant {
-			workflowDefinitionToCheck = pipelineWorkflow.Source
-		}
+			if _, ok := config.Workflows[pipelineWorkflow.Source]; !ok {
+				return fmt.Errorf("workflow (%s) referenced in pipeline (%s) in workflow variant (%s) is not found in the workflow definitions", pipelineWorkflow.Source, pipelineID, pipelineWorkflowID)
+			}
 
-		if _, ok := config.Workflows[workflowDefinitionToCheck]; !ok {
-			return fmt.Errorf("workflow (%s) defined in pipeline (%s) is not found in the workflow definitions", workflowDefinitionToCheck, pipelineID)
+			if _, ok := config.Workflows[pipelineWorkflowID]; ok {
+				return fmt.Errorf("workflow (%s) defined in pipeline (%s) is a variant of another workflow, but it is also defined as a workflow", pipelineWorkflowID, pipelineID)
+			}
+		} else {
+			if _, ok := config.Workflows[pipelineWorkflowID]; !ok {
+				return fmt.Errorf("workflow (%s) defined in pipeline (%s) is not found in the workflow definitions", pipelineWorkflowID, pipelineID)
+			}
 		}
 
 		uniqueItems := make(map[string]bool)

--- a/models/models_methods.go
+++ b/models/models_methods.go
@@ -365,7 +365,6 @@ func (with *WithModel) Validate(workflowID string, containers, services map[stri
 	}
 
 	return warnings, nil
-
 }
 
 func (workflow *WorkflowModel) Validate() error {
@@ -605,8 +604,14 @@ func validateDAGPipeline(pipelineID string, pipeline *PipelineModel, config *Bit
 			return fmt.Errorf("workflow (%s) defined in pipeline (%s) is a utility workflow", pipelineWorkflowID, pipelineID)
 		}
 
-		if _, ok := config.Workflows[pipelineWorkflowID]; !ok {
-			return fmt.Errorf("workflow (%s) defined in pipeline (%s) is not found in the workflow definitions", pipelineWorkflowID, pipelineID)
+		isWorkflowVariant := pipelineWorkflow.Source != ""
+		workflowDefinitionToCheck := pipelineWorkflowID
+		if isWorkflowVariant {
+			workflowDefinitionToCheck = pipelineWorkflow.Source
+		}
+
+		if _, ok := config.Workflows[workflowDefinitionToCheck]; !ok {
+			return fmt.Errorf("workflow (%s) defined in pipeline (%s) is not found in the workflow definitions", workflowDefinitionToCheck, pipelineID)
 		}
 
 		uniqueItems := make(map[string]bool)
@@ -988,7 +993,7 @@ func MergeEnvironmentWith(env *envmanModels.EnvironmentItemModel, otherEnv envma
 
 	(*env)[key] = otherValue
 
-	//merge options
+	// merge options
 	options, err := env.GetOptions()
 	if err != nil {
 		return err


### PR DESCRIPTION
 [CI-4035]

- introduce `uses` attribute for workflows in a graph pipeline
- validation should behave somewhat differently for those workflow variants
- out intention is to keep this feature experimental for now (meaning it might change in the future, e.g. the naming of field)
- but we would like to start using it internally, and we can't as the current CLI version doesn't consider workflow variants valid (as they miss a definition)

Also:
- there were some linting issues failing the master as well
- some autformatting via `gofumpt` and `goimports` (let me know if they're not welcome 😅 )

<!--
  Thanks for contributing to the Bitrise CLI!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-io/bitrise/blob/master/.github/CONTRIBUTING.md)
- [x] `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *MAJOR/MINOR/PATCH* [version update](https://semver.org/)

### Context

<!--- 
  One sentence summary on why the change is needed.
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->

<!-- Please link the issue that the PR fixes.
Resolves: #GITHUB_ISSUE_ID or https://link_to_the_issue_on_discuss.bitrise.io.
-->

### Changes

<!-- 
  Details are important, and help maintainers processing your PR.
  Please list additional details, for example:
  - Update dependencies
  - Make `foo` optional in `main.go`
  - `foo` now returns an `error` for better error handling
-->

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->

[CI-4035]: https://bitrise.atlassian.net/browse/CI-4035?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ