### PR TITLE
[EXPERIMENT] Add performance metrics tracking and reporting

### DIFF
--- a/cli/commands.go
+++ b/cli/commands.go
@@ -115,5 +115,6 @@ var (
 		pluginCommand,
 		envmanCommand,
 		mergeConfigCommand,
+		PerformanceCommand(),
 	}
 )

--- a/cli/performance.go
+++ b/cli/performance.go
@@ -1,0 +1,210 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"sort"
+	"text/tabwriter"
+
+	"github.com/bitrise-io/bitrise/v2/log"
+	"github.com/bitrise-io/bitrise/v2/models"
+	"github.com/urfave/cli"
+)
+
+const (
+	// PerformanceJSONPath is the path where performance data is saved
+	PerformanceJSONPath = ".bitrise/performance_data.json"
+)
+
+// SavePerformanceMetrics saves the performance metrics to a JSON file
+func SavePerformanceMetrics(buildResults models.BuildRunResultsModel) error {
+	if buildResults.PerformanceMetrics == nil {
+		return nil
+	}
+
+	// Create the directory if it doesn't exist
+	dir := ".bitrise"
+	if _, err := os.Stat(dir); os.IsNotExist(err) {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			return err
+		}
+	}
+
+	// Marshal the performance metrics to JSON
+	data, err := json.MarshalIndent(buildResults.PerformanceMetrics, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	// Write to file
+	return os.WriteFile(PerformanceJSONPath, data, 0644)
+}
+
+// LoadPerformanceMetrics loads performance metrics from the JSON file
+func LoadPerformanceMetrics() (*models.BuildPerformanceMetrics, error) {
+	// Check if file exists
+	if _, err := os.Stat(PerformanceJSONPath); os.IsNotExist(err) {
+		return nil, fmt.Errorf("no performance data found - run a workflow first")
+	}
+
+	// Read the file
+	data, err := ioutil.ReadFile(PerformanceJSONPath)
+	if err != nil {
+		return nil, err
+	}
+
+	// Unmarshal the data
+	var metrics models.BuildPerformanceMetrics
+	if err := json.Unmarshal(data, &metrics); err != nil {
+		return nil, err
+	}
+
+	return &metrics, nil
+}
+
+// GenerateTraceProfile generates a Chrome trace profile file from performance metrics
+func GenerateTraceProfile(metrics *models.BuildPerformanceMetrics, outputPath string) error {
+	// Create a new trace profile
+	profile := models.NewTraceProfile(metrics)
+	
+	// Marshal to JSON
+	data, err := json.MarshalIndent(profile, "", "  ")
+	if err != nil {
+		return err
+	}
+	
+	// Ensure directory exists
+	dir := filepath.Dir(outputPath)
+	if dir != "" && dir != "." {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			return err
+		}
+	}
+	
+	// Write to file
+	return os.WriteFile(outputPath, data, 0644)
+}
+
+// PerformanceCommand returns the performance command
+func PerformanceCommand() cli.Command {
+	return cli.Command{
+		Name:    "performance",
+		Aliases: []string{"perf"},
+		Usage:   "Show performance metrics for the last build",
+		Flags: []cli.Flag{
+			cli.IntFlag{
+				Name:  "top",
+				Usage: "Show only the top N slowest steps",
+				Value: 10,
+			},
+			cli.BoolFlag{
+				Name:  "summary",
+				Usage: "Show only the summary",
+			},
+			cli.BoolFlag{
+				Name:  "detailed",
+				Usage: "Show detailed phase timing for each step",
+			},
+			cli.StringFlag{
+				Name:  "trace",
+				Usage: "Generate Chrome trace profile and save to the specified file",
+			},
+		},
+		Action: func(c *cli.Context) error {
+			// Set up the logger
+			logger := log.NewLogger(log.GetGlobalLoggerOpts())
+
+			// Load the performance metrics
+			metrics, err := LoadPerformanceMetrics()
+			if err != nil {
+				return err
+			}
+
+			// Initialize tabwriter for formatted output
+			w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+
+			// Print build summary
+			fmt.Fprintf(w, "Build Performance Summary:\n")
+			fmt.Fprintf(w, "------------------------\n")
+			fmt.Fprintf(w, "Total Build Time:\t%s\n", models.FormatDuration(metrics.TotalTime))
+			fmt.Fprintf(w, "Number of Workflows:\t%d\n", len(metrics.Workflows))
+
+			var totalSteps int
+			for _, wf := range metrics.Workflows {
+				totalSteps += len(wf.Steps)
+			}
+			fmt.Fprintf(w, "Total Steps:\t%d\n\n", totalSteps)
+			w.Flush()
+
+			if !c.Bool("summary") {
+				// Print workflow details
+				fmt.Fprintf(w, "Workflow Performance:\n")
+				fmt.Fprintf(w, "--------------------\n")
+
+				// Sort workflows by execution time
+				sort.Slice(metrics.Workflows, func(i, j int) bool {
+					return metrics.Workflows[i].TotalTime > metrics.Workflows[j].TotalTime
+				})
+
+				for _, wf := range metrics.Workflows {
+					fmt.Fprintf(w, "Workflow: %s\n", wf.WorkflowTitle)
+					fmt.Fprintf(w, "Duration: %s\n", models.FormatDuration(wf.TotalTime))
+					fmt.Fprintf(w, "Steps: %d\n\n", len(wf.Steps))
+				}
+				w.Flush()
+			}
+
+			// Get top slowest steps
+			topN := c.Int("top")
+			slowestSteps := metrics.GetTopNSlowestSteps(topN)
+
+			fmt.Fprintf(w, "Top %d Slowest Steps:\n", topN)
+			fmt.Fprintf(w, "-------------------\n")
+			fmt.Fprintf(w, "Step\tDuration\t%% of Build\n")
+			fmt.Fprintf(w, "----\t--------\t----------\n")
+
+			for _, step := range slowestSteps {
+				percentOfBuild := float64(step.TotalTime.Milliseconds()) / float64(metrics.TotalTime.Milliseconds()) * 100
+				fmt.Fprintf(w, "%s\t%s\t%.1f%%\n", step.StepTitle, models.FormatDuration(step.TotalTime), percentOfBuild)
+			}
+			w.Flush()
+
+			if c.Bool("detailed") {
+				fmt.Fprintf(w, "\nDetailed Phase Timing:\n")
+				fmt.Fprintf(w, "--------------------\n")
+
+				for _, step := range slowestSteps {
+					fmt.Fprintf(w, "Step: %s (Total: %s)\n", step.StepTitle, models.FormatDuration(step.TotalTime))
+
+					// Sort phases by duration
+					sort.Slice(step.Phases, func(i, j int) bool {
+						return step.Phases[i].Duration > step.Phases[j].Duration
+					})
+
+					for _, phase := range step.Phases {
+						percentOfStep := float64(phase.Duration.Milliseconds()) / float64(step.TotalTime.Milliseconds()) * 100
+						fmt.Fprintf(w, "  %s:\t%s\t(%.1f%%)\n", phase.Phase, models.FormatDuration(phase.Duration), percentOfStep)
+					}
+					fmt.Fprintln(w, "")
+				}
+				w.Flush()
+			}
+
+			// Generate trace profile if requested
+			if tracePath := c.String("trace"); tracePath != "" {
+				if err := GenerateTraceProfile(metrics, tracePath); err != nil {
+					logger.Errorf("Failed to generate trace profile: %s", err)
+				} else {
+					logger.Infof("\nTrace profile saved to: %s", tracePath)
+					logger.Infof("You can open this file in Chrome by navigating to chrome://tracing")
+				}
+			}
+			
+			logger.Infof("\nTo improve build performance, focus on optimizing the steps that take the longest time.")
+			return nil
+		},
+	}
+}

