### PR TITLE
Bump version number to 2.30.6

### DIFF
--- a/version/build.go
+++ b/version/build.go
@@ -1,7 +1,7 @@
 package version
 
 // VERSION is the main CLI version number. It's defined at build time using -ldflags
-var VERSION = "2.30.5"
+var VERSION = "2.30.6"
 
 // BuildNumber is the CI build number that creates the release. It's defined at build time using -ldflags
 var BuildNumber = ""


### PR DESCRIPTION
### Checklist

- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-io/bitrise/blob/master/.github/CONTRIBUTING.md)
- [x] `README.md` is updated with the changes (if needed)

### Version

Requires a *PATCH* [version update](https://semver.org/)

### Context

This PR bumps the CLI version to 2.30.6 to release:
- https://github.com/bitrise-io/bitrise/pull/1076
- https://github.com/bitrise-io/bitrise/pull/1079
