### PR TITLE
Fix include.repository format

### DIFF
--- a/_tests/integration/helper.go
+++ b/_tests/integration/helper.go
@@ -14,9 +14,8 @@ func binPath() string {
 	return os.Getenv("INTEGRATION_TEST_BINARY_PATH")
 }
 
-func toBase64(t *testing.T, str string) string {
-	bytes := base64.StdEncoding.EncodeToString([]byte(str))
-	return string(bytes)
+func toBase64(str string) string {
+	return base64.StdEncoding.EncodeToString([]byte(str))
 }
 
 func toJSON(t *testing.T, stringStringMap map[string]interface{}) string {
@@ -25,7 +24,7 @@ func toJSON(t *testing.T, stringStringMap map[string]interface{}) string {
 	return string(bytes)
 }
 
-func withRunningTimeCheck(f func(), ms time.Duration) time.Duration {
+func withRunningTimeCheck(f func()) time.Duration {
 	start := time.Now()
 	f()
 	end := time.Now()

--- a/_tests/integration/helper.go
+++ b/_tests/integration/helper.go
@@ -7,11 +7,28 @@ import (
 	"testing"
 	"time"
 
+	"github.com/bitrise-io/bitrise/log"
 	"github.com/stretchr/testify/require"
 )
 
+var binPathStr string
+
 func binPath() string {
-	return os.Getenv("INTEGRATION_TEST_BINARY_PATH")
+	if binPathStr != "" {
+		return binPathStr
+	}
+
+	pth := os.Getenv("INTEGRATION_TEST_BINARY_PATH")
+	if pth == "" {
+		if os.Getenv("CI") == "true" {
+			panic("INTEGRATION_TEST_BINARY_PATH env is required in CI")
+		} else {
+			log.Warn("INTEGRATION_TEST_BINARY_PATH is not set, make sure 'bitrise' binary in your PATH is up-to-date")
+			pth = "bitrise"
+		}
+	}
+	binPathStr = pth
+	return pth
 }
 
 func toBase64(str string) string {

--- a/_tests/integration/json_params_test.go
+++ b/_tests/integration/json_params_test.go
@@ -68,7 +68,7 @@ func Test_JsonParams(t *testing.T) {
 			"workflow": "json_params_test_target",
 		}
 
-		cmd := command.New(binPath(), "run", "--json-params-base64", toBase64(t, toJSON(t, config)))
+		cmd := command.New(binPath(), "run", "--json-params-base64", toBase64(toJSON(t, config)))
 		out, err := cmd.RunAndReturnTrimmedCombinedOutput()
 		require.NoError(t, err, out)
 	}
@@ -80,7 +80,7 @@ func Test_JsonParams(t *testing.T) {
 			"pattern": "json_params_test_target",
 		}
 
-		cmd := command.New(binPath(), "trigger", "--json-params-base64", toBase64(t, toJSON(t, config)))
+		cmd := command.New(binPath(), "trigger", "--json-params-base64", toBase64(toJSON(t, config)))
 		out, err := cmd.RunAndReturnTrimmedCombinedOutput()
 		require.NoError(t, err, out)
 	}

--- a/_tests/integration/modular_config_main.yml
+++ b/_tests/integration/modular_config_main.yml
@@ -4,7 +4,7 @@ default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
 include:
 - path: modular_config_module.yml
 - path: print-hello.yml
-  repository: https://github.com/bitrise-io/test-bitrise-config-modules.git
+  repository: test-bitrise-config-modules
   branch: main
 
 workflows:

--- a/_tests/integration/modular_config_test.go
+++ b/_tests/integration/modular_config_test.go
@@ -54,8 +54,10 @@ func Test_ModularConfig(t *testing.T) {
 
 func Test_ModularConfig_Run_JSON_Logs(t *testing.T) {
 	configPth := "modular_config_main.yml"
+	currentRepositoryURLEnv := "BITRISE_CURRENT_REPOSITORY_URL=https://github.com/bitrise-io/bitrise.git"
 
 	cmd := command.New(binPath(), "run", "print_hello_world", "--config", configPth, "--output-format", "json")
+	cmd.AppendEnvs(currentRepositoryURLEnv)
 	out, err := cmd.RunAndReturnTrimmedCombinedOutput()
 	require.NoError(t, err, out)
 	require.Contains(t, out, "Hello World!")

--- a/_tests/integration/modular_config_test.go
+++ b/_tests/integration/modular_config_test.go
@@ -14,32 +14,39 @@ import (
 func Test_ModularConfig(t *testing.T) {
 	configPth := "modular_config_main.yml"
 	deployDir := os.Getenv("BITRISE_DEPLOY_DIR")
+	currentRepositoryURLEnv := "BITRISE_CURRENT_REPOSITORY_URL=https://github.com/bitrise-io/bitrise.git"
 
 	cmd := command.New(binPath(), "merge", configPth, "-o", deployDir)
+	cmd.AppendEnvs(currentRepositoryURLEnv)
 	out, err := cmd.RunAndReturnTrimmedCombinedOutput()
 	require.NoError(t, err, out)
 
 	cmd = command.New(binPath(), "validate", "--config", configPth)
+	cmd.AppendEnvs(currentRepositoryURLEnv)
 	out, err = cmd.RunAndReturnTrimmedCombinedOutput()
 	require.NoError(t, err, out)
 	require.Equal(t, "Config is valid: \u001B[32;1mtrue\u001B[0m", out)
 
 	cmd = command.New(binPath(), "workflows", "--id-only", "--config", configPth)
+	cmd.AppendEnvs(currentRepositoryURLEnv)
 	out, err = cmd.RunAndReturnTrimmedCombinedOutput()
 	require.NoError(t, err, out)
 	require.Equal(t, "print_hello print_hello_bitrise print_hello_world", out)
 
 	cmd = command.New(binPath(), "run", "print_hello", "--config", configPth)
+	cmd.AppendEnvs(currentRepositoryURLEnv)
 	out, err = cmd.RunAndReturnTrimmedCombinedOutput()
 	require.NoError(t, err, out)
 	require.Contains(t, out, "Hello John Doe!")
 
 	cmd = command.New(binPath(), "run", "print_hello_bitrise", "--config", configPth)
+	cmd.AppendEnvs(currentRepositoryURLEnv)
 	out, err = cmd.RunAndReturnTrimmedCombinedOutput()
 	require.NoError(t, err, out)
 	require.Contains(t, out, "Hello Bitrise!")
 
 	cmd = command.New(binPath(), "run", "print_hello_world", "--config", configPth)
+	cmd.AppendEnvs(currentRepositoryURLEnv)
 	out, err = cmd.RunAndReturnTrimmedCombinedOutput()
 	require.NoError(t, err, out)
 	require.Contains(t, out, "Hello World!")

--- a/_tests/integration/new_trigger_test.go
+++ b/_tests/integration/new_trigger_test.go
@@ -120,7 +120,7 @@ func Test_NewTrigger(t *testing.T) {
 			"format":           "json",
 		}
 
-		cmd := command.New(binPath(), "trigger-check", "--json-params-base64", toBase64(t, toJSON(t, config)))
+		cmd := command.New(binPath(), "trigger-check", "--json-params-base64", toBase64(toJSON(t, config)))
 		out, err := cmd.RunAndReturnTrimmedCombinedOutput()
 		require.NoError(t, err, out)
 		require.Equal(t, `{"pr-source-branch":"pr_source","pr-target-branch":"pr_target","workflow":"pr_source_and_target"}`, out)

--- a/_tests/integration/validate_test.go
+++ b/_tests/integration/validate_test.go
@@ -60,7 +60,7 @@ func Test_ValidateTest(t *testing.T) {
 		elapsed := withRunningTimeCheck(func() {
 			cmd := command.New(binPath(), "validate", "-c", "trigger_params_test_bitrise.yml")
 			out, err = cmd.RunAndReturnTrimmedCombinedOutput()
-		}, runtimeLimit)
+		})
 		require.NoError(t, err)
 		require.Equal(t, "Config is valid: \x1b[32;1mtrue\x1b[0m", out)
 		require.Equal(t, true, elapsed < runtimeLimit, runningTimeMsg, elapsed, elapsed-runtimeLimit)
@@ -76,7 +76,7 @@ func Test_ValidateTest(t *testing.T) {
 		elapsed := withRunningTimeCheck(func() {
 			cmd := command.New(binPath(), "validate", "-c", configPth)
 			out, err = cmd.RunAndReturnTrimmedCombinedOutput()
-		}, runtimeLimit)
+		})
 		require.NoError(t, err)
 		expected := "Config is valid: \x1b[32;1mtrue\x1b[0m\nWarning(s):\n- invalid pipeline ID (invalid:id): doesn't conform to: [A-Za-z0-9-_.]"
 		require.Equal(t, expected, out)
@@ -93,7 +93,7 @@ func Test_ValidateTest(t *testing.T) {
 		elapsed := withRunningTimeCheck(func() {
 			cmd := command.New(binPath(), "validate", "-c", configPth)
 			out, err = cmd.RunAndReturnTrimmedCombinedOutput()
-		}, runtimeLimit)
+		})
 		require.NoError(t, err)
 		expected := "Config is valid: \x1b[32;1mtrue\x1b[0m\nWarning(s):\n- invalid workflow ID (invalid:id): doesn't conform to: [A-Za-z0-9-_.]"
 		require.Equal(t, expected, out)
@@ -110,7 +110,7 @@ func Test_ValidateTest(t *testing.T) {
 		elapsed := withRunningTimeCheck(func() {
 			cmd := command.New(binPath(), "validate", "-c", configPth)
 			out, err = cmd.RunAndReturnTrimmedCombinedOutput()
-		}, runtimeLimit)
+		})
 		require.Error(t, err, out)
 		expected := fmt.Sprintf("Config is valid: \x1b[31;1mfalse\x1b[0m\nError: \x1b[31;1mconfig (%s) is not valid: empty config\x1b[0m", configPth)
 		require.Equal(t, expected, out)
@@ -132,7 +132,7 @@ func Test_ValidateTestJSON(t *testing.T) {
 		elapsed := withRunningTimeCheck(func() {
 			cmd := command.New(binPath(), "validate", "-c", "trigger_params_test_bitrise.yml", "--format", "json")
 			out, err = cmd.RunAndReturnTrimmedCombinedOutput()
-		}, runtimeLimit)
+		})
 		require.NoError(t, err)
 		require.Equal(t, "{\"data\":{\"config\":{\"is_valid\":true}}}", out)
 		require.Equal(t, true, elapsed < runtimeLimit, runningTimeMsg, elapsed, elapsed-runtimeLimit)
@@ -148,7 +148,7 @@ func Test_ValidateTestJSON(t *testing.T) {
 		elapsed := withRunningTimeCheck(func() {
 			cmd := command.New(binPath(), "validate", "-c", configPth, "--format", "json")
 			out, err = cmd.RunAndReturnTrimmedCombinedOutput()
-		}, runtimeLimit)
+		})
 		require.NoError(t, err)
 		expected := "{\"data\":{\"config\":{\"is_valid\":true,\"warnings\":[\"invalid pipeline ID (invalid:id): doesn't conform to: [A-Za-z0-9-_.]\"]}}}"
 		require.Equal(t, expected, out)
@@ -165,7 +165,7 @@ func Test_ValidateTestJSON(t *testing.T) {
 		elapsed := withRunningTimeCheck(func() {
 			cmd := command.New(binPath(), "validate", "-c", configPth, "--format", "json")
 			out, err = cmd.RunAndReturnTrimmedCombinedOutput()
-		}, runtimeLimit)
+		})
 		require.NoError(t, err)
 		expected := "{\"data\":{\"config\":{\"is_valid\":true,\"warnings\":[\"invalid workflow ID (invalid:id): doesn't conform to: [A-Za-z0-9-_.]\"]}}}"
 		require.Equal(t, expected, out)
