### PR TITLE
Use a prebuilt Python version in integration tests

### DIFF
--- a/integrationtests/toolprovider/setup_command_test.go
+++ b/integrationtests/toolprovider/setup_command_test.go
@@ -44,14 +44,14 @@ func TestToolsSetupCommand(t *testing.T) {
 		{
 			name: "setup from .tool-versions with multiple tools",
 			fileContent: `nodejs 20.0.0
-python 3.11.0`,
+python 3.11.4`,
 			fileName:     ".tool-versions",
 			outputFormat: "plaintext",
 			validateOutput: func(t *testing.T, output string) {
 				assert.Contains(t, output, "nodejs")
 				assert.Contains(t, output, "20.0.0")
 				assert.Contains(t, output, "python")
-				assert.Contains(t, output, "3.11.0")
+				assert.Contains(t, output, "3.11.4")
 			},
 		},
 		{
@@ -78,7 +78,7 @@ workflows:
   test:
     tools:
       nodejs: 20.0.0
-      python: 3.11.0
+      python: 3.11.4
     steps:
       - script:
           inputs:
@@ -90,7 +90,7 @@ workflows:
 				assert.Contains(t, output, "nodejs")
 				assert.Contains(t, output, "20.0.0")
 				assert.Contains(t, output, "python")
-				assert.Contains(t, output, "3.11.0")
+				assert.Contains(t, output, "3.11.4")
 				// Global tool should also be included
 				assert.Contains(t, output, "golang")
 				assert.Contains(t, output, "1.21.0")
@@ -390,7 +390,7 @@ func TestToolsSetupCommand_GlobalToolsWithoutWorkflow(t *testing.T) {
 	content := `format_version: "17"
 tools:
   nodejs: 20.0.0
-  python: 3.11.0
+  python: 3.11.4
 workflows:
   test:
     steps:
@@ -414,7 +414,7 @@ workflows:
 	assert.Contains(t, out, "nodejs")
 	assert.Contains(t, out, "20.0.0")
 	assert.Contains(t, out, "python")
-	assert.Contains(t, out, "3.11.0")
+	assert.Contains(t, out, "3.11.4")
 }
 
 func TestToolsSetupCommandNoArg(t *testing.T) {


### PR DESCRIPTION
<!--
  Thanks for contributing to the Bitrise CLI!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [ ] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-io/bitrise/blob/master/.github/CONTRIBUTING.md)
- [ ] `README.md` is updated with the changes (if needed)
- [ ] I've run `go mod tidy` both in root and in `integrationtests/` if any dependencies have changed. <!-- Integration tests are treated separate. See `integrationtests/README.md` -->

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *MAJOR/MINOR/PATCH* [version update](https://semver.org/)

### Context

Even running against `master`, our integration tests time out: https://app.bitrise.io/app/665682b1-d109-4e81-b9ca-16f5e95e3403/build/a0d957ae-1d6c-42f0-831a-6b709c935eb7

My best guess is that something changed in the (server-side) mise tool registry. Even in my local env, this version is built from source for some reason:

```
❯ mise install python@3.11.0 --force
mise WARN  no precompiled python found for 3.11.0, force mise to use a precompiled version with `mise settings set python.compile false`
mise python@3.11.0             python-build: use openssl@3 from homebrew              ⠂  2s^C⏎                    
```

### Changes

<!-- 
  Details are important, and help maintainers processing your PR.
  Please list additional details, for example:
  - Update dependencies
  - Make `foo` optional in `main.go`
  - `foo` now returns an `error` for better error handling
-->

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->