### PR TITLE
Bump CLI version to 2.30.0

### DIFF
--- a/version/build.go
+++ b/version/build.go
@@ -1,7 +1,7 @@
 package version
 
 // VERSION is the main CLI version number. It's defined at build time using -ldflags
-var VERSION = "2.29.4"
+var VERSION = "2.30.0"
 
 // BuildNumber is the CI build number that creates the release. It's defined at build time using -ldflags
 var BuildNumber = ""


### PR DESCRIPTION
### Checklist

- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-io/bitrise/blob/master/.github/CONTRIBUTING.md)
- [x] `README.md` is updated with the changes (if needed)

### Version

The next release version will be: 2.30.0

### Context

This PR bumps the CLI version from 2.29.4 to 2.30.0, to release:
- https://github.com/bitrise-io/bitrise/pull/1063