@@ -182,7 +182,7 @@ func Test_ValidateTestJSON(t *testing.T) {
 		elapsed := withRunningTimeCheck(func() {
 			cmd := command.New(binPath(), "validate", "-c", configPth, "--format", "json")
 			out, err = cmd.RunAndReturnTrimmedCombinedOutput()
-		}, runtimeLimit)
+		})
 		require.Error(t, err, out)
 		expected := fmt.Sprintf("{\"data\":{\"config\":{\"is_valid\":false,\"error\":\"config (%s) is not valid: empty config\"}}}", configPth)
 		require.Equal(t, expected, out)
@@ -199,7 +199,7 @@ func Test_ValidateTestJSON(t *testing.T) {
 		elapsed := withRunningTimeCheck(func() {
 			cmd := command.New(binPath(), "validate", "-c", configPth, "--format", "json")
 			out, err = cmd.RunAndReturnTrimmedCombinedOutput()
-		}, runtimeLimit)
+		})
 		require.Error(t, err, out)
 		expected := fmt.Sprintf("{\"data\":{\"config\":{\"is_valid\":false,\"error\":\"config (%s) is not valid: missing format_version\"}}}", configPth)
 		require.Equal(t, expected, out)
@@ -221,7 +221,7 @@ func Test_SecretValidateTest(t *testing.T) {
 		elapsed := withRunningTimeCheck(func() {
 			cmd := command.New(binPath(), "validate", "-i", "global_flag_test_secrets.yml")
 			out, err = cmd.RunAndReturnTrimmedCombinedOutput()
-		}, runtimeLimit)
+		})
 		require.NoError(t, err)
 		require.Equal(t, "Secret is valid: \x1b[32;1mtrue\x1b[0m", out)
 		require.Equal(t, true, elapsed < runtimeLimit, runningTimeMsg, elapsed, elapsed-runtimeLimit)