--- a/cli/performance.go
+++ b/cli/performance.go
@@ -3,7 +3,6 @@ package cli
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -51,7 +50,7 @@ func LoadPerformanceMetrics() (*models.BuildPerformanceMetrics, error) {
 	}
 
 	// Read the file
-	data, err := ioutil.ReadFile(PerformanceJSONPath)
+	data, err := os.ReadFile(PerformanceJSONPath)
 	if err != nil {
 		return nil, err
 	}
@@ -69,13 +68,13 @@ func LoadPerformanceMetrics() (*models.BuildPerformanceMetrics, error) {
 func GenerateTraceProfile(metrics *models.BuildPerformanceMetrics, outputPath string) error {
 	// Create a new trace profile
 	profile := models.NewTraceProfile(metrics)
-	
+
 	// Marshal to JSON
 	data, err := json.MarshalIndent(profile, "", "  ")
 	if err != nil {
 		return err
 	}
-	
+
 	// Ensure directory exists
 	dir := filepath.Dir(outputPath)
 	if dir != "" && dir != "." {
@@ -83,7 +82,7 @@ func GenerateTraceProfile(metrics *models.BuildPerformanceMetrics, outputPath st
 			return err
 		}
 	}
-	
+
 	// Write to file
 	return os.WriteFile(outputPath, data, 0644)
 }
@@ -202,7 +201,7 @@ func PerformanceCommand() cli.Command {
 					logger.Infof("You can open this file in Chrome by navigating to chrome://tracing")
 				}
 			}
