### PR TITLE
Limit failed step env vars size

### DIFF
--- a/bitrise/util.go
+++ b/bitrise/util.go
@@ -204,7 +204,7 @@ func FailedStepEnvs(failedStepRunResult models.StepRunResultsModel) []envmanMode
 	errorMessage := failedStepRunResult.ErrorStr
 	errorMessage, limited := tools.LimitEnvVarValue(errorMessage, FailedStepErrorMessageEnvVarSizeLimitInBytes)
 	if limited {
-		log.Warnf("Truncating error message to %dKB", FailedStepErrorMessageEnvVarSizeLimitInBytes)
+		log.Warnf("Truncating BITRISE_FAILED_STEP_ERROR_MESSAGE value to %dKB", FailedStepErrorMessageEnvVarSizeLimitInBytes/1024)
 	}
 
 	return []envmanModels.EnvironmentItemModel{

--- a/tools/env.go
+++ b/tools/env.go
@@ -59,3 +59,24 @@ func ExpandEnvItems(toExpand []models.EnvironmentItemModel, externalEnvs []strin
 
 	return expanded, nil
 }
+
+func LimitEnvVarValue(value string, limitInBytes int) (string, bool) {
+	if limitInBytes < 5 {
+		// limit indicator is '...' and
+		// the minimal limit is the length of the indicator + 1 leading and 1 trailing character (1byte each)
+		return value, false
+	}
+
+	if len(value) <= limitInBytes {
+		return value, false
+	}
+
+	// Calculate the length of the prefix and suffix
+	prefixLength := (limitInBytes - 3) / 2
+	suffixLength := limitInBytes - 3 - prefixLength
+
+	// Trim the middle of the value and insert '...'
+	trimmedValue := value[:prefixLength] + "..." + value[len(value)-suffixLength:]
+
+	return trimmedValue, true
+}

--- a/tools/env_test.go
+++ b/tools/env_test.go
@@ -1,0 +1,54 @@
+package tools
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLimitEnvVarValue(t *testing.T) {
+	tests := []struct {
+		name         string
+		value        string
+		limitInBytes int
+		wantValue    string
+		wantLimited  bool
+	}{
+		{
+			name:         "no truncation if value is not exceeding the limit",
+			value:        strings.Repeat("a", 5),
+			limitInBytes: 5,
+			wantValue:    strings.Repeat("a", 5),
+			wantLimited:  false,
+		},
+		{
+			name:         "no truncation below min limit (5 bytes)",
+			value:        strings.Repeat("a", 5),
+			limitInBytes: 4,
+			wantValue:    strings.Repeat("a", 5),
+			wantLimited:  false,
+		},
+		{
+			name:         "truncating to min limit (5 bytes)",
+			value:        strings.Repeat("a", 6),
+			limitInBytes: 5,
+			wantValue:    "a...a",
+			wantLimited:  true,
+		},
+		{
+			name:         "truncating to a limit",
+			value:        strings.Repeat("a", 7),
+			limitInBytes: 6,
+			wantValue:    "a...aa",
+			wantLimited:  true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotValue, gotLimited := LimitEnvVarValue(tt.value, tt.limitInBytes)
+			require.Equal(t, tt.wantValue, gotValue)
+			require.Equal(t, tt.wantLimited, gotLimited)
+		})
+	}
+}

--- a/version/build.go
+++ b/version/build.go
@@ -1,7 +1,7 @@
 package version
 
 // VERSION is the main CLI version number. It's defined at build time using -ldflags
-var VERSION = "2.30.4"
+var VERSION = "2.30.5"
 
 // BuildNumber is the CI build number that creates the release. It's defined at build time using -ldflags
 var BuildNumber = ""


### PR DESCRIPTION
### Checklist

- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-io/bitrise/blob/master/.github/CONTRIBUTING.md)
- [x] `README.md` is updated with the changes (if needed)

### Version

Requires a *PATCH* [version update](https://semver.org/)

### Context

This PR limits the BITRISE_FAILED_STEP_ERROR_MESSAGE env var value to 1KB, because Steps might produce a large error message, which can exceed the env var value and env var list limits.