### PR TITLE
Step bundle inputs

### DIFF
--- a/_tests/integration/step_bundles_test.go
+++ b/_tests/integration/step_bundles_test.go
@@ -1,0 +1,17 @@
+package integration
+
+import (
+	"testing"
+
+	"github.com/bitrise-io/go-utils/command"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStepBundles(t *testing.T) {
+	configPth := "step_bundles_test_bitrise.yml"
+
+	cmd := command.New(binPath(), "run", "test_step_bundle_inputs", "-c", configPth)
+	out, err := cmd.RunAndReturnTrimmedCombinedOutput()
+	require.NoError(t, err, out)
+	require.Contains(t, out, "Hello Bitrise!")
+}

--- a/_tests/integration/step_bundles_test_bitrise.yml
+++ b/_tests/integration/step_bundles_test_bitrise.yml
@@ -1,0 +1,18 @@
+format_version: "18"
+default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
+
+step_bundles:
+  print_hello:
+    inputs:
+    - name: World
+    steps:
+    - script:
+        inputs:
+        - content: echo "Hello $name!"
+
+workflows:
+  test_step_bundle_inputs:
+    steps:
+    - bundle::print_hello:
+        inputs:
+        - name: Bitrise

--- a/cli/run.go
+++ b/cli/run.go
@@ -584,7 +584,12 @@ func createWorkflowRunPlan(
 					return models.WorkflowRunPlan{}, fmt.Errorf("referenced step bundle not defined: %s", bundleID)
 				}
 
-				bundleEnvs := append([]envmanModels.EnvironmentItemModel{}, bundleDefinition.Inputs...)
+				var bundleEnvs []envmanModels.EnvironmentItemModel
+
+				bundleEnvs = append(bundleEnvs, bundleDefinition.Environments...)
+				bundleEnvs = append(bundleEnvs, bundleOverride.Environments...)
+
+				bundleEnvs = append(bundleEnvs, bundleDefinition.Inputs...)
 
 				// Filter undefined bundleOverride inputs
 				bundleDefinitionInputKeys := map[string]bool{}
@@ -606,11 +611,6 @@ func createWorkflowRunPlan(
 						bundleEnvs = append(bundleEnvs, input)
 					}
 				}
-				// ---
-
-				// TODO: deprecate
-				bundleEnvs = append(bundleEnvs, bundleDefinition.Environments...)
-				bundleEnvs = append(bundleEnvs, bundleOverride.Environments...)
 
 				bundleUUID := uuidProvider()
 

--- a/cli/run_test.go
+++ b/cli/run_test.go
@@ -477,6 +477,7 @@ workflows:
 	}
 }
 
+// TODO: test step bundle inputs
 func TestEnvOrders(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/cli/run_test.go
+++ b/cli/run_test.go
@@ -477,7 +477,6 @@ workflows:
 	}
 }
 