-			
+
 			logger.Infof("\nTo improve build performance, focus on optimizing the steps that take the longest time.")
 			return nil
 		},

--- a/cli/run.go
+++ b/cli/run.go
@@ -336,6 +336,15 @@ func (r WorkflowRunner) runWorkflows(tracker analytics.Tracker) (models.BuildRun
 	// Build finished
 	bitrise.PrintSummary(buildRunResults)
 
+	// Save performance metrics
+	if buildRunResults.PerformanceMetrics != nil {
+		if err := SavePerformanceMetrics(buildRunResults); err != nil {
+			log.Warnf("Failed to save performance metrics: %s", err)
+		} else {
+			log.Infof("Performance metrics saved. Run 'bitrise performance' to view detailed timing information.")
+		}
+	}
+
 	// Trigger WorkflowRunDidFinish
 	buildRunResults.EventName = string(plugins.DidFinishRun)
 	if err := plugins.TriggerEvent(plugins.DidFinishRun, buildRunResults); err != nil {

--- a/models/build_run_results.go
+++ b/models/build_run_results.go
@@ -16,6 +16,7 @@ type BuildRunResultsModel struct {
 	FailedSteps          []StepRunResultsModel `json:"failed_steps" yaml:"failed_steps"`
 	FailedSkippableSteps []StepRunResultsModel `json:"failed_skippable_steps" yaml:"failed_skippable_steps"`
 	SkippedSteps         []StepRunResultsModel `json:"skipped_steps" yaml:"skipped_steps"`
+	PerformanceMetrics   *BuildPerformanceMetrics `json:"performance_metrics,omitempty" yaml:"performance_metrics,omitempty"`
 }
 
 func NewBuildRunResultsModel(workflowID string, start time.Time, projectType string) BuildRunResultsModel {

--- a/models/performance_metrics.go
+++ b/models/performance_metrics.go
@@ -1,0 +1,137 @@
+package models
+
+import (
+	"fmt"
+	"sort"
+	"time"
+)
+
+// StepPhase represents a distinct phase in step execution
+type StepPhase string
+
+const (
+	// StepPhaseActivation is the phase where step is activated (preparing dependencies, etc.)
+	StepPhaseActivation StepPhase = "activation"
+	// StepPhaseEnvPreparation is the phase where environment variables are prepared
+	StepPhaseEnvPreparation StepPhase = "env_preparation"
+	// StepPhaseDependencies is the phase where step dependencies are resolved
+	StepPhaseDependencies StepPhase = "dependencies"
+	// StepPhaseExecution is the phase where step is actually executing its main function
+	StepPhaseExecution StepPhase = "execution"
+	// StepPhaseContainer is the phase for container start/stop
+	StepPhaseContainer StepPhase = "container"
+)
+
+// StepPhaseTiming tracks timing for a specific phase of step execution
+type StepPhaseTiming struct {
+	Phase    StepPhase `json:"phase"`
+	Duration time.Duration `json:"duration_ms"`
+}
+
+// StepPerformanceMetrics captures detailed timing data for a step run
+type StepPerformanceMetrics struct {
+	StepID    string           `json:"step_id"`
+	StepTitle string           `json:"step_title"` 
+	StartTime time.Time        `json:"start_time"`
+	EndTime   time.Time        `json:"end_time"`
+	TotalTime time.Duration    `json:"total_time_ms"`
+	Phases    []StepPhaseTiming `json:"phases"`
+}
+
+// AddPhase adds a phase timing record to the step metrics
+func (spm *StepPerformanceMetrics) AddPhase(phase StepPhase, duration time.Duration) {
+	spm.Phases = append(spm.Phases, StepPhaseTiming{
+		Phase:    phase,
+		Duration: duration,
+	})
+}
+
+// CalculateTotalTime calculates the total time spent in this step
+func (spm *StepPerformanceMetrics) CalculateTotalTime() {
+	spm.TotalTime = spm.EndTime.Sub(spm.StartTime)
+}
+
+// WorkflowPerformanceMetrics captures performance data for an entire workflow execution
+type WorkflowPerformanceMetrics struct {
+	WorkflowID    string                  `json:"workflow_id"`
+	WorkflowTitle string                  `json:"workflow_title"`
+	StartTime     time.Time               `json:"start_time"`
+	EndTime       time.Time               `json:"end_time"`
+	TotalTime     time.Duration           `json:"total_time_ms"`
+	Steps         []StepPerformanceMetrics `json:"steps"`
+}
+
+// AddStep adds a step's performance metrics to the workflow metrics
+func (wpm *WorkflowPerformanceMetrics) AddStep(stepMetrics StepPerformanceMetrics) {
+	wpm.Steps = append(wpm.Steps, stepMetrics)
+}
+
+// CalculateTotalTime calculates the total time spent in this workflow
+func (wpm *WorkflowPerformanceMetrics) CalculateTotalTime() {
+	wpm.TotalTime = wpm.EndTime.Sub(wpm.StartTime)
+}
+
+// SortStepsByExecution sorts steps by execution time in descending order
+func (wpm *WorkflowPerformanceMetrics) SortStepsByExecution() {
+	sort.Slice(wpm.Steps, func(i, j int) bool {
+		return wpm.Steps[i].TotalTime > wpm.Steps[j].TotalTime
+	})
+}
+
+// BuildPerformanceMetrics captures performance data for an entire build execution
+type BuildPerformanceMetrics struct {
+	BuildSlug  string                      `json:"build_slug,omitempty"`
+	StartTime  time.Time                   `json:"start_time"`
+	EndTime    time.Time                   `json:"end_time"`
+	TotalTime  time.Duration               `json:"total_time_ms"`
+	Workflows  []WorkflowPerformanceMetrics `json:"workflows"`
+}
+
+// AddWorkflow adds a workflow's performance metrics to the build metrics
+func (bpm *BuildPerformanceMetrics) AddWorkflow(workflowMetrics WorkflowPerformanceMetrics) {
+	bpm.Workflows = append(bpm.Workflows, workflowMetrics)
+}
+
+// CalculateTotalTime calculates the total time spent in this build
+func (bpm *BuildPerformanceMetrics) CalculateTotalTime() {
+	bpm.TotalTime = bpm.EndTime.Sub(bpm.StartTime)
+}
+
+// GetTopNSlowestSteps returns the top N slowest steps across all workflows
+func (bpm *BuildPerformanceMetrics) GetTopNSlowestSteps(n int) []StepPerformanceMetrics {
+	var allSteps []StepPerformanceMetrics
+	for _, wf := range bpm.Workflows {
+		allSteps = append(allSteps, wf.Steps...)
+	}
+
+	sort.Slice(allSteps, func(i, j int) bool {
+		return allSteps[i].TotalTime > allSteps[j].TotalTime
+	})
+
+	if len(allSteps) < n {
+		return allSteps
+	}
+	return allSteps[:n]
+}
+
+// FormatDuration formats a duration in a human-readable format
+func FormatDuration(d time.Duration) string {
+	if d.Hours() >= 1 {
+		h := int(d.Hours())
+		m := int(d.Minutes()) % 60
+		s := int(d.Seconds()) % 60
+		return fmt.Sprintf("%dh %dm %ds", h, m, s)
+	}
+	if d.Minutes() >= 1 {
+		m := int(d.Minutes())
+		s := int(d.Seconds()) % 60
+		ms := int(d.Milliseconds()) % 1000
+		return fmt.Sprintf("%dm %ds %dms", m, s, ms)
+	}
+	if d.Seconds() >= 1 {
+		s := int(d.Seconds())
+		ms := int(d.Milliseconds()) % 1000
+		return fmt.Sprintf("%ds %dms", s, ms)
+	}
+	return fmt.Sprintf("%dms", d.Milliseconds())
+}

--- a/models/trace_profile.go
+++ b/models/trace_profile.go
@@ -1,0 +1,147 @@
+package models
+
+import (
+	"time"
+)
+
+// TraceEvent represents a single event in a Chrome trace format
+type TraceEvent struct {
+	Name     string    `json:"name"`
+	Cat      string    `json:"cat,omitempty"`
+	Ph       string    `json:"ph"`
+	Ts       int64     `json:"ts"`
+	Dur      int64     `json:"dur,omitempty"`
+	Pid      int       `json:"pid"`
+	Tid      int       `json:"tid"`
+	Args     TraceArgs `json:"args,omitempty"`
+	ID       string    `json:"id,omitempty"`
+	ParentID string    `json:"parentId,omitempty"`
+}
+
+// TraceArgs contains additional data for a trace event
+type TraceArgs struct {
+	StepTitle    string `json:"stepTitle,omitempty"`
+	WorkflowID   string `json:"workflowId,omitempty"`
+	WorkflowName string `json:"workflowName,omitempty"`
+	StepID       string `json:"stepId,omitempty"`
+	Phase        string `json:"phase,omitempty"`
+	Duration     string `json:"duration,omitempty"`
+}
+
+// TraceProfile is a collection of trace events in Chrome trace format
+type TraceProfile struct {
+	TraceEvents     []TraceEvent `json:"traceEvents"`
+	DisplayTimeUnit string       `json:"displayTimeUnit"`
+}
+
+// NewTraceProfile creates a new trace profile from build performance metrics
+func NewTraceProfile(metrics *BuildPerformanceMetrics) *TraceProfile {
+	profile := &TraceProfile{
+		TraceEvents:     []TraceEvent{},
+		DisplayTimeUnit: "ms",
+	}
+
+	// Add build begin/end events
+	buildStartTs := metrics.StartTime.UnixMicro() / 1000
+	buildID := "build_1"
+
+	// Add build begin event
+	profile.TraceEvents = append(profile.TraceEvents, TraceEvent{
+		Name: "Build",
+		Ph:   "b", // Begin event
+		Ts:   buildStartTs,
+		Pid:  1,
+		Tid:  1,
+		ID:   buildID,
+	})
+
+	// Add build end event
+	profile.TraceEvents = append(profile.TraceEvents, TraceEvent{
+		Name: "Build",
+		Ph:   "e", // End event
+		Ts:   metrics.EndTime.UnixMicro() / 1000,
+		Pid:  1,
+		Tid:  1,
+		ID:   buildID,
+	})
+
+	// Add workflow events
+	for wfIdx, workflow := range metrics.Workflows {
+		// workflowID := "workflow_" + workflow.WorkflowID
+		workflowStartTs := workflow.StartTime.UnixMicro() / 1000
+
+		// Add workflow duration event
+		profile.TraceEvents = append(profile.TraceEvents, TraceEvent{
+			Name: workflow.WorkflowTitle,
+			Cat:  "workflow",
+			Ph:   "X", // Complete event with duration
+			Ts:   workflowStartTs,
+			Dur:  workflow.TotalTime.Microseconds() / 1000,
+			Pid:  1,
+			Tid:  wfIdx + 2, // Use different thread IDs for workflows
+			Args: TraceArgs{
+				WorkflowID:   workflow.WorkflowID,
+				WorkflowName: workflow.WorkflowTitle,
+				Duration:     FormatDuration(workflow.TotalTime),
+			},
+		})
+
+		// Add step events
+		for stepIdx, step := range workflow.Steps {
+			stepStartTs := step.StartTime.UnixMicro() / 1000
+
+			// Add step duration event
+			profile.TraceEvents = append(profile.TraceEvents, TraceEvent{
+				Name: step.StepTitle,
+				Cat:  "step",
+				Ph:   "X", // Complete event with duration
+				Ts:   stepStartTs,
+				Dur:  step.TotalTime.Microseconds() / 1000,
+				Pid:  1,
+				Tid:  wfIdx + 2, // Same thread ID as parent workflow
+				Args: TraceArgs{
+					StepTitle:    step.StepTitle,
+					StepID:       step.StepID,
+					WorkflowID:   workflow.WorkflowID,
+					WorkflowName: workflow.WorkflowTitle,
+					Duration:     FormatDuration(step.TotalTime),
+				},
+			})
+
+			// Add phase events
+			for phaseIdx, phase := range step.Phases {
+				phaseStartTs := step.StartTime.Add(time.Duration(calcPhaseStartOffset(step.Phases, phaseIdx))).UnixMicro() / 1000
+
+				profile.TraceEvents = append(profile.TraceEvents, TraceEvent{
+					Name: string(phase.Phase),
+					Cat:  "phase",
+					Ph:   "X", // Complete event with duration
+					Ts:   phaseStartTs,
+					Dur:  phase.Duration.Microseconds() / 1000,
+					Pid:  2,           // Use different process ID for phases
+					Tid:  stepIdx + 2, // Different thread ID for each step's phases
+					Args: TraceArgs{
+						StepTitle:    step.StepTitle,
+						StepID:       step.StepID,
+						Phase:        string(phase.Phase),
+						WorkflowID:   workflow.WorkflowID,
+						WorkflowName: workflow.WorkflowTitle,
+						Duration:     FormatDuration(phase.Duration),
+					},
+				})
+			}
+		}
+	}
+
+	return profile
+}
+
+// calcPhaseStartOffset calculates an approximate offset for a phase within a step
+// This is an approximation since we don't have exact phase ordering information
+func calcPhaseStartOffset(phases []StepPhaseTiming, currentPhaseIdx int) int64 {
+	var offset int64 = 0
+	for i := 0; i < currentPhaseIdx; i++ {
+		offset += phases[i].Duration.Microseconds()
+	}
+	return offset
+}


### PR DESCRIPTION
- Introduced performance metrics for workflows and steps, including timing for various phases.
- Implemented saving and loading of performance metrics to/from a JSON file.
- Added a new command to display performance metrics.

<!--
  Thanks for contributing to the Bitrise CLI!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-io/bitrise/blob/master/.github/CONTRIBUTING.md)
- [x] `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *MAJOR/MINOR/PATCH* [version update](https://semver.org/)

### Context

Add Performance Observability and Profiling to Bitrise CLI

  Summary

  - Adds detailed performance metrics collection during workflow and step execution
  - Introduces a new `bitrise performance` command to visualize performance data
  - Supports Chrome trace profile export for advanced performance analysis
  - Helps users identify and optimize slow steps in their workflows

  Why this change is beneficial

  Users often spend significant time waiting for Bitrise workflows to complete, with little insight into what's causing slowdowns. This change
   provides comprehensive performance metrics to identify bottlenecks and optimize build times.

  The performance observability system:

  1. Identifies bottlenecks: Tracks granular timing metrics for workflows, steps, and specific execution phases (activation, environment
  preparation, execution, container setup)
  2. Provides visualization: The bitrise performance command shows build summary, workflow details, and lists the slowest steps with their
  percentage of total build time
  3. Supports advanced analysis: Users can export Chrome trace profiles to visualize the full execution timeline with the --trace flag,
  enabling sophisticated analysis in Chrome's tracing tool
  4. Minimizes overhead: The instrumentation adds negligible performance impact while providing detailed timing information
  5. Encourages optimization: By highlighting the slowest steps and execution phases, users can focus optimization efforts where they'll have
  the most impact

  This change helps users understand their build performance, make data-driven optimizations, and reduce wait times during development.

  Test plan

  - Run different workflows with various step configurations
  - Verify execution time is accurately captured for all steps
  - Confirm the Performance command displays accurate metrics
  - Validate Chrome trace profiles can be generated and opened in chrome://tracing

How it works:

- Every `bitrise run` generates a performance profile json file, saved into `.bitrise/performance_data.json`
- The new `bitrise performance` command can be used to read this file (the last `bitrise run`'s profile) and present useful statistics from it.
  - `bitrise performance --trage=...` can also convert the performance data JSON into a JSONTraceProfile.