### PR TITLE
Update version package name

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -18,9 +18,9 @@ builds:
   - goos: linux
     goarch: arm64
   ldflags:
-  - -X github.com/bitrise-io/bitrise/version.VERSION={{ .Version }}
-  - -X github.com/bitrise-io/bitrise/version.Commit={{ .FullCommit }}
-  - -X github.com/bitrise-io/bitrise/version.BuildNumber={{ index .Env "BITRISE_BUILD_NUMBER" }}
+  - -X github.com/bitrise-io/bitrise/v2/version.VERSION={{ .Version }}
+  - -X github.com/bitrise-io/bitrise/v2/version.Commit={{ .FullCommit }}
+  - -X github.com/bitrise-io/bitrise/v2/version.BuildNumber={{ index .Env "BITRISE_BUILD_NUMBER" }}
 
 archives:
   # GitHub release should contain the raw binaries (no zip or tar.gz)

--- a/_tests/integration/docker_test.go
+++ b/_tests/integration/docker_test.go
@@ -63,7 +63,7 @@ func Test_Docker(t *testing.T) {
 			requireErr:   true,
 			requireLogs: []string{
 				"failed to start containers:",
-				"bind: address already in use",
+				"address already in use",
 			},
 		},
 		"docker create succeeds when valid port is provided": {


### PR DESCRIPTION
### Checklist

- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-io/bitrise/blob/master/.github/CONTRIBUTING.md)
- [x] `README.md` is updated with the changes (if needed)

### Version

Requires a *PATCH* [version update](https://semver.org/)

### Context

In version 2.29.2 the project's package was updated to `github.com/bitrise-io/bitrise/v2`, but in the `.goreleaser.yaml` config, the version package's name was not updated. Because of this, no proper version information was built into the binaries, e.g.:
```
$ bitrise version --full

version: 2.30.5
format version: 23
os: darwin (arm64)
go: go1.22.7
build number: 
commit: (devel)
```
This PR fixes the issue by updating the version package name in `.goreleaser.yaml`.
