### PR TITLE
Fix tool version compare

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -248,7 +248,7 @@ step_bundles:
 
             export PR="" PULL_REQUEST_ID=""
             export INTEGRATION_TEST_BINARY_PATH="$current_bitrise"
-            $current_bitrise setup --clean
+            $current_bitrise setup
 
             # Setup per OS test name and log file name
             if [ "$(uname)" = "Linux" ]; then
@@ -295,7 +295,7 @@ step_bundles:
 
             export PR="" PULL_REQUEST_ID=""
             export INTEGRATION_TEST_BINARY_PATH="$current_bitrise"
-            $current_bitrise setup --clean
+            $current_bitrise setup
 
             # Setup per OS test name and log file name
             linux_only_test_name_json='{"test-name":"Linux only integration tests"}'

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -248,7 +248,7 @@ step_bundles:
 
             export PR="" PULL_REQUEST_ID=""
             export INTEGRATION_TEST_BINARY_PATH="$current_bitrise"
-            $current_bitrise setup
+            $current_bitrise setup --clean
 
             # Setup per OS test name and log file name
             if [ "$(uname)" = "Linux" ]; then
@@ -295,7 +295,7 @@ step_bundles:
 
             export PR="" PULL_REQUEST_ID=""
             export INTEGRATION_TEST_BINARY_PATH="$current_bitrise"
-            $current_bitrise setup
+            $current_bitrise setup --clean
 
             # Setup per OS test name and log file name
             linux_only_test_name_json='{"test-name":"Linux only integration tests"}'

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/stretchr/testify v1.10.0
 	github.com/urfave/cli v1.22.15
 	golang.org/x/exp v0.0.0-20240909161429-701f63a606c0
+	golang.org/x/mod v0.21.0
 	golang.org/x/sys v0.29.0
 	gopkg.in/yaml.v2 v2.4.0
 )
@@ -67,7 +68,6 @@ require (
 	go.opentelemetry.io/otel/sdk v1.34.0 // indirect
 	go.opentelemetry.io/otel/trace v1.34.0 // indirect
 	golang.org/x/crypto v0.32.0 // indirect
-	golang.org/x/mod v0.21.0 // indirect
 	golang.org/x/net v0.34.0 // indirect
 	golang.org/x/sync v0.10.0 // indirect
 	golang.org/x/term v0.28.0 // indirect

--- a/tools/tools_test.go
+++ b/tools/tools_test.go
@@ -171,3 +171,59 @@ To increase env var limits please visit: https://support.bitrise.io/en/articles/
 		})
 	}
 }
+
+func Test_createGitHubBinDownloadURL(t *testing.T) {
+	tests := []struct {
+		name        string
+		githubUser  string
+		toolName    string
+		toolVersion string
+		unameGOOS   string
+		unameGOARCH string
+		want        string
+	}{
+		{
+			name:        "envman pre 2.5.2 version",
+			githubUser:  "bitrise-io",
+			toolName:    "envman",
+			toolVersion: "2.5.1",
+			unameGOOS:   "Darwin",
+			unameGOARCH: "arm64",
+			want:        "https://github.com/bitrise-io/envman/releases/download/2.5.1/envman-Darwin-arm64",
+		},
+		{
+			name:        "envman post 2.5.2 version",
+			githubUser:  "bitrise-io",
+			toolName:    "envman",
+			toolVersion: "2.5.2",
+			unameGOOS:   "Darwin",
+			unameGOARCH: "arm64",
+			want:        "https://github.com/bitrise-io/envman/releases/download/v2.5.2/envman-Darwin-arm64",
+		},
+		{
+			name:        "stepman pre 0.17.2 version",
+			githubUser:  "bitrise-io",
+			toolName:    "stepman",
+			toolVersion: "0.17.1",
+			unameGOOS:   "Darwin",
+			unameGOARCH: "arm64",
+			want:        "https://github.com/bitrise-io/stepman/releases/download/0.17.1/stepman-Darwin-arm64",
+		},
+		{
+			name:        "stepman post 0.17.2 version",
+			githubUser:  "bitrise-io",
+			toolName:    "stepman",
+			toolVersion: "0.17.2",
+			unameGOOS:   "Darwin",
+			unameGOARCH: "arm64",
+			want:        "https://github.com/bitrise-io/stepman/releases/download/v0.17.2/stepman-Darwin-arm64",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := createGitHubBinDownloadURL(tt.githubUser, tt.toolName, tt.toolVersion, tt.unameGOOS, tt.unameGOARCH); got != tt.want {
+				t.Errorf("createGitHubBinDownloadURL() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/version/build.go
+++ b/version/build.go
@@ -1,7 +1,7 @@
 package version
 
 // VERSION is the main CLI version number. It's defined at build time using -ldflags
-var VERSION = "2.30.3"
+var VERSION = "2.30.4"
 
 // BuildNumber is the CI build number that creates the release. It's defined at build time using -ldflags
 var BuildNumber = ""


### PR DESCRIPTION
### Checklist

- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-io/bitrise/blob/master/.github/CONTRIBUTING.md)
- [x] `README.md` is updated with the changes (if needed)

### Version

The new version will be 2.30.4

### Context

This PR fixes envman and stepman tool version comparison at tool download URL creation. Also updates the HTTP client's logger to print logs as debug logs, to make `bitrise setup` less noisy.