### PR TITLE
Add debug logs for the config merge process

### DIFF
--- a/configmerge/config_reader.go
+++ b/configmerge/config_reader.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 
 	"github.com/bitrise-io/bitrise/log"
-	pathutilV2 "github.com/bitrise-io/go-utils/v2/pathutil"
+	"github.com/bitrise-io/go-utils/v2/pathutil"
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/config"
 	"github.com/go-git/go-git/v5/plumbing"
@@ -25,7 +25,7 @@ type fileReader struct {
 }
 
 func NewConfigReader(logger log.Logger) (ConfigReader, error) {
-	tmpDir, err := pathutilV2.NewPathProvider().CreateTempDir("config-merge")
+	tmpDir, err := pathutil.NewPathProvider().CreateTempDir("config-merge")
 	if err != nil {
 		return nil, err
 	}
@@ -75,8 +75,8 @@ func (f *fileReader) Read(ref ConfigReference) ([]byte, error) {
 
 	moduleGitRepoURL := f.repoURL.RepoURLForRepo(ref.Repository)
 	moduleRepoURL := moduleGitRepoURL.URLString(moduleGitRepoURL.OriginalSyntax)
-	f.logger.Debugf("cloning repository '%s' %s", moduleRepoURL, cloneRepoStateText)
 	repoDir := filepath.Join(f.tmpDir, ref.RepoKey())
+	f.logger.Debugf("cloning repository '%s' %s into %s", moduleRepoURL, cloneRepoStateText, repoDir)
 	if err := f.cloneGitRepository(repoDir, moduleRepoURL, ref.Branch, ref.Tag, ref.Commit); err != nil {
 		return nil, err
 	}

--- a/configmerge/config_reader.go
+++ b/configmerge/config_reader.go
@@ -18,7 +18,7 @@ const (
 )
 
 type fileReader struct {
-	logger    log.Logger
+	logger    Logger
 	tmpDir    string
 	repoCache map[string]string
 	repoURL   *GitRepoURL
@@ -31,7 +31,7 @@ func NewConfigReader(logger log.Logger) (ConfigReader, error) {
 	}
 
 	return &fileReader{
-		logger:    logger,
+		logger:    newDebugLogger(logger),
 		tmpDir:    tmpDir,
 		repoCache: map[string]string{},
 	}, nil

--- a/configmerge/config_reader.go
+++ b/configmerge/config_reader.go
@@ -84,7 +84,7 @@ func (f *fileReader) Read(ref ConfigReference) ([]byte, error) {
 	f.setRepo(repoDir, ref)
 
 	pth := filepath.Join(repoDir, ref.Path)
-	f.logger.Debugf("reading config module (%s) from a cloned repository: %s", ref.Path, pth)
+	f.logger.Debugf("reading config module '%s' from a cloned repository: %s", ref.Path, pth)
 	return f.readFileFromFileSystem(pth)
 }
 

--- a/configmerge/config_reader.go
+++ b/configmerge/config_reader.go
@@ -89,6 +89,7 @@ func (f *fileReader) Read(ref ConfigReference) ([]byte, error) {
 }
 
 func (f *fileReader) CleanupRepoDirs() error {
+	f.logger.Debugf("Cleaning up modular config local cache dir: %s", f.tmpDir)
 	return os.RemoveAll(f.tmpDir)
 }
 

--- a/configmerge/configmerge.go
+++ b/configmerge/configmerge.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/bitrise-io/bitrise/log"
 	"github.com/bitrise-io/bitrise/models"
 	"github.com/bitrise-io/go-utils/sliceutil"
 	"gopkg.in/yaml.v2"
@@ -44,18 +45,14 @@ type ConfigReader interface {
 	CleanupRepoDirs() error
 }
 
-type Logger interface {
-	Warnf(format string, args ...interface{})
-}
-
 type Merger struct {
 	configReader ConfigReader
-	logger       Logger
+	logger       log.Logger
 
 	filesCount int
 }
 
-func NewMerger(configReader ConfigReader, logger Logger) Merger {
+func NewMerger(configReader ConfigReader, logger log.Logger) Merger {
 	return Merger{
 		configReader: configReader,
 		logger:       logger,
@@ -65,9 +62,11 @@ func NewMerger(configReader ConfigReader, logger Logger) Merger {
 func (m *Merger) MergeConfig(mainConfigPth string) (string, *models.ConfigFileTreeModel, error) {
 	defer func() {
 		if err := m.configReader.CleanupRepoDirs(); err != nil {
-			m.logger.Warnf("Failed to cleanup repo dirs: %s", err)
+			m.logger.Warnf("Failed to cleanup modular config local cache dir: %s", err)
 		}
 	}()
+
+	m.logger.Debugf("Merge config modules included in %s", mainConfigPth)
 
 	mainConfigRef := ConfigReference{
 		Path: mainConfigPth,
@@ -78,11 +77,14 @@ func (m *Merger) MergeConfig(mainConfigPth string) (string, *models.ConfigFileTr
 		return "", nil, err
 	}
 
+	m.logger.Debugf("Building config tree")
+
 	configTree, err := m.buildConfigTree(mainConfigBytes, mainConfigRef, 1, nil)
 	if err != nil {
 		return "", nil, err
 	}
 
+	m.logger.Debugf("Merging config tree")
 	mergedConfigContent, err := configTree.Merge()
 	if err != nil {
 		return "", nil, err

--- a/configmerge/configmerge.go
+++ b/configmerge/configmerge.go
@@ -85,6 +85,7 @@ func (m *Merger) MergeConfig(mainConfigPth string) (string, *models.ConfigFileTr
 	}
 
 	m.logger.Debugf("Merging config tree")
+
 	mergedConfigContent, err := configTree.Merge()
 	if err != nil {
 		return "", nil, err

--- a/configmerge/configmerge.go
+++ b/configmerge/configmerge.go
@@ -47,7 +47,7 @@ type ConfigReader interface {
 
 type Merger struct {
 	configReader ConfigReader
-	logger       log.Logger
+	logger       Logger
 
 	filesCount int
 }
@@ -55,7 +55,7 @@ type Merger struct {
 func NewMerger(configReader ConfigReader, logger log.Logger) Merger {
 	return Merger{
 		configReader: configReader,
-		logger:       logger,
+		logger:       newDebugLogger(logger),
 	}
 }
 

--- a/configmerge/configmerge_test.go
+++ b/configmerge/configmerge_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	logV2 "github.com/bitrise-io/go-utils/v2/log"
+	"github.com/bitrise-io/bitrise/log"
 	"github.com/stretchr/testify/require"
 )
 
@@ -120,7 +120,7 @@ include:
 		t.Run(tt.name, func(t *testing.T) {
 			m := &Merger{
 				configReader: tt.configReader,
-				logger:       logV2.NewLogger(),
+				logger:       log.NewLogger(log.GetGlobalLoggerOpts()),
 			}
 			got, _, err := m.MergeConfig(tt.mainConfigPth)
 			if tt.wantErr != "" {
@@ -232,7 +232,7 @@ format_version: "15"
 		t.Run(tt.name, func(t *testing.T) {
 			m := &Merger{
 				configReader: tt.configReader,
-				logger:       logV2.NewLogger(),
+				logger:       log.NewLogger(log.GetGlobalLoggerOpts()),
 			}
 			got, _, err := m.MergeConfig(tt.mainConfigPth)
 			if tt.wantErr != "" {

--- a/configmerge/debug_logger.go
+++ b/configmerge/debug_logger.go
@@ -1,0 +1,36 @@
+package configmerge
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/bitrise-io/bitrise/log"
+)
+
+const timestampLayout = "15:04:05"
+
+type Logger interface {
+	Debugf(format string, args ...interface{})
+	Warnf(format string, args ...interface{})
+}
+
+type debugLogger struct {
+	logger log.Logger
+}
+
+func newDebugLogger(logger log.Logger) Logger {
+	return debugLogger{logger: logger}
+}
+
+func (l debugLogger) Debugf(format string, args ...interface{}) {
+	message := fmt.Sprintf(format, args...)
+	l.logger.Debugf("[%s] %s", l.timestamp(), message)
+}
+
+func (l debugLogger) Warnf(format string, args ...interface{}) {
+	l.logger.Warnf(format, args...)
+}
+
+func (l debugLogger) timestamp() string {
+	return time.Now().Format(timestampLayout)
+}


### PR DESCRIPTION
### Checklist

- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-io/bitrise/blob/master/.github/CONTRIBUTING.md)
- [x] `README.md` is updated with the changes (if needed)

### Version

Requires a *MINOR* [version update](https://semver.org/)

### Context

This PR adds debug logs for the config merge process to support debugging.

The new debug logs look like this:

```
[DEBUG] POST https://step-analytics.bitrise.io/track
[14:48:31] Merge config modules included in bitrise.yml
[14:48:31] reading local config module at: bitrise.yml
[14:48:31] Building config tree
[14:48:31] reading local config module at: ./../config-module/module.yml
[14:48:31] reading remote config module 'module.yml' from repo 'sample-artifacts' on commit '86f6dc5eec51cfcd2e70c0dff19e4ca466e353e5'
[14:48:31] getting current repository url
[14:48:31] current repository url: git@github.com:bitrise-io/config-main.git
[14:48:31] cloning repository 'git@github.com:bitrise-io/sample-artifacts.git' with commit '86f6dc5eec51cfcd2e70c0dff19e4ca466e353e5' into /var/folders/jc/dg8f_wz562qgy5ch5wv692_r0000gn/T/config-merge2005627788/repo:sample-artifacts@commit:86f6dc5eec51cfcd2e70c0dff19e4ca466e353e5
[14:49:25] reading config module 'module.yml' from a cloned repository: /var/folders/jc/dg8f_wz562qgy5ch5wv692_r0000gn/T/config-merge2005627788/repo:sample-artifacts@commit:86f6dc5eec51cfcd2e70c0dff19e4ca466e353e5/module.yml
[14:49:25] Merging config tree
[14:49:25] Cleaning up modular config local cache dir: /var/folders/jc/dg8f_wz562qgy5ch5wv692_r0000gn/T/config-merge2005627788
```