### PR TITLE
[EXPERIMENTA] Add experimental trace logging support to Bitrise CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ _FAKE_HOME/
 .vscode
 .idea/
 dist/
+_examples/experimentals/trace-log/build-log.txt
+_examples/tutorials/steps-and-workflows/build-log.txt

--- a/_examples/experimentals/trace-log/README.md
+++ b/_examples/experimentals/trace-log/README.md
@@ -1,0 +1,59 @@
+# Bitrise CLI Trace Logging Example
+
+## Enable Experimental Trace Logging
+
+To enable trace logging in Bitrise CLI, use the `--experimental_trace_logs` flag:
+
+```bash
+bitrise run workflow_name --experimental_trace_logs
+```
+
+## Example Output
+
+When trace logging is enabled, you'll see structured trace events in the output:
+
+```
+BITRISE_TRACE:{"ts":1234567890000000,"type":"workflow_start","step_title":"My Workflow","workflow":"primary","pid":1,"tid":0}
+BITRISE_TRACE:{"ts":1234567890001000,"type":"step_start","step_id":"git-clone","step_title":"Git Clone Repository","workflow":"primary","pid":1,"tid":1}
+BITRISE_TRACE:{"ts":1234567890020000,"type":"step_end","step_id":"git-clone","step_title":"Git Clone Repository","workflow":"primary","status":"success","duration_us":19000,"pid":1,"tid":1}
+BITRISE_TRACE:{"ts":1234567890085000,"type":"workflow_end","step_title":"My Workflow","workflow":"primary","status":"success","duration_us":85000,"pid":1,"tid":0}
+```
+
+## Converting to JSON Trace Profile
+
+You can pipe the output to the log-to-json-trace-profile converter:
+
+```bash
+bitrise run primary --experimental_trace_logs 2>&1 | ./log-to-json-trace-profile -output trace.json
+```
+
+## Viewing in Chrome DevTools
+
+1. Open Chrome DevTools (or go to [text](https://ui.perfetto.dev/))
+2. Go to Performance tab
+3. Click "Load profile"
+4. Select the generated `trace.json` file
+5. Analyze the workflow and step performance
+
+## Demo
+
+```shell
+# compile bitrise CLI with the new experimental feature
+go build -o /tmp/experimental-bitrise-cli
+
+# run `bitrise run` with the new `--experimental_trace_logs` flag
+/tmp/experimental-bitrise-cli run trace-log-example-workflow --experimental_trace_logs | tee build-log.txt
+
+# extract and convert the Bitrise Trace Logs into JSON Trace Profile
+# NOTE: the log-to-json-trace-profile CLI tool currently lives in a separate private repo
+# could be converted to be a Bitrise CLI plugin
+log-to-json-trace-profile -input ./build-log.txt -output ./trace.json
+```
+
+Additional notes:
+- The `log-to-json-trace-profile` could be a Bitrise CLI plugin, to easily extract and convert the timestamps.
+- This `log-to-json-trace-profile` based CLI plugin could also be used in Shell scripts: to perform a specific command and print the `BITRISE_TRACE` log traces before and after performing the command, as working with timestamps and micro seconds in Bash is quite tricky.
+- The CLI could pass in an env var for the steps, which indicates whether trace logging is enabled or not. The `log-to-json-trace-profile` could get and use it, not printing trace logs when the mode isn't enabled.
+
+Questions/TODO:
+- Do we have a way for the step to figure out the `Step ID`?

--- a/_examples/experimentals/trace-log/bitrise.yml
+++ b/_examples/experimentals/trace-log/bitrise.yml
@@ -1,0 +1,30 @@
+format_version: "23"
+default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
+project_type: other
+workflows:
+  trace-log-example-workflow:
+    steps:
+    - activate-ssh-key@4:
+        run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+    - git-clone@8: {}
+    - script@1:
+        title: Script step one
+        inputs:
+        - content: |
+            #!/bin/bash
+            set -ex
+            echo "This is a trace log example."
+    - script@1:
+        title: Step which also prints trace logs
+        inputs:
+        - content: |
+            #!/bin/bash
+            set -e
+            echo "This step will also print trace logs."
+
+            # Questions/TODO: Do we have a way for the step to figure out the 'Step ID'?
+            go run ./trace_command.go -step-id="script@1" -- sleep 1
+            go run ./trace_command.go -step-id="script@1" -- curl https://api.bitrise.io/
+            go run ./trace_command.go -step-id="script@1" -- sleep 1
+
+    - deploy-to-bitrise-io@2: {}

--- a/_examples/experimentals/trace-log/trace_command.go
+++ b/_examples/experimentals/trace-log/trace_command.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func main() {
+	// Define flags
+	var stepID string
+	flag.StringVar(&stepID, "step-id", "script", "The ID of the step that is executing the command")
+
+	// Custom usage message
+	flag.Usage = func() {
+		fmt.Fprintf(os.Stderr, "Usage: %s [options] -- <command> [args...]\n\nOptions:\n", os.Args[0])
+		flag.PrintDefaults()
+	}
+
+	// Find the index of the "--" separator
+	separatorIndex := -1
+	for i, arg := range os.Args {
+		if arg == "--" {
+			separatorIndex = i
+			break
+		}
+	}
+
+	// Check if separator was found
+	if separatorIndex == -1 || separatorIndex == len(os.Args)-1 {
+		flag.Usage()
+		os.Exit(1)
+	}
+
+	// Parse flags from arguments before the "--" separator
+	flag.CommandLine.Parse(os.Args[1:separatorIndex])
+
+	// Get the command and its arguments after the "--" separator
+	cmdName := os.Args[separatorIndex+1]
+	cmdArgs := []string{}
+	if len(os.Args) > separatorIndex+2 {
+		cmdArgs = os.Args[separatorIndex+2:]
+	}
+
+	// Generate command string for the trace log
+	cmdString := cmdName
+	if len(cmdArgs) > 0 {
+		cmdString += " " + strings.Join(cmdArgs, " ")
+	}
+
+	// Current timestamp in microseconds for starting the command
+	startTime := time.Now()
+	startTimeUnixMicro := startTime.UnixMicro()
+
+	// Get process ID
+	pid := os.Getpid()
+
+	// Print command start trace log
+	fmt.Printf("BITRISE_TRACE:{\"ts\":%d,\"type\":\"command_start\",\"step_id\":\"%s\",\"command\":\"%s\",\"pid\":%d,\"tid\":1}\n",
+		startTimeUnixMicro, stepID, cmdString, pid)
+
+	// Prepare the command to run
+	cmd := exec.Command(cmdName, cmdArgs...)
+
+	// Set the command to use the current process's stdin, stdout, and stderr
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	// Run the command
+	err := cmd.Run()
+
+	// Current timestamp in microseconds for ending the command
+	endTime := time.Now()
+	endTimeUnixMicro := endTime.UnixMicro()
+
+	// Calculate duration in microseconds
+	durationMicro := endTimeUnixMicro - startTimeUnixMicro
+
+	// Get exit code
+	exitCode := 0
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			exitCode = exitErr.ExitCode()
+		} else {
+			exitCode = 1
+		}
+	}
+
+	// Print command end trace log
+	fmt.Printf("BITRISE_TRACE:{\"ts\":%d,\"type\":\"command_end\",\"step_id\":\"%s\",\"command\":\"%s\",\"exit_code\":%d,\"duration_us\":%d,\"pid\":%d,\"tid\":1}\n",
+		endTimeUnixMicro, stepID, cmdString, exitCode, durationMicro, pid)
+
+	// Exit with the same code as the command
+	if err != nil {
+		os.Exit(exitCode)
+	}
+}

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -1,0 +1,133 @@
+package trace
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"time"
+)
+
+// Logger handles trace event logging
+type Logger struct {
+	enabled bool
+}
+
+// NewLogger creates a new trace logger
+func NewLogger(enabled bool) *Logger {
+	return &Logger{enabled: enabled}
+}
+
+// Event represents a Bitrise trace event
+type Event struct {
+	Timestamp  int64  `json:"ts"`
+	Type       string `json:"type"`
+	ProcessID  int    `json:"pid"`
+	ThreadID   int    `json:"tid"`
+	StepID     string `json:"step_id,omitempty"`
+	StepTitle  string `json:"step_title,omitempty"`
+	Workflow   string `json:"workflow,omitempty"`
+	Status     string `json:"status,omitempty"`
+	DurationUs int64  `json:"duration_us,omitempty"`
+	BuildID    string `json:"build_id,omitempty"`
+	Project    string `json:"project,omitempty"`
+}
+
+// Event types
+const (
+	WorkflowStart = "workflow_start"
+	WorkflowEnd   = "workflow_end"
+	StepStart     = "step_start"
+	StepEnd       = "step_end"
+)
+
+// LogWorkflowStart logs a workflow start event
+func (l *Logger) LogWorkflowStart(workflow, workflowTitle string) {
+	if !l.enabled {
+		return
+	}
+
+	event := Event{
+		Timestamp: time.Now().UnixMicro(),
+		Type:      WorkflowStart,
+		ProcessID: 1,
+		ThreadID:  0,
+		Workflow:  workflow,
+		StepTitle: workflowTitle,
+	}
+
+	l.logEvent(event)
+}
+
+// LogWorkflowEnd logs a workflow end event
+func (l *Logger) LogWorkflowEnd(workflow, workflowTitle, status string, startTime, endTime time.Time) {
+	if !l.enabled {
+		return
+	}
+
+	duration := endTime.Sub(startTime)
+
+	event := Event{
+		Timestamp:  endTime.UnixMicro(),
+		Type:       WorkflowEnd,
+		ProcessID:  1,
+		ThreadID:   0,
+		Workflow:   workflow,
+		StepTitle:  workflowTitle,
+		Status:     status,
+		DurationUs: duration.Microseconds(),
+	}
+
+	l.logEvent(event)
+}
+
+// LogStepStart logs a step start event
+func (l *Logger) LogStepStart(stepID, stepTitle, workflow string) {
+	if !l.enabled {
+		return
+	}
+
+	event := Event{
+		Timestamp: time.Now().UnixMicro(),
+		Type:      StepStart,
+		ProcessID: 1,
+		ThreadID:  1,
+		StepID:    stepID,
+		StepTitle: stepTitle,
+		Workflow:  workflow,
+	}
+
+	l.logEvent(event)
+}
+
+// LogStepEnd logs a step end event
+func (l *Logger) LogStepEnd(stepID, stepTitle, workflow, status string, startTime, endTime time.Time) {
+	if !l.enabled {
+		return
+	}
+
+	duration := endTime.Sub(startTime)
+
+	event := Event{
+		Timestamp:  endTime.UnixMicro(),
+		Type:       StepEnd,
+		ProcessID:  1,
+		ThreadID:   1,
+		StepID:     stepID,
+		StepTitle:  stepTitle,
+		Workflow:   workflow,
+		Status:     status,
+		DurationUs: duration.Microseconds(),
+	}
+
+	l.logEvent(event)
+}
+
+// logEvent outputs the trace event in the expected format
+func (l *Logger) logEvent(event Event) {
+	data, err := json.Marshal(event)
+	if err != nil {
+		return // Silently fail to avoid disrupting the build
+	}
+
+	fmt.Fprintf(os.Stdout, "BITRISE_TRACE:%s\n", string(data))
+}


