### PR TITLE
Handle arbitrary large env vars correctly

### DIFF
--- a/bitrise/template_util.go
+++ b/bitrise/template_util.go
@@ -37,8 +37,8 @@ func getEnv(key string, envList envmanModels.EnvsJSONListModel) string {
 
 	value, err := envfile.GetEnv(key, envList, envfilePath)
 	if err != nil {
-		// TODO
-		log.Warnf("Failed to get env from envfile: %s", err)
+		log.Warnf("Failed to read env from envfile: %s", err)
+		log.Warnf("Falling back to the current value of $%s", key)
 		return os.Getenv(key)
 	}
 

--- a/bitrise/template_util.go
+++ b/bitrise/template_util.go
@@ -39,6 +39,11 @@ func getEnv(key string, envList envmanModels.EnvsJSONListModel) string {
 	if err != nil {
 		log.Warnf("Failed to read env from envfile: %s", err)
 		log.Warnf("Falling back to the current value of $%s", key)
+		for aKey, value := range envList {
+			if aKey == key {
+				return value
+			}
+		}
 		return os.Getenv(key)
 	}
 

--- a/bitrise/template_util.go
+++ b/bitrise/template_util.go
@@ -24,23 +24,25 @@ type TemplateDataModel struct {
 }
 
 func getEnv(key string, envList envmanModels.EnvsJSONListModel) string {
-	filepath := os.Getenv(envfile.DefaultEnvfilePathEnv)
-	if filepath != "" {
-		_, err := os.Stat(filepath)
-		if errors.Is(err, os.ErrNotExist) {
-			return os.Getenv(key)
+	envfilePath := os.Getenv(envfile.DefaultEnvfilePathEnv)
+	_, err := os.Stat(envfilePath)
+	if errors.Is(err, os.ErrNotExist) {
+		for aKey, value := range envList {
+			if aKey == key {
+				return value
+			}
 		}
-
-		value, err := envfile.GetEnv(key, envList, filepath)
-		if err != nil {
-			// TODO
-			log.Warnf("Failed to get env from envfile: %s", err)
-			return os.Getenv(key)
-		}
-
-		return value
+		return os.Getenv(key)
 	}
-	return os.Getenv(key)
+
+	value, err := envfile.GetEnv(key, envList, envfilePath)
+	if err != nil {
+		// TODO
+		log.Warnf("Failed to get env from envfile: %s", err)
+		return os.Getenv(key)
+	}
+
+	return value
 }
 
 func createTemplateDataModel(isCI, isPR bool, buildResults models.BuildRunResultsModel) TemplateDataModel {

--- a/bitrise/template_util.go
+++ b/bitrise/template_util.go
@@ -31,7 +31,7 @@ func getEnv(key string, envList envmanModels.EnvsJSONListModel) string {
 			return os.Getenv(key)
 		}
 
-		value, err := envfile.GetEnv(key, envList, envfile.DefaultEnvfilePathEnv)
+		value, err := envfile.GetEnv(key, envList, filepath)
 		if err != nil {
 			// TODO
 			log.Warnf("Failed to get env from envfile: %s", err)

--- a/bitrise/template_util.go
+++ b/bitrise/template_util.go
@@ -28,19 +28,19 @@ func getEnv(key string, envList envmanModels.EnvsJSONListModel) string {
 	if filepath != "" {
 		_, err := os.Stat(filepath)
 		if errors.Is(err, os.ErrNotExist) {
-			return envList[key]
+			return os.Getenv(key)
 		}
 
 		value, err := envfile.GetEnv(key, envList, envfile.DefaultEnvfilePathEnv)
 		if err != nil {
 			// TODO
 			log.Warnf("Failed to get env from envfile: %s", err)
-			return envList[key]
+			return os.Getenv(key)
 		}
 
 		return value
 	}
-	return envList[key]
+	return os.Getenv(key)
 }
 
 func createTemplateDataModel(isCI, isPR bool, buildResults models.BuildRunResultsModel) TemplateDataModel {

--- a/cli/run.go
+++ b/cli/run.go
@@ -15,6 +15,7 @@ import (
 	"github.com/bitrise-io/bitrise/v2/bitrise"
 	"github.com/bitrise-io/bitrise/v2/cli/docker"
 	"github.com/bitrise-io/bitrise/v2/configs"
+	"github.com/bitrise-io/bitrise/v2/envfile"
 	"github.com/bitrise-io/bitrise/v2/log"
 	"github.com/bitrise-io/bitrise/v2/models"
 	"github.com/bitrise-io/bitrise/v2/plugins"
@@ -238,6 +239,8 @@ func (r WorkflowRunner) RunWorkflowsWithSetupAndCheckForUpdate() (int, error) {
 
 func (r WorkflowRunner) runWorkflows(tracker analytics.Tracker) (models.BuildRunResultsModel, error) {
 	startTime := time.Now()
+
+	envfile.LogLargeEnvWarning(envfile.DefaultEnvfilePathEnv)
 
 	// Register run modes
 	if err := registerRunModes(r.config.Modes); err != nil {

--- a/cli/run.go
+++ b/cli/run.go
@@ -240,7 +240,7 @@ func (r WorkflowRunner) RunWorkflowsWithSetupAndCheckForUpdate() (int, error) {
 func (r WorkflowRunner) runWorkflows(tracker analytics.Tracker) (models.BuildRunResultsModel, error) {
 	startTime := time.Now()
 
-	envfile.LogLargeEnvWarning(envfile.DefaultEnvfilePathEnv)
+	envfile.LogLargeEnvWarning()
 
 	// Register run modes
 	if err := registerRunModes(r.config.Modes); err != nil {

--- a/cli/run.go
+++ b/cli/run.go
@@ -240,7 +240,7 @@ func (r WorkflowRunner) RunWorkflowsWithSetupAndCheckForUpdate() (int, error) {
 func (r WorkflowRunner) runWorkflows(tracker analytics.Tracker) (models.BuildRunResultsModel, error) {
 	startTime := time.Now()
 
-	envfile.LogLargeEnvWarning()
+	envfile.LogEnvVarLimitIfExceeded()
 
 	// Register run modes
 	if err := registerRunModes(r.config.Modes); err != nil {

--- a/cli/run_util.go
+++ b/cli/run_util.go
@@ -17,6 +17,7 @@ import (
 	"github.com/bitrise-io/bitrise/v2/cli/docker"
 	"github.com/bitrise-io/bitrise/v2/configmerge"
 	"github.com/bitrise-io/bitrise/v2/configs"
+	"github.com/bitrise-io/bitrise/v2/envfile"
 	"github.com/bitrise-io/bitrise/v2/log"
 	"github.com/bitrise-io/bitrise/v2/log/logwriter"
 	"github.com/bitrise-io/bitrise/v2/models"
@@ -231,6 +232,16 @@ func (r WorkflowRunner) activateAndRunStep(
 		if err != nil {
 			err = fmt.Errorf("EnvmanReadEnvList failed, err: %s", err)
 			return newActivateAndRunStepResult(mergedStep, stepInfoPtr, models.StepRunStatusCodePreparationFailed, 1, err, false, map[string]string{}, nil)
+		}
+
+		if true {
+			envfilePath := "TODO"
+			runIfEnvList, err = envfile.MergeEnvfileWithRuntimeEnvs(runIfEnvList, envfilePath)
+			if err != nil {
+				err = fmt.Errorf("restore large envs from envfile: %s", err)
+				return newActivateAndRunStepResult(mergedStep, stepInfoPtr, models.StepRunStatusCodePreparationFailed, 1, err, false, map[string]string{}, nil)
+			}
+			envfile.LogLargeEnvWarning(envfilePath)
 		}
 
 		isRun, err := bitrise.EvaluateTemplateToBool(*mergedStep.RunIf, configs.IsCIMode, configs.IsPullRequestMode, buildRunResults, runIfEnvList)

--- a/cli/run_util.go
+++ b/cli/run_util.go
@@ -17,7 +17,6 @@ import (
 	"github.com/bitrise-io/bitrise/v2/cli/docker"
 	"github.com/bitrise-io/bitrise/v2/configmerge"
 	"github.com/bitrise-io/bitrise/v2/configs"
-	"github.com/bitrise-io/bitrise/v2/envfile"
 	"github.com/bitrise-io/bitrise/v2/log"
 	"github.com/bitrise-io/bitrise/v2/log/logwriter"
 	"github.com/bitrise-io/bitrise/v2/models"
@@ -232,16 +231,6 @@ func (r WorkflowRunner) activateAndRunStep(
 		if err != nil {
 			err = fmt.Errorf("EnvmanReadEnvList failed, err: %s", err)
 			return newActivateAndRunStepResult(mergedStep, stepInfoPtr, models.StepRunStatusCodePreparationFailed, 1, err, false, map[string]string{}, nil)
-		}
-
-		if true {
-			envfilePath := "TODO"
-			runIfEnvList, err = envfile.MergeEnvfileWithRuntimeEnvs(runIfEnvList, envfilePath)
-			if err != nil {
-				err = fmt.Errorf("restore large envs from envfile: %s", err)
-				return newActivateAndRunStepResult(mergedStep, stepInfoPtr, models.StepRunStatusCodePreparationFailed, 1, err, false, map[string]string{}, nil)
-			}
-			envfile.LogLargeEnvWarning(envfilePath)
 		}
 
 		isRun, err := bitrise.EvaluateTemplateToBool(*mergedStep.RunIf, configs.IsCIMode, configs.IsPullRequestMode, buildRunResults, runIfEnvList)

--- a/envfile/envfile.go
+++ b/envfile/envfile.go
@@ -18,13 +18,13 @@ type EnvFile struct {
 	ErasedEnvs []string          `yaml:"erased_envs"`
 }
 
-// GetEnv returns the true value of an env var, even if it was not exposed to the CLI process because of its size.
+// GetEnv returns the true value of an env var, even if its value was erased because of its size.
 // Typical large env vars are git-related build trigger env vars, like BITRISE_GIT_COMMIT_MESSAGES or BITRISE_GIT_CHANGED_FILES.
 // If these were exposed as env vars to the CLI process, the execve() syscall would fail because it has a limit on
 // the size of all env vars and arguments. Instead, the agent launching the Bitrise CLI process clears these env vars and
 // stores their original values in a file on disk.
-// Why is this whole thing not implemented in envman? Because (currently) Bitrise CLI interacts with envman through
-// its CLI interface, so that envman subprocess exec would also fail with the same error when passing large env vars.
+// Why is this whole thing not implemented with envman? Because a step subprocess is started with all env vars (prepared by envman),
+// so that subprocess exec would also fail with the same error when passing large env vars.
 // Note: envfilePath must point to an existing file, you should not call this unconditionally.
 func GetEnv(key string, runtimeEnvs envmanModels.EnvsJSONListModel, envfilePath string) (string, error) {
 	originalBuildTriggerEnvs, err := load(envfilePath)
@@ -54,7 +54,7 @@ func GetEnv(key string, runtimeEnvs envmanModels.EnvsJSONListModel, envfilePath 
 	return runtimeEnvValue, nil
 }
 
-func LogLargeEnvWarning() {
+func LogEnvVarLimitIfExceeded() {
 	path := os.Getenv(DefaultEnvfilePathEnv)
 	if path == "" {
 		// No envfile path set, CLI is probably running outside of Bitrise CI.

--- a/envfile/envfile.go
+++ b/envfile/envfile.go
@@ -1,55 +1,90 @@
 package envfile
 
 import (
+	"errors"
+	"fmt"
 	"os"
 
+	"github.com/bitrise-io/bitrise/v2/log"
 	envmanModels "github.com/bitrise-io/envman/v2/models"
 	"gopkg.in/yaml.v3"
 )
 
+// DefaultEnvfilePathEnv is the env var that points to the (platform-dependent) envfile location.
+const DefaultEnvfilePathEnv = "BITRISEIO_ENVFILE_PATH"
+
 type EnvFile struct {
-	Envs map[string]string `yaml:"envs"`
+	Envs           map[string]string `yaml:"envs"`
+	// TODO: naming
+	ClearedEnvKeys []string          `yaml:"cleared_env_keys"`
 }
 
-func MergeEnvfileWithRuntimeEnvs(runtimeEnvs envmanModels.EnvsJSONListModel, envFilePath string) (map[string]string, error) {
-	originalBuildTriggerEnvs, err := load(envFilePath)
+// GetEnv...
+// Why this is not in envman? Because (currently) Bitrise CLI interacts with envman through
+// its CLI interface, so the subprocess execution 
+// envfilePath must point to an existing file, you should not call this unconditionally.
+func GetEnv(key string, runtimeEnvs envmanModels.EnvsJSONListModel, envfilePath string) (string, error) {
+	originalBuildTriggerEnvs, err := load(envfilePath)
 	if err != nil {
-		return nil, err
+		return "", err
 	}
 
-	for k, v := range runtimeEnvs {
-		if v == "" {
-			// Env var value was possibly cleared because of its length, we should restore it from
-			// the original env file
-			if originalValue, ok := originalBuildTriggerEnvs[k]; ok {
-				runtimeEnvs[k] = originalValue
-			}
+	runtimeEnvValue, ok := runtimeEnvs[key]
+	if !ok {
+		// Same behavior as os.Getenv(key)
+		return "", nil
+	}
+
+	if runtimeEnvValue == "" {
+		// Env var value was possibly cleared because of its length, we should restore it from
+		// the env file
+		if originalValue, ok := originalBuildTriggerEnvs.Envs[key]; ok {
+			return originalValue, nil
 		}
+		// Note: !ok means no original value found in envfile, but this can be a valid case
+		// if somehow one empty env var (value) ends up in runtime envs.
 	}
 
-	return runtimeEnvs, nil
+	// If the value is not empty, it means that it didn't hit the size limit, we can just return it
+	return runtimeEnvValue, nil
 }
 
 func LogLargeEnvWarning(envfilePath string) {
-	
+	originalBuildTriggerEnvs, err := load(envfilePath)
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		// We are on the critical path and should not fail here.
+		log.Warnf("Failed to load envfile at $%s: %s", envfilePath, err)
+		return
+	}
+
+	if len(originalBuildTriggerEnvs.ClearedEnvKeys) == 0 {
+		return
+	}
+
+	clearedEnvList := ""
+	for _, key := range originalBuildTriggerEnvs.ClearedEnvKeys {
+		clearedEnvList += fmt.Sprintf("- %s", key)
+		clearedEnvList += "\n"
+	}
+
+	message := fmt.Sprintf(`Some env vars were removed because their size exceeds system limits.
+If you rely on these env vars in steps, you should read the original values from a file on disk. This file is available at $%s.
+The following env vars were removed and are not available in the runtime environment:
+%s`, DefaultEnvfilePathEnv, clearedEnvList)
+	log.Warnf(message)
 }
 
-func load(filepath string) (map[string]string, error) {
+func load(filepath string) (EnvFile, error) {
 	data, err := os.ReadFile(filepath)
 	if err != nil {
-		return nil, err
+		return EnvFile{}, err
 	}
 
 	var envFile EnvFile
 	err = yaml.Unmarshal(data, &envFile)
 	if err != nil {
-		return nil, err
+		return EnvFile{}, err
 	}
 
-	if envFile.Envs == nil {
-		return make(map[string]string), nil
-	}
-
-	return envFile.Envs, nil
+	return envFile, nil
 }
-

--- a/envfile/envfile.go
+++ b/envfile/envfile.go
@@ -1,0 +1,55 @@
+package envfile
+
+import (
+	"os"
+
+	envmanModels "github.com/bitrise-io/envman/v2/models"
+	"gopkg.in/yaml.v3"
+)
+
+type EnvFile struct {
+	Envs map[string]string `yaml:"envs"`
+}
+
+func MergeEnvfileWithRuntimeEnvs(runtimeEnvs envmanModels.EnvsJSONListModel, envFilePath string) (map[string]string, error) {
+	originalBuildTriggerEnvs, err := load(envFilePath)
+	if err != nil {
+		return nil, err
+	}
+
+	for k, v := range runtimeEnvs {
+		if v == "" {
+			// Env var value was possibly cleared because of its length, we should restore it from
+			// the original env file
+			if originalValue, ok := originalBuildTriggerEnvs[k]; ok {
+				runtimeEnvs[k] = originalValue
+			}
+		}
+	}
+
+	return runtimeEnvs, nil
+}
+
+func LogLargeEnvWarning(envfilePath string) {
+	
+}
+
+func load(filepath string) (map[string]string, error) {
+	data, err := os.ReadFile(filepath)
+	if err != nil {
+		return nil, err
+	}
+
+	var envFile EnvFile
+	err = yaml.Unmarshal(data, &envFile)
+	if err != nil {
+		return nil, err
+	}
+
+	if envFile.Envs == nil {
+		return make(map[string]string), nil
+	}
+
+	return envFile.Envs, nil
+}
+

--- a/envfile/envfile_test.go
+++ b/envfile/envfile_test.go
@@ -1,0 +1,98 @@
+package envfile
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	envmanModels "github.com/bitrise-io/envman/v2/models"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestMergeEnvfileWithRuntimeEnvs(t *testing.T) {
+	tests := []struct {
+		name           string
+		envfileContent map[string]string
+		runtimeEnvs    envmanModels.EnvsJSONListModel
+		expected       map[string]string
+		wantErr        bool
+	}{
+		{
+			name: "cleared_runtime_envs",
+			envfileContent: map[string]string {
+				"BITRISE_GIT_CHANGED_FILES":   "README.md",
+				"BITRISE_GIT_COMMIT_MESSAGES": "Merge x into y",
+				"KEY3":                        "original_value3",
+				"ENV_ONLY_DEFINED_HERE":      "original_value4",
+			},
+			runtimeEnvs: envmanModels.EnvsJSONListModel{
+				"BITRISE_GIT_CHANGED_FILES":   "README.md",      // This should stay as is
+				"BITRISE_GIT_COMMIT_MESSAGES": "",               // This should be restored from original
+				"KEY3":                        "runtime_value3", // This should stay as is
+				"KEY5":                        "runtime_value5", // This is only in runtime, should stay
+			},
+			expected: map[string]string{
+				"BITRISE_GIT_CHANGED_FILES":   "README.md",
+				"BITRISE_GIT_COMMIT_MESSAGES": "Merge x into y", // Restored from original
+				"KEY3":                        "runtime_value3",
+				"KEY5":                        "runtime_value5",
+			},
+			wantErr: false,
+		},
+		{
+			name:           "empty_envfile",
+			envfileContent: map[string]string{},
+			runtimeEnvs: envmanModels.EnvsJSONListModel{
+				"BITRISE_GIT_CHANGED_FILES":   "README.md",      // This should stay as is
+				"BITRISE_GIT_COMMIT_MESSAGES": "Fix things",     // This should stay as is
+				"KEY3":                        "runtime_value3", // This should stay as is
+				"KEY5":                        "runtime_value5", // This is only in runtime, should stay
+			},
+			expected: map[string]string{
+				"BITRISE_GIT_CHANGED_FILES":   "README.md",
+				"BITRISE_GIT_COMMIT_MESSAGES": "Fix things",
+				"KEY3":                        "runtime_value3",
+				"KEY5":                        "runtime_value5",
+			},
+			wantErr: false,
+		},
+		{
+			name: "runtime_env_overrides_envfile",
+			envfileContent: map[string]string{
+				"CI":              "true",
+				"BITRISE_SRC_DIR": "/bitrise/src",
+			},
+			runtimeEnvs: envmanModels.EnvsJSONListModel{
+				"BITRISE_SRC_DIR": "/bitrise/src", // This should stay as is
+				"CI":              "false",        // This should override the envfile value
+			},
+			expected: map[string]string{
+				"BITRISE_SRC_DIR": "/bitrise/src",
+				"CI":              "false",
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testEnvPath := filepath.Join(t.TempDir(), ".env")
+
+			out, err := yaml.Marshal(&EnvFile{Envs: tt.envfileContent})
+			require.NoError(t, err)
+			err = os.WriteFile(testEnvPath, out, 0644)
+			require.NoError(t, err)
+
+			got, err := MergeEnvfileWithRuntimeEnvs(tt.runtimeEnvs, testEnvPath)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("MergeEnvfileWithRuntimeEnvs() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.expected) {
+				t.Errorf("MergeEnvfileWithRuntimeEnvs() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}

--- a/version/build.go
+++ b/version/build.go
@@ -1,7 +1,7 @@
 package version
 
 // VERSION is the main CLI version number. It's defined at build time using -ldflags
-var VERSION = "2.31.1"
+var VERSION = "2.31.2"
 
 // BuildNumber is the CI build number that creates the release. It's defined at build time using -ldflags
 var BuildNumber = ""


### PR DESCRIPTION
<!--
  Thanks for contributing to the Bitrise CLI!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [ ] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-io/bitrise/blob/master/.github/CONTRIBUTING.md)
- [ ] `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *MINOR* [version update](https://semver.org/)

### Context

The list of env vars passed to a build can grow really large in some cases. So large that it hits the [exec syscall](https://man7.org/linux/man-pages/man2/execve.2.html) size limit and either the Bitrise CLI process can't be launched, or one of the subprocesses that the CLI launches (envman, step processes, etc.)

This happens most often when one of the Bitrise-generated env vars is huge, such as `$BITRISE_GIT_CHANGED_FILES` or `$BITRISE_GIT_COMMIT_MESSAGE`.

### Changes

Like many other tools, we should support reading env vars from an env file on disk. This requires a change in the agent launching the CLI process, so this remains an optional feature and the fallback mechanism is the same as before.

The main idea behind this change is that once all env vars are saved to a file on disk, the actual env vars in the runtime environment can be cleared so that their size stays below that limit. The CLI just needs to reconstruct the original env vars from this envfile.

There are two areas where env vars are exposed to the user:

#### `run_if` templates

This PR patches the `getenv`, `enveq` and `envcontain` template functions so that they return the original env var values. There should be no breaking change here.

#### Env vars exposed to steps and scripts

It's not possible to expose arbitrary large env vars to the step subprocess because of the syscall limits mentioned above.

Therefore, custom steps are suggested to read the original env value from the env file. We present this warning:

<img width="963" alt="image" src="https://github.com/user-attachments/assets/68dfea5b-9fdb-4206-a984-b9bcdc6147c8" />

This is going to be a breaking change for some custom scripts and tools. We minimize the impact by:
- Only erasing the offending env vars (not present in this PR, it's in the agent codebase launching the CLI). 99% of the env vars stay below the limit and they are exposed to the CLI and steps just like before.
- When an env var needs to be erased, the env var is still exposed, but with an empty string value. Tooling that relies only on the presence of an env var should not break.

Also, considering that the builds with env vars above the limit simply do not start today, this is going to be an improvement.

### Decisions

We considered truncating env vars (to stay within the system limits), but that would lead to data corruption and hard-to-debug errors for users.

We also considered removing the offending env var altogether (instead of erasing its value), but that seems like a bigger breaking change than keeping the env var with an empty string value.