@@ -237,7 +237,7 @@ func Test_SecretValidateTest(t *testing.T) {
 		elapsed := withRunningTimeCheck(func() {
 			cmd := command.New(binPath(), "validate", "-i", secretsPth)
 			out, err = cmd.RunAndReturnTrimmedCombinedOutput()
-		}, runtimeLimit)
+		})
 		require.Error(t, err, out)
 		expected := "Secret is valid: \x1b[31;1mfalse\x1b[0m\nError: \x1b[31;1mempty config\x1b[0m"
 		require.Equal(t, expected, out)
@@ -254,7 +254,7 @@ func Test_SecretValidateTest(t *testing.T) {
 		elapsed := withRunningTimeCheck(func() {
 			cmd := command.New(binPath(), "validate", "-i", secretsPth)
 			out, err = cmd.RunAndReturnTrimmedCombinedOutput()
-		}, runtimeLimit)
+		})
 		require.Error(t, err, out)
 		expected := "Secret is valid: \x1b[31;1mfalse\x1b[0m\nError: \x1b[31;1mInvalid inventory format: yaml: unmarshal errors:\n  line 1: cannot unmarshal !!seq into models.EnvsSerializeModel\x1b[0m"
 		require.Equal(t, expected, out)
@@ -277,7 +277,7 @@ func Test_SecretValidateTestJSON(t *testing.T) {
 
 		elapsed := withRunningTimeCheck(func() {
 			out, err = cmd.RunAndReturnTrimmedCombinedOutput()
-		}, runtimeLimit)
+		})
 		require.NoError(t, err)
 		require.Equal(t, "{\"data\":{\"secrets\":{\"is_valid\":true}}}", out)
 		require.Equal(t, true, elapsed < runtimeLimit, runningTimeMsg, elapsed, elapsed-runtimeLimit)
