### PR TITLE
Clean up container test workarounds

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -318,13 +318,6 @@ step_bundles:
             mkdir -p "${test_results_dir}"
             cp "${ORIG_BITRISE_DEPLOY_DIR}/${linux_only_test_log_file_name}.xml" "${test_results_dir}/${linux_only_test_log_file_name}.xml"
             echo "${linux_only_test_name_json}" > "${test_results_dir}/test-info.json"
-    - script:
-        # The Go + ASDF situation is messed up on the Ubuntu 20 stack. Even though this workflow starts by installing
-        # the correct Go version with ASDF, the first non-Bash-toolkit step (deploy-to-bitrise-io) will fail,
-        # probably because the CLI process (which runs the steps) is already running by the time the Go version is set.
-        title: Ubuntu 20 Go hackery  # TODO: remove this once the workflow is migrated to the Ubuntu 22 stack
-        inputs:
-        - content: rm ~/.asdf/shims/go
     - deploy-to-bitrise-io@2: { }
 
   test_binary_build:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -76,10 +76,6 @@ workflows:
     - bundle::run_docker_integration_tests:
         envs:
         - SRC_DIR_IN_GOPATH: $BITRISE_SOURCE_DIR
-    # meta:
-    #   bitrise.io:
-    #     machine_type_id: g2.linux.x-large
-    #     stack: linux-docker-android-20.04  # TODO: Docker tests are failing on Ubuntu 22.04
 
   test_binary_build_macos:
     steps:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -76,10 +76,10 @@ workflows:
     - bundle::run_docker_integration_tests:
         envs:
         - SRC_DIR_IN_GOPATH: $BITRISE_SOURCE_DIR
-    meta:
-      bitrise.io:
-        machine_type_id: g2.linux.x-large
-        stack: linux-docker-android-20.04  # TODO: Docker tests are failing on Ubuntu 22.04
+    # meta:
+    #   bitrise.io:
+    #     machine_type_id: g2.linux.x-large
+    #     stack: linux-docker-android-20.04  # TODO: Docker tests are failing on Ubuntu 22.04
 
   test_binary_build_macos:
     steps:


### PR DESCRIPTION
<!--
  Thanks for contributing to the Bitrise CLI!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [ ] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-io/bitrise/blob/master/.github/CONTRIBUTING.md)
- [ ] `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *MAJOR/MINOR/PATCH* [version update](https://semver.org/)

### Context

We had mysterious test failures when the container integration tests were running on the Ubuntu 22 stack. This no longer happens (I have no idea why or which component was the root cause), but the workarounds are no longer necessary.

### Changes

<!-- 
  Details are important, and help maintainers processing your PR.
  Please list additional details, for example:
  - Update dependencies
  - Make `foo` optional in `main.go`
  - `foo` now returns an `error` for better error handling
-->

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->