### PR TITLE
Expand and create HTML_REPORT_DIR in agent config mode.

### DIFF
--- a/configs/agent_config.go
+++ b/configs/agent_config.go
@@ -9,10 +9,13 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-const agentConfigFileName = "agent-config.yml"
-const defaultSourceDir = "workspace"
-const defaultDeployDir = "$BITRISE_APP_SLUG/$BITRISE_BUILD_SLUG/artifacts"
-const defaultTestDeployDir = "$BITRISE_APP_SLUG/$BITRISE_BUILD_SLUG/test_results"
+const (
+	agentConfigFileName  = "agent-config.yml"
+	defaultSourceDir     = "workspace"
+	defaultDeployDir     = "$BITRISE_APP_SLUG/$BITRISE_BUILD_SLUG/artifacts"
+	defaultTestDeployDir = "$BITRISE_APP_SLUG/$BITRISE_BUILD_SLUG/test_results"
+	defaultHTMLReportDir = "$BITRISE_APP_SLUG/$BITRISE_BUILD_SLUG/html_reports"
+)
 
 type AgentConfig struct {
 	BitriseDirs BitriseDirs `yaml:"bitrise_dirs"`
@@ -117,6 +120,16 @@ func ReadAgentConfig(configFile string) (AgentConfig, error) {
 		return AgentConfig{}, fmt.Errorf("expand BITRISE_TEST_DEPLOY_DIR value: %s", err)
 	}
 	config.BitriseDirs.TestDeployDir = testDeployDir
+
+	// BITRISE_HTML_REPORT_DIR
+	if config.BitriseDirs.HTMLReportDir == "" {
+		config.BitriseDirs.HTMLReportDir = filepath.Join(config.BitriseDirs.BitriseDataHomeDir, defaultHTMLReportDir)
+	}
+	htmlReportDir, err := normalizePath(config.BitriseDirs.HTMLReportDir)
+	if err != nil {
+		return AgentConfig{}, fmt.Errorf("expand BITRISE_HTML_REPORT_DIR value: %w", err)
+	}
+	config.BitriseDirs.HTMLReportDir = htmlReportDir
 
 	// Hooks
 	if config.Hooks.DoOnBuildStart != "" {

--- a/configs/agent_config_test.go
+++ b/configs/agent_config_test.go
@@ -31,6 +31,7 @@ func TestReadAgentConfig(t *testing.T) {
 					SourceDir:          "/opt/bitrise/workspace/ef7a9665e8b6408b",
 					DeployDir:          "/opt/bitrise/ef7a9665e8b6408b/80b66786-d011-430f-9c68-00e9416a7325/artifacts",
 					TestDeployDir:      "/opt/bitrise/ef7a9665e8b6408b/80b66786-d011-430f-9c68-00e9416a7325/test_results",
+					HTMLReportDir:      "/opt/bitrise/ef7a9665e8b6408b/80b66786-d011-430f-9c68-00e9416a7325/html_reports",
 				},
 				AgentHooks{
 					CleanupOnBuildStart: []string{"$BITRISE_DEPLOY_DIR"},
@@ -50,6 +51,7 @@ func TestReadAgentConfig(t *testing.T) {
 					SourceDir:          "/opt/bitrise/workspace",
 					DeployDir:          "/opt/bitrise/ef7a9665e8b6408b/80b66786-d011-430f-9c68-00e9416a7325/artifacts",
 					TestDeployDir:      "/opt/bitrise/ef7a9665e8b6408b/80b66786-d011-430f-9c68-00e9416a7325/test_results",
+					HTMLReportDir:      "/opt/bitrise/ef7a9665e8b6408b/80b66786-d011-430f-9c68-00e9416a7325/html_reports",
 				},
 				AgentHooks{},
 			},


### PR DESCRIPTION
<!--
  Thanks for contributing to the Bitrise CLI!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-io/bitrise/blob/master/.github/CONTRIBUTING.md)
- [x] `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *PATCH* [version update](https://semver.org/)

### Context

In agent config mode the HTML_REPORT_DIR was not usable, as it was not expanded and created on init. Fixed this oversight.
<!--- 
  One sentence summary on why the change is needed.
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->

<!-- Please link the issue that the PR fixes.
Resolves: #GITHUB_ISSUE_ID or https://link_to_the_issue_on_discuss.bitrise.io.
-->

### Changes

<!-- 
  Details are important, and help maintainers processing your PR.
  Please list additional details, for example:
  - Update dependencies
  - Make `foo` optional in `main.go`
  - `foo` now returns an `error` for better error handling
-->

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->