-// TODO: test step bundle inputs
 func TestEnvOrders(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -592,7 +591,45 @@ workflows:
             fi`,
 		},
 		{
-			name: "Step Bundle definition's env var overrides secrets, app, workflow and step output env vars with the same env key",
+			name: "Step Bundle definition's inputs overrides secrets, app, workflow and step output env vars with the same env key",
+			secrets: `
+envs:
+- ENV_ORDER_TEST: "should be the 1."`,
+			config: `
+format_version: "15"
+default_step_lib_source: "https://github.com/bitrise-io/bitrise-steplib.git"
+
+app:
+  envs:
+  - ENV_ORDER_TEST: "should be the 2."
+
+step_bundles:
+  test-bundle:
+    inputs:
+    - ENV_ORDER_TEST: "should be the 5."
+    steps:
+    - script:
+        inputs:
+        - content: |
+            #!/bin/bash
+            set -v
+            echo "ENV_ORDER_TEST: $ENV_ORDER_TEST"
+            if [[ "$ENV_ORDER_TEST" != "should be the 5." ]] ; then
+              exit 1
+            fi
+
+workflows:
+  test:
+    envs:
+    - ENV_ORDER_TEST: "should be the 3."
+    steps:
+    - script:
+        inputs:
+        - content: envman add --key ENV_ORDER_TEST --value "should be the 4."
+    - bundle::test-bundle: {}`,
+		},
+		{
+			name: "Step Bundle definition's envs overrides secrets, app, workflow and step output env vars with the same env key",
 			secrets: `
 envs:
 - ENV_ORDER_TEST: "should be the 1."`,
@@ -630,7 +667,87 @@ workflows:
     - bundle::test-bundle: {}`,
 		},
 		{
-			name: "Step Bundle list item's env var overrides secrets, app, workflow, step output and step bundle definition env vars with the same env key",
+			name: "Step Bundle definition's inputs override Step Bundle definition envs with the same env key",
+			secrets: `
+envs:
+- ENV_ORDER_TEST: "should be the 1."`,
+			config: `
+format_version: "15"
+default_step_lib_source: "https://github.com/bitrise-io/bitrise-steplib.git"
+
+app:
+  envs:
+  - ENV_ORDER_TEST: "should be the 2."
+
+step_bundles:
+  test-bundle:
+    inputs:
+    - ENV_ORDER_TEST: "should be the 6."
+    envs:
+    - ENV_ORDER_TEST: "should be the 5."
+    steps:
+    - script:
+        inputs:
+        - content: |
+            #!/bin/bash
+            set -v
+            echo "ENV_ORDER_TEST: $ENV_ORDER_TEST"
+            if [[ "$ENV_ORDER_TEST" != "should be the 6." ]] ; then
+              exit 1
+            fi
+
+workflows:
+  test:
+    envs:
+    - ENV_ORDER_TEST: "should be the 3."
+    steps:
+    - script:
+        inputs:
+        - content: envman add --key ENV_ORDER_TEST --value "should be the 4."
+    - bundle::test-bundle: {}`,
+		},
+		{
+			name: "Step Bundle list item's inputs overrides secrets, app, workflow, step output and step bundle definition env vars with the same env key",
+			secrets: `
+envs:
+- ENV_ORDER_TEST: "should be the 1."`,
+			config: `
+format_version: "15"
+default_step_lib_source: "https://github.com/bitrise-io/bitrise-steplib.git"
+
+app:
+  envs:
+  - ENV_ORDER_TEST: "should be the 2."
+
+step_bundles:
+  test-bundle:
+    inputs:
+    - ENV_ORDER_TEST: "should be the 5."
+    steps:
+    - script:
+        inputs:
+        - content: |
+            #!/bin/bash
+            set -v
+            echo "ENV_ORDER_TEST: $ENV_ORDER_TEST"
+            if [[ "$ENV_ORDER_TEST" != "should be the 6." ]] ; then
+              exit 1
+            fi
+
+workflows:
+  test:
+    envs:
+    - ENV_ORDER_TEST: "should be the 3."
+    steps:
+    - script:
+        inputs:
+        - content: envman add --key ENV_ORDER_TEST --value "should be the 4."
+    - bundle::test-bundle:
+        inputs:
+        - ENV_ORDER_TEST: "should be the 6."`,
+		},
+		{
+			name: "Step Bundle list item's envs overrides secrets, app, workflow, step output and step bundle definition env vars with the same env key",
 			secrets: `
 envs:
 - ENV_ORDER_TEST: "should be the 1."`,
@@ -670,7 +787,87 @@ workflows:
         - ENV_ORDER_TEST: "should be the 6."`,
 		},
 		{
-			name: "Step Bundle input envs are not shared with the workflow",
+			name: "Step Bundle list item's inputs overrides Step Bundle list item's envs with the same env key",
+			secrets: `
+envs:
+- ENV_ORDER_TEST: "should be the 1."`,
+			config: `
+format_version: "15"
+default_step_lib_source: "https://github.com/bitrise-io/bitrise-steplib.git"
+
+app:
+  envs:
+  - ENV_ORDER_TEST: "should be the 2."
+
+step_bundles:
+  test-bundle:
+    inputs:
+    - ENV_ORDER_TEST: "should be the 6."
+    envs:
+    - ENV_ORDER_TEST: "should be the 5."
+    steps:
+    - script:
+        inputs:
+        - content: |
+            #!/bin/bash
+            set -v
+            echo "ENV_ORDER_TEST: $ENV_ORDER_TEST"
+            if [[ "$ENV_ORDER_TEST" != "should be the 8." ]] ; then
+              exit 1
+            fi
+
+workflows:
+  test:
+    envs:
+    - ENV_ORDER_TEST: "should be the 3."
+    steps:
+    - script:
+        inputs:
+        - content: envman add --key ENV_ORDER_TEST --value "should be the 4."
+    - bundle::test-bundle:
+        inputs:
+        - ENV_ORDER_TEST: "should be the 8."
+        envs:
+        - ENV_ORDER_TEST: "should be the 7."`,
+		},
+		{
+			name: "Step Bundle inputs are not shared with the workflow",
+			config: `
+format_version: "15"
+default_step_lib_source: "https://github.com/bitrise-io/bitrise-steplib.git"
+
+step_bundles:
+  test-bundle:
+    inputs:
+    - ENV_ORDER_TEST: "should be the 2."
+    steps:
+    - script:
+        inputs:
+        - content: |
+            #!/bin/bash
+            set -v
+            echo "ENV_ORDER_TEST: $ENV_ORDER_TEST"
+
+workflows:
+  test:
+    envs:
+    - ENV_ORDER_TEST: "should be the 1."
+    steps:
+    - bundle::test-bundle:
+        inputs:
+        - ENV_ORDER_TEST: "should be the 3."
+    - script:
+        inputs:
+        - content: |
+            #!/bin/bash
+            set -v
+            echo "ENV_ORDER_TEST: $ENV_ORDER_TEST"
+            if [[ "$ENV_ORDER_TEST" != "should be the 1." ]] ; then
+              exit 1
+            fi`,
+		},
+		{
+			name: "Step Bundle envs are not shared with the workflow",
 			config: `
 format_version: "15"
 default_step_lib_source: "https://github.com/bitrise-io/bitrise-steplib.git"
@@ -706,7 +903,7 @@ workflows:
             fi`,
 		},
 		{
-			name: "Step Bundle output envs are shared with the workflow",
+			name: "Step Bundle outputs are shared with the workflow",
 			config: `
 format_version: "15"
 default_step_lib_source: "https://github.com/bitrise-io/bitrise-steplib.git"

--- a/cli/run_util.go
+++ b/cli/run_util.go
@@ -85,7 +85,6 @@ func (r WorkflowRunner) activateAndRunSteps(
 
 	// Global variables for restricting Step Bundle's environment variables for the given Step Bundle
 	currentStepBundleUUID := ""
-	// TODO: add the last step bundle's envs to environments
 	var currentStepBundleEnvVars []envmanModels.EnvironmentItemModel
 
 	// ------------------------------------------

--- a/models/models.go
+++ b/models/models.go
@@ -25,15 +25,13 @@ const (
 )
 
 type StepBundleModel struct {
-	Inputs []envmanModels.EnvironmentItemModel `json:"inputs,omitempty" yaml:"inputs,omitempty"`
-	Steps  []StepListStepItemModel             `json:"steps,omitempty" yaml:"steps,omitempty"`
-	// TODO: deprecate
+	Inputs       []envmanModels.EnvironmentItemModel `json:"inputs,omitempty" yaml:"inputs,omitempty"`
 	Environments []envmanModels.EnvironmentItemModel `json:"envs,omitempty" yaml:"envs,omitempty"`
+	Steps        []StepListStepItemModel             `json:"steps,omitempty" yaml:"steps,omitempty"`
 }
 
 type StepBundleListItemModel struct {
-	Inputs []envmanModels.EnvironmentItemModel `json:"inputs,omitempty" yaml:"inputs,omitempty"`
-	// TODO: deprecate
+	Inputs       []envmanModels.EnvironmentItemModel `json:"inputs,omitempty" yaml:"inputs,omitempty"`
 	Environments []envmanModels.EnvironmentItemModel `json:"envs,omitempty" yaml:"envs,omitempty"`
 }
 

--- a/models/models.go
+++ b/models/models.go
@@ -25,11 +25,15 @@ const (
 )
 
 type StepBundleModel struct {
+	Inputs []envmanModels.EnvironmentItemModel `json:"inputs,omitempty" yaml:"inputs,omitempty"`
+	Steps  []StepListStepItemModel             `json:"steps,omitempty" yaml:"steps,omitempty"`
+	// TODO: deprecate
 	Environments []envmanModels.EnvironmentItemModel `json:"envs,omitempty" yaml:"envs,omitempty"`
-	Steps        []StepListStepItemModel             `json:"steps,omitempty" yaml:"steps,omitempty"`
 }
 
 type StepBundleListItemModel struct {
+	Inputs []envmanModels.EnvironmentItemModel `json:"inputs,omitempty" yaml:"inputs,omitempty"`
+	// TODO: deprecate
 	Environments []envmanModels.EnvironmentItemModel `json:"envs,omitempty" yaml:"envs,omitempty"`
 }
 

--- a/models/models_methods.go
+++ b/models/models_methods.go
@@ -130,7 +130,6 @@ func (bundle *StepBundleModel) Normalize() error {
 		bundle.Inputs[i] = input
 	}
 
-	// TODO: deprecate
 	for i, env := range bundle.Environments {
 		if err := env.Normalize(); err != nil {
 			return err
@@ -149,7 +148,6 @@ func (bundle *StepBundleListItemModel) Normalize() error {
 		bundle.Inputs[i] = input
 	}
 
-	// TODO: deprecate
 	for i, env := range bundle.Environments {
 		if err := env.Normalize(); err != nil {
 			return err
@@ -330,7 +328,6 @@ func (bundle *StepBundleListItemModel) Validate(stepBundleDefinition StepBundleM
 		}
 	}
 
-	// TODO: deprecate
 	for _, env := range bundle.Environments {
 		if err := env.Validate(); err != nil {
 			return err
@@ -368,7 +365,6 @@ func (bundle *StepBundleModel) Validate() ([]string, error) {
 		}
 	}
 
-	// TODO: deprecate
 	for _, env := range bundle.Environments {
 		if err := env.Validate(); err != nil {
 			return warnings, err

--- a/models/models_methods.go
+++ b/models/models_methods.go
@@ -123,22 +123,40 @@ func (bundle *StepBundleModel) Normalize() error {
 		bundle.Steps[idx] = stepListItem
 	}
 
+	for i, input := range bundle.Inputs {
+		if err := input.Normalize(); err != nil {
+			return err
+		}
+		bundle.Inputs[i] = input
+	}
+
+	// TODO: deprecate
 	for i, env := range bundle.Environments {
 		if err := env.Normalize(); err != nil {
 			return err
 		}
 		bundle.Environments[i] = env
 	}
+
 	return nil
 }
 
 func (bundle *StepBundleListItemModel) Normalize() error {
+	for i, input := range bundle.Inputs {
+		if err := input.Normalize(); err != nil {
+			return err
+		}
+		bundle.Inputs[i] = input
+	}
+
+	// TODO: deprecate
 	for i, env := range bundle.Environments {
 		if err := env.Normalize(); err != nil {
 			return err
 		}
 		bundle.Environments[i] = env
 	}
+
 	return nil
 }
 
@@ -290,6 +308,13 @@ func (config *BitriseDataModel) Normalize() error {
 // --- Validate
 
 func (bundle *StepBundleListItemModel) Validate() error {
+	for _, input := range bundle.Inputs {
+		if err := input.Validate(); err != nil {
+			return err
+		}
+	}
+
+	// TODO: deprecate
 	for _, env := range bundle.Environments {
 		if err := env.Validate(); err != nil {
 			return err
@@ -300,12 +325,8 @@ func (bundle *StepBundleListItemModel) Validate() error {
 }
 
 func (bundle *StepBundleModel) Validate() ([]string, error) {
-	for _, env := range bundle.Environments {
-		if err := env.Validate(); err != nil {
-			return nil, err
-		}
-	}
 	var warnings []string
+
 	for _, stepListItem := range bundle.Steps {
 		stepID, step, err := stepListItem.GetStepIDAndStep()
 		if err != nil {
@@ -324,6 +345,20 @@ func (bundle *StepBundleModel) Validate() ([]string, error) {
 			return warnings, err
 		}
 	}
+
+	for _, input := range bundle.Inputs {
+		if err := input.Validate(); err != nil {
+			return warnings, err
+		}
+	}
+
+	// TODO: deprecate
+	for _, env := range bundle.Environments {
+		if err := env.Validate(); err != nil {
+			return warnings, err
+		}
+	}
+
 	return warnings, nil
 }
 

--- a/models/models_methods_test.go
+++ b/models/models_methods_test.go
@@ -18,6 +18,7 @@ import (
 // ----------------------------
 // --- Validate
 
+// TODO: test step bundle inputs
 func TestJSONMarshal(t *testing.T) {
 	tests := []struct {
 		name   string
@@ -947,6 +948,7 @@ workflows:
 	}
 }
 
+// TODO: test step bundle inputs
 func TestValidateConfig_StepBundles(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -1029,7 +1031,7 @@ workflows:
     steps:
     - bundle::non-existing-bundle: {}
 `),
-			wantErr: "step-bundle (non-existing-bundle) referenced in workflow (print-hellos), but this step-bundle is not defined",
+			wantErr: "step bundle (non-existing-bundle) referenced in workflow (print-hellos), but this step-bundle is not defined",
 		},
 	}
 	for _, tt := range tests {

--- a/models/models_methods_test.go
+++ b/models/models_methods_test.go
@@ -18,7 +18,6 @@ import (
 // ----------------------------
 // --- Validate
 
-// TODO: test step bundle inputs
 func TestJSONMarshal(t *testing.T) {
 	tests := []struct {
 		name   string
@@ -177,6 +176,14 @@ project_type: other
 
 step_bundles:
   print-hello:
+    inputs:
+    - NAME: World
+      opts:
+        is_expand: false
+        meta:
+          bitrise.io:
+            stack: osx-xcode-16.0.x-edge
+            machine_type_id: g2-m1-max.10core
     envs:
     - NAME: World
       opts:
@@ -216,6 +223,14 @@ workflows:
         inputs:
         - content: echo "Hello, $NAME!"
     - bundle::print-hello:
+        inputs:
+        - NAME: Universe
+          opts:
+            is_expand: false
+            meta:
+              bitrise.io:
+                stack: osx-xcode-16.0.x-edge
+                machine_type_id: g2-m1-max.10core
         envs:
         - NAME: Universe
           opts:
@@ -948,7 +963,6 @@ workflows:
 	}
 }
 
-// TODO: test step bundle inputs
 func TestValidateConfig_StepBundles(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -964,6 +978,10 @@ project_type: other
 
 step_bundles:
   print-hello:
+    inputs:
+    - NAME: World
+      opts:
+        is_expand: false
     envs:
     - NAME: World
       opts:
@@ -983,6 +1001,8 @@ workflows:
         inputs:
         - content: echo "Hello, $NAME!"
     - bundle::print-hello:
+        inputs:
+        - NAME: Universe
         envs:
         - NAME: Universe
 `),
@@ -1011,7 +1031,7 @@ workflows:
 			wantErr: "step bundle has empty ID defined",
 		},
 		{
-			name: "Invalid bitrise.yml: non-existing container referenced",
+			name: "Invalid bitrise.yml: non-existing step bundle referenced",
 			config: createConfig(t, `
 format_version: "15"
 default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
@@ -1032,6 +1052,31 @@ workflows:
     - bundle::non-existing-bundle: {}
 `),
 			wantErr: "step bundle (non-existing-bundle) referenced in workflow (print-hellos), but this step-bundle is not defined",
+		},
+		{
+			name: "Invalid bitrise.yml: non-existing step bundle input set",
+			config: createConfig(t, `
+format_version: "15"
+default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
+project_type: other
+
+step_bundles:
+  print-hello:
+    inputs:
+    - NAME: World
+    steps:
+    - script:
+        inputs:
+        - content: echo "Hello, $NAME!"
+
+workflows:
+  print-hellos:
+    steps:
+    - bundle::print-hello:
+        inputs:
+        - FIRST_NAME: Universe
+`),
+			wantErr: "step bundle (print-hello) referenced in workflow (print-hellos) has config issue: input (FIRST_NAME) is not defined in the step bundle definition",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
### Checklist

- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-io/bitrise/blob/master/.github/CONTRIBUTING.md)
- [x] `README.md` is updated with the changes (if needed)

### Version

Requires a *MINOR* [version update](https://semver.org/)

### Context

This PR introduces `inputs` for Step Bundles.

Currently, Step Bundles can be configured with `envs`. The new `inputs` are meant to replace `envs` in the future to unify how different entities in bitrise.yml can be configured.

Step Bundle related analytics are under an update to contain information about the actual usage of Step Bundle `envs`, based on the data we either just remove `envs` from bitrise.yml or deprecate it in a later PR. For now `inputs` and `envs` live next to each other, but `inputs` have priority over `envs` (a Step Bundle input overrides a Step Bundle env with the same key).

The only difference between inputs and envs is that inputs need to be defined on the step bundle, to be able to step value when used in a workflow.