### PR TITLE
Pass a copy of the runifs

### DIFF
--- a/models/workflow_run_plan.go
+++ b/models/workflow_run_plan.go
@@ -309,13 +309,20 @@ func gatherBundleSteps(
 				runIf = *override.RunIf
 			}
 
-			internalSlice := make([]string, len(runIfs))
-			copy(internalSlice, runIfs)
+			// Create a new runIfs slice that includes the runIf of the current bundle, instead of modifying the original slice.
+			// This is necessary to ensure that the runIfs of the current bundle are evaluated correctly in the context of the parent bundle.
+			// The Go slice wraps a pointer to the actual data inside.
+			// So passing it around and adding items to it would update all the slices internal data storage.
+			var newBundleRunIfs []string
+			if len(runIfs) > 0 {
+				newBundleRunIfs = make([]string, len(runIfs))
+				copy(newBundleRunIfs, runIfs)
+			}
 			if runIf != "" {
-				internalSlice = append(internalSlice, runIf)
+				newBundleRunIfs = append(newBundleRunIfs, runIf)
 			}
 
-			plans, err := gatherBundleSteps(definition, uuid, envs, internalSlice, stepBundles, stepBundlePlans, uuidProvider)
+			plans, err := gatherBundleSteps(definition, uuid, envs, newBundleRunIfs, stepBundles, stepBundlePlans, uuidProvider)
 			if err != nil {
 				return nil, err
 			}

--- a/models/workflow_run_plan_test.go
+++ b/models/workflow_run_plan_test.go
@@ -266,10 +266,10 @@ func TestNewWorkflowRunPlan(t *testing.T) {
 				ExecutionPlan: []WorkflowExecutionPlan{
 					{UUID: "uuid_10", WorkflowID: "workflow1", WorkflowTitle: "workflow1", Steps: []StepExecutionPlan{
 						{UUID: "uuid_2", StepID: "bundle3-step1", Step: stepmanModels.StepModel{}, StepBundleUUID: "uuid_1"},
-						{UUID: "uuid_5", StepID: "bundle1-step1", Step: stepmanModels.StepModel{}, StepBundleUUID: "uuid_4", StepBundleRunIfs: []string{}},
-						{UUID: "uuid_6", StepID: "bundle1-step2", Step: stepmanModels.StepModel{}, StepBundleUUID: "uuid_4", StepBundleRunIfs: []string{}},
-						{UUID: "uuid_7", StepID: "bundle2-step1", Step: stepmanModels.StepModel{}, StepBundleUUID: "uuid_3", StepBundleRunIfs: []string{}},
-						{UUID: "uuid_8", StepID: "bundle2-step2", Step: stepmanModels.StepModel{}, StepBundleUUID: "uuid_3", StepBundleRunIfs: []string{}},
+						{UUID: "uuid_5", StepID: "bundle1-step1", Step: stepmanModels.StepModel{}, StepBundleUUID: "uuid_4"},
+						{UUID: "uuid_6", StepID: "bundle1-step2", Step: stepmanModels.StepModel{}, StepBundleUUID: "uuid_4"},
+						{UUID: "uuid_7", StepID: "bundle2-step1", Step: stepmanModels.StepModel{}, StepBundleUUID: "uuid_3"},
+						{UUID: "uuid_8", StepID: "bundle2-step2", Step: stepmanModels.StepModel{}, StepBundleUUID: "uuid_3"},
 						{UUID: "uuid_9", StepID: "bundle3-step2", Step: stepmanModels.StepModel{}, StepBundleUUID: "uuid_1"},
 					}},
 				},
@@ -336,8 +336,8 @@ func TestNewWorkflowRunPlan(t *testing.T) {
 							// bundle1 definition inputs
 							{"input1": "value1"}, {"input2": ""},
 							// bundle1 override inputs
-							{"input2": "value2"}}, StepBundleRunIfs: []string{}},
-						{UUID: "uuid_4", StepID: "bundle1-step2", Step: stepmanModels.StepModel{}, StepBundleUUID: "uuid_2", StepBundleRunIfs: []string{}},
+							{"input2": "value2"}}},
+						{UUID: "uuid_4", StepID: "bundle1-step2", Step: stepmanModels.StepModel{}, StepBundleUUID: "uuid_2"},
 						{UUID: "uuid_5", StepID: "bundle2-step1", Step: stepmanModels.StepModel{}, StepBundleUUID: "uuid_1", StepBundleEnvs: []envmanModels.EnvironmentItemModel{
 							// bundle2 definition inputs
 							{"input1": "value3"}, {"input3": ""},


### PR DESCRIPTION
<!--
  Thanks for contributing to the Bitrise CLI!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [ ] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-io/bitrise/blob/master/.github/CONTRIBUTING.md)
- [ ] `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *PATCH* [version update](https://semver.org/)

### Context

There is an issue with run_if propagation when there is an embedded bundle mixed with steps inside a step bundle. Here is a rough example:
```
step_bundles:
  A:
    steps:
    - bundle::B: {}
    - script@1: {}
  B:
    run_if: '{{ getenv "SOME_ENV" | ne "1" }}'
    steps: 
    - script@1: {}
workflows:
  A:
    steps:
    - bundle::A: {}
```
Using the above example, what happens is that the run_if statement from the B bundle gets inherited by the script inside the A bundle. This is incorrect as only the steps inside the B bundle should inherit the bundle's run_if statement. The A bundle has no run_ifs specified so the A bundle's script step should have no run_if statement. 

We are using a recursive function to resolve all of the step bundles as there could be embedded bundles inside a bundle. The embedded bundles should inherit the parents run_if statements so we pass the so far collected run_if statements to this recursive function as we iterate over the embedded items. The Go slice is a value type from the outside but actually it wraps a pointer to the actual data inside. So passing it around and adding items to it will update all of the slices internal data storage as there is only a single one backing every value type. That is why the first embedded step bundle's run_if collection was carried over to the next step item.

The solution is to make a hard copy of the run_ifs slice which will be passed to the recursive function.