### PR TITLE
Bump version to 2.25.2

### DIFF
--- a/version/build.go
+++ b/version/build.go
@@ -1,7 +1,7 @@
 package version
 
 // VERSION is the main CLI version number. It's defined at build time using -ldflags
-var VERSION = "2.25.1"
+var VERSION = "2.25.2"
 
 // BuildNumber is the CI build number that creates the release. It's defined at build time using -ldflags
 var BuildNumber = ""


### PR DESCRIPTION
### Checklist

- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-io/bitrise/blob/master/.github/CONTRIBUTING.md)
- [x] `README.md` is updated with the changes (if needed)

### Version

The next version will be 2.25.2

### Context

This PR bumps the CLI version to 2.25.2 to release:
- https://github.com/bitrise-io/bitrise/pull/1033
- https://github.com/bitrise-io/bitrise/pull/1034
- https://github.com/bitrise-io/bitrise/pull/1036
