### PR TITLE
Update envman dep and envman tool min version to 2.5.3

### DIFF
--- a/bitrise/dependencies.go
+++ b/bitrise/dependencies.go
@@ -191,16 +191,14 @@ func checkIsBitriseToolInstalled(toolname, minVersion string, isInstall bool) er
 
 // CheckIsEnvmanInstalled ...
 func CheckIsEnvmanInstalled(minEnvmanVersion string) error {
-	toolname := "envman"
 	minVersion := minEnvmanVersion
-	return checkIsBitriseToolInstalled(toolname, minVersion, true)
+	return checkIsBitriseToolInstalled(tools.EnvmanToolName, minVersion, true)
 }
 
 // CheckIsStepmanInstalled ...
 func CheckIsStepmanInstalled(minStepmanVersion string) error {
-	toolname := "stepman"
 	minVersion := minStepmanVersion
-	return checkIsBitriseToolInstalled(toolname, minVersion, true)
+	return checkIsBitriseToolInstalled(tools.StepmanToolName, minVersion, true)
 }
 
 func checkIfBrewPackageInstalled(packageName string) bool {

--- a/bitrise/setup.go
+++ b/bitrise/setup.go
@@ -21,7 +21,7 @@ const (
 )
 
 const (
-	minEnvmanVersion  = "2.4.3"
+	minEnvmanVersion  = "2.5.3"
 	minStepmanVersion = "0.16.3"
 )
 

--- a/bitrise/setup.go
+++ b/bitrise/setup.go
@@ -164,11 +164,11 @@ func doSetupBitriseCoreTools() error {
 	log.Infof("Checking Bitrise Core tools...")
 
 	if err := CheckIsEnvmanInstalled(minEnvmanVersion); err != nil {
-		return fmt.Errorf("Envman failed to install: %s", err)
+		return fmt.Errorf("failed to install envman: %s", err)
 	}
 
 	if err := CheckIsStepmanInstalled(minStepmanVersion); err != nil {
-		return fmt.Errorf("Stepman failed to install: %s", err)
+		return fmt.Errorf("failed to install stepman: %s", err)
 	}
 
 	return nil

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ toolchain go1.22.7
 
 require (
 	github.com/bitrise-io/colorstring v0.0.0-20180614154802-a8cd70115192
-	github.com/bitrise-io/envman/v2 v2.5.2
+	github.com/bitrise-io/envman/v2 v2.5.3
 	github.com/bitrise-io/go-steputils/v2 v2.0.0-alpha.19
 	github.com/bitrise-io/go-utils v1.0.13
 	github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.22

--- a/go.sum
+++ b/go.sum
@@ -14,8 +14,8 @@ github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPd
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/bitrise-io/colorstring v0.0.0-20180614154802-a8cd70115192 h1:vSHYT6kCL/iOT9BVuUPm0tVcbW57r5zldLWg0aB7qbQ=
 github.com/bitrise-io/colorstring v0.0.0-20180614154802-a8cd70115192/go.mod h1:CIHVcxZUvsG99XUJV6JlR7okNsMMGY81jMvPC20W+O0=
-github.com/bitrise-io/envman/v2 v2.5.2 h1:NRB5oq4MiYCTIE/73ui+Jnb9xM0A0aIRISIxAasdxMk=
-github.com/bitrise-io/envman/v2 v2.5.2/go.mod h1:N+HmJ9EVvGgCyw2bZ1O+YLltSHHhWemKOcQTssSj7UY=
+github.com/bitrise-io/envman/v2 v2.5.3 h1:ggnqYQOWTNCwdh1aGMiObu6mDKEiyjOvcTXy0W2icNE=
+github.com/bitrise-io/envman/v2 v2.5.3/go.mod h1:N+HmJ9EVvGgCyw2bZ1O+YLltSHHhWemKOcQTssSj7UY=
 github.com/bitrise-io/go-steputils/v2 v2.0.0-alpha.19 h1:zP9oZRZA9JGPELjBcWSzo/nd8g7apc7EBd7KZHHFdvs=
 github.com/bitrise-io/go-steputils/v2 v2.0.0-alpha.19/go.mod h1:/ueNOKnsjcUrlt8Ck75WRNspL7E6nAAylvl9oGJtYio=
 github.com/bitrise-io/go-utils v1.0.13 h1:1QENhTS/JlKH9F7+/nB+TtbTcor6jGrE6cQ4CJWfp5U=

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -3,6 +3,7 @@ package tools
 import (
 	"errors"
 	"fmt"
+	"go/version"
 	"io"
 	"os"
 	"path/filepath"
@@ -22,6 +23,11 @@ import (
 )
 
 const envVarLimitErrorKnowledgeBaseURL = "https://support.bitrise.io/en/articles/9676692-env-var-value-too-large-env-var-list-too-large"
+
+const (
+	EnvmanToolName  = "envman"
+	StepmanToolName = "stepman"
+)
 
 func UnameGOOS() (string, error) {
 	switch runtime.GOOS {
@@ -44,14 +50,29 @@ func UnameGOARCH() (string, error) {
 }
 
 func InstallToolFromGitHub(toolname, githubUser, toolVersion string) error {
+	shouldAddVPrefix := false
+	if toolname == EnvmanToolName {
+		if version.Compare(toolVersion, "2.5.2") >= 0 {
+			shouldAddVPrefix = true
+		}
+	} else if toolname == StepmanToolName {
+		if version.Compare(toolVersion, "0.17.2") >= 0 {
+			shouldAddVPrefix = true
+		}
+	}
+	if shouldAddVPrefix {
+		toolVersion = "v" + toolVersion
+	}
+
 	unameGOOS, err := UnameGOOS()
 	if err != nil {
-		return fmt.Errorf("Failed to determine OS: %s", err)
+		return fmt.Errorf("failed to determine OS: %w", err)
 	}
 	unameGOARCH, err := UnameGOARCH()
 	if err != nil {
-		return fmt.Errorf("Failed to determine ARCH: %s", err)
+		return fmt.Errorf("failed to determine ARCH: %w", err)
 	}
+
 	downloadURL := "https://github.com/" + githubUser + "/" + toolname + "/releases/download/" + toolVersion + "/" + toolname + "-" + unameGOOS + "-" + unameGOARCH
 
 	return InstallFromURL(toolname, downloadURL)

--- a/vendor/github.com/bitrise-io/envman/v2/version/version.go
+++ b/vendor/github.com/bitrise-io/envman/v2/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the main CLI version number. It's defined at build time using -ldflags
-var Version = "2.5.2"
+var Version = "2.5.3"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -35,7 +35,7 @@ github.com/ProtonMail/go-crypto/openpgp/x448
 # github.com/bitrise-io/colorstring v0.0.0-20180614154802-a8cd70115192
 ## explicit
 github.com/bitrise-io/colorstring
-# github.com/bitrise-io/envman/v2 v2.5.2
+# github.com/bitrise-io/envman/v2 v2.5.3
 ## explicit; go 1.22
 github.com/bitrise-io/envman/v2/cli
 github.com/bitrise-io/envman/v2/env


### PR DESCRIPTION
### Checklist

- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-io/bitrise/blob/master/.github/CONTRIBUTING.md)
- [x] `README.md` is updated with the changes (if needed)

### Version

This change will be released under version 2.30.2

### Context

This PR updates the CLI's min envman version. The [new envman version](https://github.com/bitrise-io/envman/releases/tag/v2.5.3) improves error messages related to the env var size limits.