### PR DESCRIPTION
- Introduced trace logging functionality to monitor workflow and step execution.
- Added new trace logging commands in the CLI and implemented logging in the workflow runner.
- Created example workflows and scripts to demonstrate trace logging usage.
- Updated .gitignore to exclude generated log files.

## Demo

You can see detailed step by step instructions in https://github.com/bitrise-io/bitrise/blob/experimental-trace-logs/_examples/experimentals/trace-log/README.md

Short example, if you have a Bitrise CLI compiled with the changes:

```shell
# Run a bitrise workflow the same way as usual, specifying the `--experimental_trace_logs` flag
$ bitrise run trace-log-example-workflow --experimental_trace_logs
# Then copy and save the output into a file, let's say called `build-log.txt`

# OR, save the bitrise run output into a file
$ bitrise run trace-log-example-workflow --experimental_trace_logs | tee build-log.txt
```

This new build log includes Trace Logs, for every workflow start/end, step start/end, and potentially - showcased in the example bitrise.yml - on command level start/end as well.
The lines can be easily extracted from the log, and converted to JSON Trace Profile.
We have an example implementation of this in our private monorepo.
Once it's converted to a JSON Trace Profile and opened e.g. in https://ui.perfetto.dev/ you can see the timeline like this:

<img width="1728" alt="Screenshot 2025-05-27 at 8 33 31 PM" src="https://github.com/user-attachments/assets/17381dd6-c95f-4335-9ac1-acf109124d54" />