@@ -294,7 +294,7 @@ func Test_SecretValidateTestJSON(t *testing.T) {
 
 		elapsed := withRunningTimeCheck(func() {
 			out, err = cmd.RunAndReturnTrimmedCombinedOutput()
-		}, runtimeLimit)
+		})
 		require.Error(t, err, out)
 		expected := "{\"data\":{\"secrets\":{\"is_valid\":false,\"error\":\"empty config\"}}}"
 		require.Equal(t, expected, out)
@@ -311,7 +311,7 @@ func Test_SecretValidateTestJSON(t *testing.T) {
 		cmd := command.New(binPath(), "validate", "-i", secretsPth, "--format", "json")
 		elapsed := withRunningTimeCheck(func() {
 			out, err = cmd.RunAndReturnTrimmedCombinedOutput()
-		}, runtimeLimit)
+		})
 		require.Error(t, err, out)
 		expected := "{\"data\":{\"secrets\":{\"is_valid\":false,\"error\":\"Invalid inventory format: yaml: unmarshal errors:\\n  line 1: cannot unmarshal !!seq into models.EnvsSerializeModel\"}}}"
 		require.Equal(t, expected, out)

--- a/configmerge/config_reader.go
+++ b/configmerge/config_reader.go
@@ -1,19 +1,23 @@
 package configmerge
 
 import (
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 
 	pathutilV2 "github.com/bitrise-io/go-utils/v2/pathutil"
 	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/config"
 	"github.com/go-git/go-git/v5/plumbing"
 )
 
 type fileReader struct {
+	logger    Logger
 	tmpDir    string
 	repoCache map[string]string
-	logger    Logger
+	repoURL   GitRepoURL
 }
 
 func NewConfigReader(logger Logger) (ConfigReader, error) {
@@ -22,10 +26,16 @@ func NewConfigReader(logger Logger) (ConfigReader, error) {
 		return nil, err
 	}
 
+	repoURL, err := getRepositoryURL()
+	if err != nil {
+		return nil, err
+	}
+
 	return fileReader{
+		logger:    logger,
 		tmpDir:    tmpDir,
 		repoCache: map[string]string{},
-		logger:    logger,
+		repoURL:   *repoURL,
 	}, nil
 }
 
