### PR TITLE
Workflows for integration-test stacks and toolproviders

### DIFF
--- a/_tests/integration/toolprovider/asdf/harness_test.go
+++ b/_tests/integration/toolprovider/asdf/harness_test.go
@@ -42,6 +42,26 @@ type testEnv struct {
 
 // createTestEnv creates an isolated installation of a given asdf version for testing.
 func createTestEnv(t *testing.T, installRequest asdfInstallation) (testEnv, error) {
+
+	if useSystemAsdf() {
+		// Remove installed tools between test runs because tests don't run their own isolated asdf install in this mode
+		out, err := exec.Command("bash", "-c", "rm -rf ~/.asdf/installs").CombinedOutput()
+		if err != nil {
+			t.Log(string(out))
+			return testEnv{}, fmt.Errorf("cleanup asdf installs between tests: %w", err)
+		}
+		out, err = exec.Command("bash", "-lc", "asdf reshim").CombinedOutput()
+		if err != nil {
+			t.Log(string(out))
+			return testEnv{}, fmt.Errorf("asdf reshim between tests: %w", err)
+		}
+
+		return testEnv{
+			envVars:   map[string]string{},
+			shellInit: "",
+		}, nil
+	}
+
 	homeDir := t.TempDir()
 	dataDir := t.TempDir()
 	shimsDir := filepath.Join(dataDir, "shims")
@@ -84,7 +104,7 @@ func createTestEnv(t *testing.T, installRequest asdfInstallation) (testEnv, erro
 func (te *testEnv) toExecEnv() execenv.ExecEnv {
 	return execenv.ExecEnv{
 		EnvVars:            te.envVars,
-		ClearInheritedEnvs: true,
+		ClearInheritedEnvs: !useSystemAsdf(),
 		ShellInit:          te.shellInit,
 	}
 }
@@ -222,4 +242,9 @@ func downloadReleaseBinary(t *testing.T, version string, targetDir string) error
 	}
 
 	return nil
+}
+
+func useSystemAsdf() bool {
+	useSystemAsdfFlag := strings.TrimSpace(os.Getenv("TOOLPROVIDER_TEST_USE_SYSTEM_ASDF"))
+	return useSystemAsdfFlag == "1" || strings.ToLower(useSystemAsdfFlag) == "true"
 }

--- a/_tests/integration/toolprovider/asdf/install_test.go
+++ b/_tests/integration/toolprovider/asdf/install_test.go
@@ -6,12 +6,16 @@ package asdf
 import (
 	"testing"
 
-	"github.com/bitrise-io/bitrise/v2/toolprovider/provider"
 	"github.com/bitrise-io/bitrise/v2/toolprovider/asdf"
+	"github.com/bitrise-io/bitrise/v2/toolprovider/provider"
 	"github.com/stretchr/testify/require"
 )
 
 func TestAsdfInstallClassic(t *testing.T) {
+	if useSystemAsdf() {
+		t.Skip("Irrelevant test when using system asdf")
+	}
+
 	testEnv, err := createTestEnv(t, asdfInstallation{
 		flavor:  flavorAsdfClassic,
 		version: "0.14.0",
@@ -35,6 +39,10 @@ func TestAsdfInstallClassic(t *testing.T) {
 }
 
 func TestAsdfInstallRewrite(t *testing.T) {
+	if useSystemAsdf() {
+		t.Skip("Irrelevant test when using system asdf")
+	}
+
 	testEnv, err := createTestEnv(t, asdfInstallation{
 		flavor:  flavorAsdfRewrite,
 		version: "0.18.0",

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -85,6 +85,13 @@ workflows:
     - bundle::run_docker_integration_tests:
         envs:
         - SRC_DIR_IN_GOPATH: $BITRISE_SOURCE_DIR
+  
+  # Note: this workflow is triggered externally during stack testing, do not remove or break.
+  run_system_asdf_tests:
+    steps:
+    - bundle::setup_repo: { }
+    - bundle::setup_go_junit_report: { }
+    - bundle::run_system_asdf_integration_tests: { }
 
   test_binary_build_macos:
     steps:
@@ -277,6 +284,21 @@ step_bundles:
             cp "${ORIG_BITRISE_DEPLOY_DIR}/${test_log_file_name}.xml" "${test_results_dir}/${test_log_file_name}.xml"
             echo "${test_name_json}" > "${test_results_dir}/test-info.json"
     - deploy-to-bitrise-io@2: { }
+
+  run_system_asdf_integration_tests:
+    steps:
+      - script@1:
+          title: Run integration tests against system asdf
+          inputs:
+            - content: |
+                #!/bin/bash
+                set -ex
+
+                # Special test mode that doesn't use the test harness but uses the system-wide asdf install and config
+                export TOOLPROVIDER_TEST_USE_SYSTEM_ASDF=1
+                # We test the system bitrise executable, not one built from source
+                export INTEGRATION_TEST_BINARY_PATH="$(which bitrise)"
+                go test -v --tags linux_and_mac ./_tests/integration/toolprovider/asdf/... -timeout 360s
 
   run_docker_integration_tests:
     steps:


### PR DESCRIPTION
<!--
  Thanks for contributing to the Bitrise CLI!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [ ] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-io/bitrise/blob/master/.github/CONTRIBUTING.md)
- [ ] `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *MAJOR/MINOR/PATCH* [version update](https://semver.org/)

### Context

Right now, integration tests create a new sandboxed asdf environment for each test (in order to make it not depend on the system-wide asdf installation and config).

We could flip this and use the test cases for testing the system-wide asdf installation and shell config.

The toolprovider thing relies on a preinstalled asdf version (right now), as well as preinstalled asdf plugin versions. If we accidentally change the versions of asdf plugins (which are impossible to pin), it could break the entire feature.

### Changes

Test builds:

- [Ubuntu 2025](https://app.bitrise.io/build/ba2677d9-66e5-428a-852a-1bc3137c86ad)
- [Ubuntu 2024](https://app.bitrise.io/build/ce010c81-4e3b-424b-b4aa-2c7fe86b26f2)
- [Xcode 16.4](https://app.bitrise.io/build/8123c39e-38a8-4bfb-b7f8-38fc49ece3d2)

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->