### PR TITLE
replaced map[string]interface{} in step lists in workflows and bundles

### DIFF
--- a/bitrise/util_test.go
+++ b/bitrise/util_test.go
@@ -326,7 +326,7 @@ step_bundles:
   test:
     steps:
     - with: {}`,
-			wantErr: "failed to normalize step_bundle: 'with group' is not allowed in a step bundle's step list",
+			wantErr: "'with group' is not allowed in a step bundle's step list",
 		},
 		{
 			name: "Invalid bitrise.yml: step bundle in a 'with group''s steps list",
@@ -398,7 +398,7 @@ func TestConfigModelFromJSONFileContent_StepListValidation(t *testing.T) {
     }
   }
 }`,
-			wantErr: "failed to normalize step_bundle: 'with group' is not allowed in a step bundle's step list",
+			wantErr: "'with group' is not allowed in a step bundle's step list",
 		},
 		{
 			name: "Invalid bitrise.yml: step bundle in a 'with group''s steps list",

--- a/models/models.go
+++ b/models/models.go
@@ -34,7 +34,10 @@ type StepBundleModel struct {
 	Steps        []StepListItemStepOrBundleModel     `json:"steps,omitempty" yaml:"steps,omitempty"`
 }
 
-type StepListItemStepOrBundleModel map[string]any
+type StepListItemStepOrBundleModel struct {
+	Step       *StepListStepItemModel
+	StepBundle *StepListStepBundleItemModel
+}
 
 type StepBundleListItemModel struct {
 	Title        string                              `json:"title,omitempty" yaml:"title,omitempty"`
@@ -57,7 +60,11 @@ type StepListWithItemModel map[string]WithModel
 
 type StepListStepItemModel map[string]stepmanModels.StepModel
 
-type StepListItemModel map[string]interface{}
+type StepListItemModel struct {
+	Step       *StepListStepItemModel
+	With       *StepListWithItemModel
+	StepBundle *StepListStepBundleItemModel
+}
 
 type PipelineModel struct {
 	Title            string                             `json:"title,omitempty" yaml:"title,omitempty"`

--- a/models/models_methods_test.go
+++ b/models/models_methods_test.go
@@ -1742,7 +1742,9 @@ func TestGetStepIDStepDataPair(t *testing.T) {
 	t.Log("valid steplist item")
 	{
 		stepListItem := StepListItemModel{
-			"step1": stepData,
+			Step: &StepListStepItemModel{
+				"step1": stepData,
+			},
 		}
 
 		key, itemType, err := stepListItem.GetKeyAndType()
@@ -1759,8 +1761,10 @@ func TestGetStepIDStepDataPair(t *testing.T) {
 	t.Log("invalid steplist item - more than 1 step")
 	{
 		stepListItem := StepListItemModel{
-			"step1": stepData,
-			"step2": stepData,
+			Step: &StepListStepItemModel{
+				"step1": stepData,
+				"step2": stepData,
+			},
 		}
 
 		key, itemType, err := stepListItem.GetKeyAndType()

--- a/models/workflow_run_plan_test.go
+++ b/models/workflow_run_plan_test.go
@@ -38,17 +38,17 @@ func TestNewWorkflowRunPlan_StepBundleRunIf(t *testing.T) {
 				"bundle1": {
 					RunIf: "{{.IsCI}}",
 					Steps: []StepListItemStepOrBundleModel{
-						{"bundle1-step1": stepmanModels.StepModel{}},
-						{"bundle1-step2": stepmanModels.StepModel{}},
+						{Step: &StepListStepItemModel{"bundle1-step1": stepmanModels.StepModel{}}},
+						{Step: &StepListStepItemModel{"bundle1-step2": stepmanModels.StepModel{}}},
 					},
 				},
 			},
 			workflows: map[string]WorkflowModel{
 				"workflow1": {
 					Steps: []StepListItemModel{
-						{"step1": stepmanModels.StepModel{}},
-						{"bundle::bundle1": StepBundleListItemModel{}},
-						{"step2": stepmanModels.StepModel{}},
+						{Step: &StepListStepItemModel{"step1": stepmanModels.StepModel{}}},
+						{StepBundle: &StepListStepBundleItemModel{"bundle::bundle1": StepBundleListItemModel{}}},
+						{Step: &StepListStepItemModel{"step2": stepmanModels.StepModel{}}},
 					},
 				},
 			},
@@ -77,28 +77,28 @@ func TestNewWorkflowRunPlan_StepBundleRunIf(t *testing.T) {
 				"bundle1": {
 					RunIf: `{{enveq "RUN_IF_1" "true"}}`,
 					Steps: []StepListItemStepOrBundleModel{
-						{"bundle1-step1": stepmanModels.StepModel{}},
-						{"bundle::bundle2": StepBundleListItemModel{}},
+						{Step: &StepListStepItemModel{"bundle1-step1": stepmanModels.StepModel{}}},
+						{StepBundle: &StepListStepBundleItemModel{"bundle::bundle2": StepBundleListItemModel{}}},
 					},
 				},
 				"bundle2": {
 					RunIf: `{{enveq "RUN_IF_2" "true"}}`,
 					Steps: []StepListItemStepOrBundleModel{
-						{"bundle2-step1": stepmanModels.StepModel{}},
-						{"bundle::bundle3": StepBundleListItemModel{}},
+						{Step: &StepListStepItemModel{"bundle2-step1": stepmanModels.StepModel{}}},
+						{StepBundle: &StepListStepBundleItemModel{"bundle::bundle3": StepBundleListItemModel{}}},
 					},
 				},
 				"bundle3": {
 					RunIf: `{{enveq "RUN_IF_3" "true"}}`,
 					Steps: []StepListItemStepOrBundleModel{
-						{"bundle3-step1": stepmanModels.StepModel{}},
+						{Step: &StepListStepItemModel{"bundle3-step1": stepmanModels.StepModel{}}},
 					},
 				},
 			},
 			workflows: map[string]WorkflowModel{
 				"workflow1": {
 					Steps: []StepListItemModel{
-						{"bundle::bundle1": StepBundleListItemModel{}},
+						{StepBundle: &StepListStepBundleItemModel{"bundle::bundle1": StepBundleListItemModel{}}},
 					},
 				},
 			},
@@ -127,21 +127,21 @@ func TestNewWorkflowRunPlan_StepBundleRunIf(t *testing.T) {
 			stepBundles: map[string]StepBundleModel{
 				"bundle1": {
 					Steps: []StepListItemStepOrBundleModel{
-						{"bundle::bundle2": StepBundleListItemModel{}},
-						{"bundle1-step1": stepmanModels.StepModel{}},
+						{StepBundle: &StepListStepBundleItemModel{"bundle::bundle2": StepBundleListItemModel{}}},
+						{Step: &StepListStepItemModel{"bundle1-step1": stepmanModels.StepModel{}}},
 					},
 				},
 				"bundle2": {
 					RunIf: `{{enveq "RUN_IF_1" "true"}}`,
 					Steps: []StepListItemStepOrBundleModel{
-						{"bundle2-step1": stepmanModels.StepModel{}},
+						{Step: &StepListStepItemModel{"bundle2-step1": stepmanModels.StepModel{}}},
 					},
 				},
 			},
 			workflows: map[string]WorkflowModel{
 				"workflow1": {
 					Steps: []StepListItemModel{
-						{"bundle::bundle1": StepBundleListItemModel{}},
+						{StepBundle: &StepListStepBundleItemModel{"bundle::bundle1": StepBundleListItemModel{}}},
 					},
 				},
 			},
@@ -192,18 +192,18 @@ func TestNewWorkflowRunPlan(t *testing.T) {
 			stepBundles: map[string]StepBundleModel{
 				"bundle1": {
 					Steps: []StepListItemStepOrBundleModel{
-						{"bundle1-step1": stepmanModels.StepModel{}},
-						{"bundle1-step2": stepmanModels.StepModel{}},
+						{Step: &StepListStepItemModel{"bundle1-step1": stepmanModels.StepModel{}}},
+						{Step: &StepListStepItemModel{"bundle1-step2": stepmanModels.StepModel{}}},
 					},
 				},
 			},
 			workflows: map[string]WorkflowModel{
 				"workflow1": {
 					Steps: []StepListItemModel{
-						{"step1": stepmanModels.StepModel{}},
-						{"bundle::bundle1": StepBundleListItemModel{}},
-						{"step2": stepmanModels.StepModel{}},
-						{"bundle::bundle1": StepBundleListItemModel{}},
+						{Step: &StepListStepItemModel{"step1": stepmanModels.StepModel{}}},
+						{StepBundle: &StepListStepBundleItemModel{"bundle::bundle1": StepBundleListItemModel{}}},
+						{Step: &StepListStepItemModel{"step2": stepmanModels.StepModel{}}},
+						{StepBundle: &StepListStepBundleItemModel{"bundle::bundle1": StepBundleListItemModel{}}},
 					},
 				},
 			},
@@ -235,29 +235,29 @@ func TestNewWorkflowRunPlan(t *testing.T) {
 			stepBundles: map[string]StepBundleModel{
 				"bundle1": {
 					Steps: []StepListItemStepOrBundleModel{
-						{"bundle1-step1": stepmanModels.StepModel{}},
-						{"bundle1-step2": stepmanModels.StepModel{}},
+						{Step: &StepListStepItemModel{"bundle1-step1": stepmanModels.StepModel{}}},
+						{Step: &StepListStepItemModel{"bundle1-step2": stepmanModels.StepModel{}}},
 					},
 				},
 				"bundle2": {
 					Steps: []StepListItemStepOrBundleModel{
-						{"bundle::bundle1": StepBundleListItemModel{}},
-						{"bundle2-step1": stepmanModels.StepModel{}},
-						{"bundle2-step2": stepmanModels.StepModel{}},
+						{StepBundle: &StepListStepBundleItemModel{"bundle::bundle1": StepBundleListItemModel{}}},
+						{Step: &StepListStepItemModel{"bundle2-step1": stepmanModels.StepModel{}}},
+						{Step: &StepListStepItemModel{"bundle2-step2": stepmanModels.StepModel{}}},
 					},
 				},
 				"bundle3": {
 					Steps: []StepListItemStepOrBundleModel{
-						{"bundle3-step1": stepmanModels.StepModel{}},
-						{"bundle::bundle2": StepBundleListItemModel{}},
-						{"bundle3-step2": stepmanModels.StepModel{}},
+						{Step: &StepListStepItemModel{"bundle3-step1": stepmanModels.StepModel{}}},
+						{StepBundle: &StepListStepBundleItemModel{"bundle::bundle2": StepBundleListItemModel{}}},
+						{Step: &StepListStepItemModel{"bundle3-step2": stepmanModels.StepModel{}}},
 					},
 				},
 			},
 			workflows: map[string]WorkflowModel{
 				"workflow1": {
 					Steps: []StepListItemModel{
-						{"bundle::bundle3": StepBundleListItemModel{}},
+						{StepBundle: &StepListStepBundleItemModel{"bundle::bundle3": StepBundleListItemModel{}}},
 					},
 				},
 			},
@@ -294,8 +294,8 @@ func TestNewWorkflowRunPlan(t *testing.T) {
 						{"input2": ""},
 					},
 					Steps: []StepListItemStepOrBundleModel{
-						{"bundle1-step1": stepmanModels.StepModel{}},
-						{"bundle1-step2": stepmanModels.StepModel{}},
+						{Step: &StepListStepItemModel{"bundle1-step1": stepmanModels.StepModel{}}},
+						{Step: &StepListStepItemModel{"bundle1-step2": stepmanModels.StepModel{}}},
 					},
 				},
 				"bundle2": {
@@ -304,24 +304,24 @@ func TestNewWorkflowRunPlan(t *testing.T) {
 						{"input3": ""},
 					},
 					Steps: []StepListItemStepOrBundleModel{
-						{"bundle::bundle1": StepBundleListItemModel{
+						{StepBundle: &StepListStepBundleItemModel{"bundle::bundle1": StepBundleListItemModel{
 							Inputs: []envmanModels.EnvironmentItemModel{
 								{"input2": "value2"},
 							},
-						}},
-						{"bundle2-step1": stepmanModels.StepModel{}},
-						{"bundle2-step2": stepmanModels.StepModel{}},
+						}}},
+						{Step: &StepListStepItemModel{"bundle2-step1": stepmanModels.StepModel{}}},
+						{Step: &StepListStepItemModel{"bundle2-step2": stepmanModels.StepModel{}}},
 					},
 				},
 			},
 			workflows: map[string]WorkflowModel{
 				"workflow1": {
 					Steps: []StepListItemModel{
-						{"bundle::bundle2": StepBundleListItemModel{
+						{StepBundle: &StepListStepBundleItemModel{"bundle::bundle2": StepBundleListItemModel{
 							Inputs: []envmanModels.EnvironmentItemModel{
 								{"input3": "value3"},
 							},
-						}},
+						}}},
 					},
 				},
 			},
@@ -376,15 +376,15 @@ func TestNewWorkflowRunPlan(t *testing.T) {
 				"bundle1": {
 					Title: "My Bundle 1",
 					Steps: []StepListItemStepOrBundleModel{
-						{"bundle1-step1": stepmanModels.StepModel{}},
+						{Step: &StepListStepItemModel{"bundle1-step1": stepmanModels.StepModel{}}},
 					},
 				},
 			},
 			workflows: map[string]WorkflowModel{
 				"workflow1": {
 					Steps: []StepListItemModel{
-						{"bundle::bundle1": StepBundleListItemModel{}},
-						{"bundle::bundle1": StepBundleListItemModel{}},
+						{StepBundle: &StepListStepBundleItemModel{"bundle::bundle1": StepBundleListItemModel{}}},
+						{StepBundle: &StepListStepBundleItemModel{"bundle::bundle1": StepBundleListItemModel{}}},
 					},
 				},
 			},
@@ -413,16 +413,16 @@ func TestNewWorkflowRunPlan(t *testing.T) {
 				"bundle1": {
 					Title: "My Bundle 1",
 					Steps: []StepListItemStepOrBundleModel{
-						{"bundle1-step1": stepmanModels.StepModel{}},
+						{Step: &StepListStepItemModel{"bundle1-step1": stepmanModels.StepModel{}}},
 					},
 				},
 			},
 			workflows: map[string]WorkflowModel{
 				"workflow1": {
 					Steps: []StepListItemModel{
-						{"bundle::bundle1": StepBundleListItemModel{}},
-						{"bundle::bundle1": StepBundleListItemModel{Title: "My Bundle Override 1"}},
-						{"bundle::bundle1": StepBundleListItemModel{Title: "My Bundle Override 2"}},
+						{StepBundle: &StepListStepBundleItemModel{"bundle::bundle1": StepBundleListItemModel{}}},
+						{StepBundle: &StepListStepBundleItemModel{"bundle::bundle1": StepBundleListItemModel{Title: "My Bundle Override 1"}}},
+						{StepBundle: &StepListStepBundleItemModel{"bundle::bundle1": StepBundleListItemModel{Title: "My Bundle Override 2"}}},
 					},
 				},
 			},


### PR DESCRIPTION
### Checklist

- [X] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-io/bitrise/blob/master/.github/CONTRIBUTING.md)
- [X] `README.md` is updated with the changes (if needed)

### Version
Requires a *PATCH* [version update](https://semver.org/)

### Context

Replaces map[string]interface{} in step lists with a better expression of possible child items. This enables better automated navigation of configuration structure.

### Changes

`StepListItemModel` and `StepListItemStepOrBundleModel` now have strongly typed contained items.