@@ -40,22 +50,24 @@ func (f fileReader) Read(ref ConfigReference) ([]byte, error) {
 		return f.readFileFromFileSystem(pth)
 	}
 
-	repoDir, err := f.cloneGitRepository(ref)
+	repoURL, err := f.createRepoURL(ref.Repository)
 	if err != nil {
 		return nil, err
 	}
 
+	repoDir := filepath.Join(f.tmpDir, ref.RepoKey())
+	if err := f.cloneGitRepository(repoDir, repoURL, ref.Branch, ref.Tag, ref.Commit); err != nil {
+		return nil, err
+	}
+
 	f.setRepo(repoDir, ref)
+
 	pth := filepath.Join(repoDir, ref.Path)
 	return f.readFileFromFileSystem(pth)
 }
 
 func (f fileReader) CleanupRepoDirs() error {
 	return os.RemoveAll(f.tmpDir)
-}
-
-func isLocalReference(reference ConfigReference) bool {
-	return reference.Repository == ""
 }
 
 func (f fileReader) readFileFromFileSystem(name string) ([]byte, error) {
@@ -71,64 +83,75 @@ func (f fileReader) readFileFromFileSystem(name string) ([]byte, error) {
 	return io.ReadAll(file)
 }
 
-func (f fileReader) cloneGitRepository(ref ConfigReference) (string, error) {
-	opts := git.CloneOptions{
-		URL: ref.Repository,
+func (f fileReader) createRepoURL(repoName string) (string, error) {
+	repoURL := f.repoURL
+	pathComponents := strings.Split(repoURL.Path, "/")
+	if len(pathComponents) < 2 {
+		return "", fmt.Errorf("invalid repository path: %s", repoURL.Path)
 	}
-	if ref.Branch != "" {
-		opts.ReferenceName = plumbing.NewBranchReferenceName(ref.Branch)
-	}
+	repoURL.Path = strings.Join(pathComponents[:len(pathComponents)-2], "/") + "/" + repoName + ".git"
 
-	repoDir := filepath.Join(f.tmpDir, ref.RepoKey())
+	return repoURL.URLString(repoURL.OriginalSyntax), nil
+}
+
+func (f fileReader) cloneGitRepository(repoDir, repoURL, branch, tag, commit string) error {
+	opts := git.CloneOptions{
+		URL: repoURL,
+	}
+	if branch != "" {
+		opts.ReferenceName = plumbing.NewBranchReferenceName(branch)
+	}
 
 	repo, cloneErr := git.PlainClone(repoDir, false, &opts)
 	if cloneErr != nil {
-		if !isHttpFormatRepoURL(ref.Repository) {
-			return "", cloneErr
-		}
+		// TODO: revisit error handling
 
 		// Try repo url with ssh syntax
-		repoURL, err := parseGitRepoURL(ref.Repository)
+		gitRepoURL, err := parseGitRepoURL(repoURL)
 		if err != nil {
-			return "", err
+			return cloneErr
 		}
-		if repoURL.User == "" {
-			repoURL.User = "git"
+		if gitRepoURL.OriginalSyntax != HTTPSRepoURLSyntax {
+			return cloneErr
 		}
 
-		opts.URL = generateSCPStyleSSHFormatRepoURL(repoURL)
+		if gitRepoURL.User == "" {
+			gitRepoURL.User = "git"
+		}
+
+		opts.URL = gitRepoURL.URLString(SSHGitRepoURLSyntax)
 		repo, err = git.PlainClone(repoDir, false, &opts)
 		if err != nil {
 			// Return the original error
-			return "", cloneErr
+			return cloneErr
 		}
 	}
 
 	tree, err := repo.Worktree()
 	if err != nil {
-		return "", err
+		return err
 	}
 
-	if ref.Commit != "" {
-		h, err := repo.ResolveRevision(plumbing.Revision(ref.Commit))
+	if commit != "" {
+		h, err := repo.ResolveRevision(plumbing.Revision(commit))
 		if err != nil {
-			return "", err
+			return err
 		}
 
 		if err := tree.Checkout(&git.CheckoutOptions{
 			Hash: *h,
 		}); err != nil {
-			return "", err
+			return err
 		}
-	} else if ref.Tag != "" {
+	} else if tag != "" {
 		if err := tree.Checkout(&git.CheckoutOptions{
-			Branch: plumbing.NewTagReferenceName(ref.Tag),
+			Branch: plumbing.NewTagReferenceName(tag),
 		}); err != nil {
-			return "", err
+			return err
 		}
 	}
 
-	return repoDir, nil
+	return nil
 }
 
 func (f fileReader) getRepo(ref ConfigReference) string {
@@ -137,4 +160,57 @@ func (f fileReader) getRepo(ref ConfigReference) string {
 
 func (f fileReader) setRepo(dir string, ref ConfigReference) {
 	f.repoCache[ref.RepoKey()] = dir
+}
+
+// TODO: review error messages
+func getRepositoryURL() (*GitRepoURL, error) {
+	repo, err := git.PlainOpen(".")
+	if err != nil {
+		return nil, err
+	}
+
+	remotes, err := repo.Remotes()
+	if err != nil {
+		return nil, err
+	}
+	if len(remotes) == 0 {
+		return nil, fmt.Errorf("no remotes found")
+	}
+
+	var remoteConfig *config.RemoteConfig
+	if len(remotes) > 1 {
+		for _, remote := range remotes {
+			c := remote.Config()
+			if c == nil {
+				continue
+			}
+
+			if c.Name == "origin" {
+				remoteConfig = c
+			}
+		}
+	} else if len(remotes) == 1 {
+		defaultRemote := remotes[0]
+		c := defaultRemote.Config()
+		if c == nil {
+			return nil, fmt.Errorf("no remote config found")
+		}
+		remoteConfig = c
+	}
+
+	if remoteConfig == nil {
+		return nil, fmt.Errorf("no default remote config found")
+	}
+
+	if len(remoteConfig.URLs) == 0 {
+		return nil, fmt.Errorf("no remote URLs found")
+	} else if len(remoteConfig.URLs) > 1 {
+		return nil, fmt.Errorf("multiple remote URLs found")
+	}
+
+	return parseGitRepoURL(remoteConfig.URLs[0])
+}
+
+func isLocalReference(reference ConfigReference) bool {
+	return reference.Repository == ""
 }

--- a/configmerge/configmerge_test.go
+++ b/configmerge/configmerge_test.go
@@ -205,11 +205,11 @@ default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
 
 include:
 - path: containers.yml
-  repository: https://github.com/bitrise-io/examples-yamls.git
+  repository: examples-yamls
   branch: dev`),
 				},
 				repoFilesOnBranch: map[string]map[string]map[string][]byte{
-					"https://github.com/bitrise-io/examples-yamls.git": {
+					"examples-yamls": {
 						"dev": {
 							"containers.yml": []byte(`
 containers:

--- a/configmerge/configmerge_test.go
+++ b/configmerge/configmerge_test.go
@@ -254,7 +254,7 @@ type mockConfigReader struct {
 }
 
 func (m mockConfigReader) Read(ref ConfigReference) ([]byte, error) {
-	if isLocalReference(ref) {
+	if ref.IsLocalReference() {
 		return m.readFileFromFileSystem(ref.Path)
 	}
 	return m.readFileFromGitRepository(ref.Repository, ref.Branch, ref.Commit, ref.Tag, ref.Path)

--- a/configmerge/git_url.go
+++ b/configmerge/git_url.go
@@ -22,7 +22,10 @@ type GitRepoURL struct {
 	OriginalSyntax GitRepoURLSyntax
 }
 
-func parseGitRepoURL(gitURL string) (*GitRepoURL, error) {
+func NewGitRepoURL(gitURL string) (*GitRepoURL, error) {
+	var user, host, port, path string
+	var syntax GitRepoURLSyntax
+
 	// https syntax: https://<host>[:<port>]/<path-to-git-repo>
 	if strings.HasPrefix(gitURL, "https://") {
 		u, err := url.Parse(gitURL)
@@ -30,50 +33,47 @@ func parseGitRepoURL(gitURL string) (*GitRepoURL, error) {
 			return nil, err
 		}
 
-		user := ""
 		if u.User != nil {
 			user = u.User.Username()
 		}
 
-		host := u.Hostname()
-		port := u.Port()
-		path := strings.TrimPrefix(u.Path, "/")
-
-		return &GitRepoURL{
-			User:           user,
-			Host:           host,
-			Port:           port,
-			Path:           path,
-			OriginalSyntax: HTTPSRepoURLSyntax,
-		}, nil
-	}
-
-	// scp-like syntax: [<user>@]<host>:<path-to-git-repo>
-	re := regexp.MustCompile(`^(?:(?P<user>[^@]+)@)?(?P<host>[^:]+):(?P<path>.+)$`)
-	matches := re.FindStringSubmatch(gitURL)
-	if matches == nil {
-		return nil, fmt.Errorf("unsupported git URL format: %s", gitURL)
-	}
-	user := ""
-	host := ""
-	path := ""
-
-	for i, name := range re.SubexpNames() {
-		switch name {
-		case "user":
-			user = matches[i]
-		case "host":
-			host = matches[i]
-		case "path":
-			path = matches[i]
+		host = u.Hostname()
+		port = u.Port()
+		path = strings.TrimPrefix(u.Path, "/")
+		syntax = HTTPSRepoURLSyntax
+	} else {
+		// scp-like syntax: [<user>@]<host>:<path-to-git-repo>
+		re := regexp.MustCompile(`^(?:(?P<user>[^@]+)@)?(?P<host>[^:]+):(?P<path>.+)$`)
+		matches := re.FindStringSubmatch(gitURL)
+		if matches == nil {
+			return nil, fmt.Errorf("unsupported git URL format: %s", gitURL)
 		}
+
+		for i, name := range re.SubexpNames() {
+			switch name {
+			case "user":
+				user = matches[i]
+			case "host":
+				host = matches[i]
+			case "path":
+				path = matches[i]
+			}
+		}
+
+		syntax = SSHGitRepoURLSyntax
+	}
+
+	pathComponents := strings.Split(path, "/")
+	if len(pathComponents) < 2 {
+		return nil, fmt.Errorf("repository path (%s) is expected in a 'user/repo_name' format", path)
 	}
 
 	return &GitRepoURL{
 		User:           user,
 		Host:           host,
+		Port:           port,
 		Path:           path,
-		OriginalSyntax: SSHGitRepoURLSyntax,
+		OriginalSyntax: syntax,
 	}, nil
 }
 
@@ -102,4 +102,32 @@ func (u GitRepoURL) URLString(syntax GitRepoURLSyntax) string {
 	}
 
 	return urlBuilder.String()
+}
+
+func (u GitRepoURL) RepoURLForRepo(repoName string) GitRepoURL {
+	if repoName == "" {
+		return GitRepoURL{
+			User:           u.User,
+			Host:           u.Host,
+			Port:           u.Port,
+			Path:           u.Path,
+			OriginalSyntax: u.OriginalSyntax,
+		}
+	}
+
+	var path string
+	pathComponents := strings.Split(u.Path, "/")
+	if len(pathComponents) < 2 {
+		path = repoName + ".git"
+	} else {
+		path = strings.Join(pathComponents[:len(pathComponents)-1], "/") + "/" + repoName + ".git"
+	}
+
+	return GitRepoURL{
+		User:           u.User,
+		Host:           u.Host,
+		Port:           u.Port,
+		Path:           path,
+		OriginalSyntax: u.OriginalSyntax,
+	}
 }

--- a/configmerge/git_url.go
+++ b/configmerge/git_url.go
@@ -23,7 +23,7 @@ type GitRepoURL struct {
 }
 
 func parseGitRepoURL(gitURL string) (*GitRepoURL, error) {
-	// https syntax: http[s]://<host>[:<port>]/<path-to-git-repo>
+	// https syntax: https://<host>[:<port>]/<path-to-git-repo>
 	if strings.HasPrefix(gitURL, "https://") {
 		u, err := url.Parse(gitURL)
 		if err != nil {

--- a/configmerge/git_url_test.go
+++ b/configmerge/git_url_test.go
@@ -61,7 +61,7 @@ func Test_parseGitURL(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := parseGitRepoURL(tt.gitURL)
+			got, err := NewGitRepoURL(tt.gitURL)
 			if tt.wantErr != "" {
 				require.EqualError(t, err, tt.wantErr)
 			} else {
@@ -143,6 +143,66 @@ func TestGitRepoURL_URLString(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := tt.gitRepoURL.URLString(tt.syntax)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestGitRepoURL_RepoURLForRepo(t *testing.T) {
+	tests := []struct {
+		name       string
+		gitRepoURL GitRepoURL
+		repoName   string
+		want       GitRepoURL
+	}{
+		{
+			name: "returns the original git repo url for empty repo name",
+			gitRepoURL: GitRepoURL{
+				User:           "git",
+				Host:           "github.com",
+				Path:           "bitrise-io/bitrise.git",
+				OriginalSyntax: SSHGitRepoURLSyntax,
+			},
+			repoName: "",
+			want: GitRepoURL{
+				User:           "git",
+				Host:           "github.com",
+				Path:           "bitrise-io/bitrise.git",
+				OriginalSyntax: SSHGitRepoURLSyntax,
+			},
+		},
+		{
+			name: "updates repo name for an scp like git repo url",
+			gitRepoURL: GitRepoURL{
+				User:           "git",
+				Host:           "github.com",
+				Path:           "bitrise-io/bitrise.git",
+				OriginalSyntax: SSHGitRepoURLSyntax,
+			},
+			repoName: "envman",
+			want: GitRepoURL{
+				User:           "git",
+				Host:           "github.com",
+				Path:           "bitrise-io/envman.git",
+				OriginalSyntax: SSHGitRepoURLSyntax,
+			},
+		},
+		{
+			name: "updates repo name for a https git repo url",
+			gitRepoURL: GitRepoURL{
+				Host: "github.com",
+				Path: "bitrise-io/bitrise.git",
+			},
+			repoName: "envman",
+			want: GitRepoURL{
+				Host: "github.com",
+				Path: "bitrise-io/envman.git",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.gitRepoURL.RepoURLForRepo(tt.repoName)
 			require.Equal(t, tt.want, got)
 		})
 	}

--- a/configmerge/reference.go
+++ b/configmerge/reference.go
@@ -84,3 +84,7 @@ func (r ConfigReference) Validate() error {
 
 	return nil
 }
+
+func (r ConfigReference) IsLocalReference() bool {
+	return r.Repository == ""
+}


### PR DESCRIPTION
### Checklist

- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-io/bitrise/blob/master/.github/CONTRIBUTING.md)
- [x] `README.md` is updated with the changes (if needed)

### Version

Requires a *PATCH* [version update](https://semver.org/)

### Context

This PR fixes an issue where the Bitrise CLI and the bitrise.io Backend use different formats for the `include.repository` property in the bitrise.yml file.

The Bitrise CLI expects the module's repository URL (`https://github.com/bitrise-io/bitrise.git`), while the Backend supports remote config modules from the same git org only and works with the config module's repository name (`bitrise`).

With this change, Bitrise CLI switches to the repository name format. This is just a format change because under the hood we will still `git clone` remote config modules, the full module repository path is derived from the current project's repository URL.
