### PR TITLE
Bump Bitrise CLI version

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -116,6 +116,20 @@ workflows:
     - AWS_SECRET_ACCESS_KEY: $AWS_SECRET_ACCESS_KEY_PROD
     steps:
     - script@1:
+        title: Validate if Bitrise CLI version matches the git tag
+        inputs:
+        - content: |-
+            #!/bin/bash
+            set -ex
+
+            go build -o ./current_bitrise
+            version=$(./current_bitrise --version)
+            if [[ "$version" != "$BITRISE_GIT_TAG" ]]; then
+              echo "Bitrise CLI version ($version) does not match the git tag ($BITRISE_GIT_TAG)"
+              echo "Please update the Bitrise CLI version to match the git tag"
+              exit 1
+            fi
+    - script@1:
         title: Fetch GCS bucket credentials
         inputs:
         - content: |-

--- a/version/build.go
+++ b/version/build.go
@@ -1,7 +1,7 @@
 package version
 
 // VERSION is the main CLI version number. It's defined at build time using -ldflags
-var VERSION = "2.26.0"
+var VERSION = "2.26.1"
 
 // BuildNumber is the CI build number that creates the release. It's defined at build time using -ldflags
 var BuildNumber = ""


### PR DESCRIPTION
### Checklist

- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-io/bitrise/blob/master/.github/CONTRIBUTING.md)
- [x] `README.md` is updated with the changes (if needed)

### Version

The new version is: 2.26.1

### Context

This PR bumps the Bitrise CLI version from 2.26.0 to 2.26.1 to release:
- https://github.com/bitrise-io/bitrise/pull/1042

Also, the PR adds a new step to the `create-release` workflow to test if the version bump was done before the actual release.
