### PR TITLE
Bump CLI version and bitrise.yml format version

### DIFF
--- a/models/models.go
+++ b/models/models.go
@@ -19,7 +19,7 @@ const (
 )
 
 const (
-	FormatVersion                   = "18"
+	FormatVersion                   = "19"
 	StepListItemWithKey             = "with"
 	StepListItemStepBundleKeyPrefix = "bundle::"
 )

--- a/version/build.go
+++ b/version/build.go
@@ -1,7 +1,7 @@
 package version
 
 // VERSION is the main CLI version number. It's defined at build time using -ldflags
-var VERSION = "2.26.1"
+var VERSION = "2.27.0"
 
 // BuildNumber is the CI build number that creates the release. It's defined at build time using -ldflags
 var BuildNumber = ""


### PR DESCRIPTION
### Checklist

- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-io/bitrise/blob/master/.github/CONTRIBUTING.md)
- [x] `README.md` is updated with the changes (if needed)

### Version

The next version will be: 2.27.0

### Context

This PR bumps the CLi version to 2.27.0 and the bitrise.yml format version to 19, to release:
- https://github.com/bitrise-io/bitrise/pull/1045
