### PR TITLE
Expose GitHub token secret to declarative tool setup

### DIFF
--- a/cli/run.go
+++ b/cli/run.go
@@ -343,7 +343,7 @@ func (r WorkflowRunner) runWorkflows() (models.BuildRunResultsModel, error) {
 		environments = append(environments, workflowToRun.Environments...)
 
 		// Toolprovider entrypoint
-		toolEnvs, err := toolprovider.RunDeclarativeSetup(r.config.Config, r.tracker, r.config.Modes.CIMode, workflowRunPlan.WorkflowID, false, nil, nil)
+		toolEnvs, err := toolprovider.RunDeclarativeSetup(r.config.Config, r.tracker, r.config.Modes.CIMode, workflowRunPlan.WorkflowID, false, nil, nil, envsToMap(environments))
 		if err != nil {
 			return models.BuildRunResultsModel{}, fmt.Errorf("set up tools: %w", err)
 		}
@@ -572,4 +572,16 @@ func isContainerDebugLoggingEnabled(Secrets []envmanModels.EnvironmentItemModel)
 		}
 	}
 	return false
+}
+
+func envsToMap(envs []envmanModels.EnvironmentItemModel) map[string]string {
+	result := make(map[string]string, len(envs))
+	for _, env := range envs {
+		key, value, err := env.GetKeyValuePair()
+		if err != nil {
+			continue
+		}
+		result[key] = value
+	}
+	return result
 }

--- a/cli/tools.go
+++ b/cli/tools.go
@@ -285,7 +285,7 @@ func toolsSetup(c *cli.Context) error {
 		}
 
 		tracker := analytics.NewDefaultTracker()
-		envs, err := toolprovider.RunDeclarativeSetup(config, tracker, false, workflowID, silent, providerOverride, fastInstallOverride)
+		envs, err := toolprovider.RunDeclarativeSetup(config, tracker, false, workflowID, silent, providerOverride, fastInstallOverride, nil)
 		if err != nil {
 			return err
 		}

--- a/integrationtests/toolprovider/mise/execenv_test.go
+++ b/integrationtests/toolprovider/mise/execenv_test.go
@@ -17,7 +17,7 @@ func TestExecEnv_RunMiseWithTimeout(t *testing.T) {
 
 	miseInstallDir := t.TempDir()
 	miseDataDir := t.TempDir()
-	miseProvider, err := mise.NewToolProvider(miseInstallDir, miseDataDir, false, false)
+	miseProvider, err := mise.NewToolProvider(miseInstallDir, miseDataDir, false, false, nil)
 	require.NoError(t, err)
 
 	err = miseProvider.Bootstrap()

--- a/integrationtests/toolprovider/mise/install_error_test.go
+++ b/integrationtests/toolprovider/mise/install_error_test.go
@@ -14,7 +14,7 @@ import (
 func TestNoMatchingVersionError(t *testing.T) {
 	miseInstallDir := t.TempDir()
 	miseDataDir := t.TempDir()
-	miseProvider, err := mise.NewToolProvider(miseInstallDir, miseDataDir, false, false)
+	miseProvider, err := mise.NewToolProvider(miseInstallDir, miseDataDir, false, false, nil)
 	require.NoError(t, err)
 
 	err = miseProvider.Bootstrap()

--- a/integrationtests/toolprovider/mise/install_flutter_test.go
+++ b/integrationtests/toolprovider/mise/install_flutter_test.go
@@ -24,7 +24,7 @@ func TestMiseInstallFlutter(t *testing.T) {
 	for _, tt := range tests {
 		miseInstallDir := t.TempDir()
 		miseDataDir := t.TempDir()
-		miseProvider, err := mise.NewToolProvider(miseInstallDir, miseDataDir, false, false)
+		miseProvider, err := mise.NewToolProvider(miseInstallDir, miseDataDir, false, false, nil)
 		require.NoError(t, err)
 
 		err = miseProvider.Bootstrap()

--- a/integrationtests/toolprovider/mise/install_golang_test.go
+++ b/integrationtests/toolprovider/mise/install_golang_test.go
@@ -26,7 +26,7 @@ func TestMiseInstallGolangVersion(t *testing.T) {
 	for _, tt := range tests {
 		miseInstallDir := t.TempDir()
 		miseDataDir := t.TempDir()
-		miseProvider, err := mise.NewToolProvider(miseInstallDir, miseDataDir, false, false)
+		miseProvider, err := mise.NewToolProvider(miseInstallDir, miseDataDir, false, false, nil)
 		require.NoError(t, err)
 
 		err = miseProvider.Bootstrap()

--- a/integrationtests/toolprovider/mise/install_java_test.go
+++ b/integrationtests/toolprovider/mise/install_java_test.go
@@ -47,7 +47,7 @@ func TestMiseInstallJavaVersion(t *testing.T) {
 	for _, tt := range tests {
 		miseInstallDir := t.TempDir()
 		miseDataDir := t.TempDir()
-		miseProvider, err := mise.NewToolProvider(miseInstallDir, miseDataDir, false, false)
+		miseProvider, err := mise.NewToolProvider(miseInstallDir, miseDataDir, false, false, nil)
 		require.NoError(t, err)
 
 		err = miseProvider.Bootstrap()

--- a/integrationtests/toolprovider/mise/install_keywords_test.go
+++ b/integrationtests/toolprovider/mise/install_keywords_test.go
@@ -16,7 +16,7 @@ import (
 func TestMiseInstallWithLatestKeyword(t *testing.T) {
 	miseInstallDir := t.TempDir()
 	miseDataDir := t.TempDir()
-	miseProvider, err := mise.NewToolProvider(miseInstallDir, miseDataDir, false, false)
+	miseProvider, err := mise.NewToolProvider(miseInstallDir, miseDataDir, false, false, nil)
 	require.NoError(t, err)
 
 	err = miseProvider.Bootstrap()
@@ -52,7 +52,7 @@ func TestMiseInstallWithLatestKeyword(t *testing.T) {
 func TestMiseInstallWithInstalledKeyword(t *testing.T) {
 	miseInstallDir := t.TempDir()
 	miseDataDir := t.TempDir()
-	miseProvider, err := mise.NewToolProvider(miseInstallDir, miseDataDir, false, false)
+	miseProvider, err := mise.NewToolProvider(miseInstallDir, miseDataDir, false, false, nil)
 	require.NoError(t, err)
 
 	err = miseProvider.Bootstrap()
@@ -98,7 +98,7 @@ func TestMiseInstallWithInstalledKeyword(t *testing.T) {
 func TestMiseInstallWithLatestAfterInstalled(t *testing.T) {
 	miseInstallDir := t.TempDir()
 	miseDataDir := t.TempDir()
-	miseProvider, err := mise.NewToolProvider(miseInstallDir, miseDataDir, false, false)
+	miseProvider, err := mise.NewToolProvider(miseInstallDir, miseDataDir, false, false, nil)
 	require.NoError(t, err)
 
 	err = miseProvider.Bootstrap()

--- a/integrationtests/toolprovider/mise/install_nixpkgs_ruby_test.go
+++ b/integrationtests/toolprovider/mise/install_nixpkgs_ruby_test.go
@@ -66,7 +66,7 @@ func TestMiseInstallNixpkgsRuby(t *testing.T) {
 	for _, tt := range tests {
 		miseInstallDir := t.TempDir()
 		miseDataDir := t.TempDir()
-		miseProvider, err := mise.NewToolProvider(miseInstallDir, miseDataDir, true, false)
+		miseProvider, err := mise.NewToolProvider(miseInstallDir, miseDataDir, true, false, nil)
 		require.NoError(t, err)
 
 		err = miseProvider.Bootstrap()

--- a/integrationtests/toolprovider/mise/install_nodejs_test.go
+++ b/integrationtests/toolprovider/mise/install_nodejs_test.go
@@ -26,7 +26,7 @@ func TestMiseInstallNodeVersion(t *testing.T) {
 	for _, tt := range tests {
 		miseInstallDir := t.TempDir()
 		miseDataDir := t.TempDir()
-		miseProvider, err := mise.NewToolProvider(miseInstallDir, miseDataDir, false, false)
+		miseProvider, err := mise.NewToolProvider(miseInstallDir, miseDataDir, false, false, nil)
 		require.NoError(t, err)
 
 		err = miseProvider.Bootstrap()

--- a/integrationtests/toolprovider/mise/is_mise_installed_test.go
+++ b/integrationtests/toolprovider/mise/is_mise_installed_test.go
@@ -16,7 +16,7 @@ import (
 func TestBootstrapSkipsInstallationWhenMiseAlreadyInstalled(t *testing.T) {
 	miseInstallDir := t.TempDir()
 	miseDataDir := t.TempDir()
-	miseProvider, err := mise.NewToolProvider(miseInstallDir, miseDataDir, false, false)
+	miseProvider, err := mise.NewToolProvider(miseInstallDir, miseDataDir, false, false, nil)
 	require.NoError(t, err)
 
 	// Should install

--- a/integrationtests/toolprovider/mise/plugin_registry_test.go
+++ b/integrationtests/toolprovider/mise/plugin_registry_test.go
@@ -15,7 +15,7 @@ import (
 func TestPluginRegistry_KnownTool(t *testing.T) {
 	miseInstallDir := t.TempDir()
 	miseDataDir := t.TempDir()
-	miseProvider, err := mise.NewToolProvider(miseInstallDir, miseDataDir, false, false)
+	miseProvider, err := mise.NewToolProvider(miseInstallDir, miseDataDir, false, false, nil)
 	require.NoError(t, err)
 
 	err = miseProvider.Bootstrap()
@@ -36,7 +36,7 @@ func TestPluginRegistry_KnownTool(t *testing.T) {
 func TestPluginRegistry_CoreTool(t *testing.T) {
 	miseInstallDir := t.TempDir()
 	miseDataDir := t.TempDir()
-	miseProvider, err := mise.NewToolProvider(miseInstallDir, miseDataDir, false, false)
+	miseProvider, err := mise.NewToolProvider(miseInstallDir, miseDataDir, false, false, nil)
 	require.NoError(t, err)
 
 	err = miseProvider.Bootstrap()
@@ -57,7 +57,7 @@ func TestPluginRegistry_CoreTool(t *testing.T) {
 func TestPluginRegistry_UnknownTool(t *testing.T) {
 	miseInstallDir := t.TempDir()
 	miseDataDir := t.TempDir()
-	miseProvider, err := mise.NewToolProvider(miseInstallDir, miseDataDir, false, false)
+	miseProvider, err := mise.NewToolProvider(miseInstallDir, miseDataDir, false, false, nil)
 	require.NoError(t, err)
 
 	err = miseProvider.Bootstrap()
@@ -86,7 +86,7 @@ func TestPluginRegistry_UnknownTool(t *testing.T) {
 func TestPluginRegistry_CustomPluginURL(t *testing.T) {
 	miseInstallDir := t.TempDir()
 	miseDataDir := t.TempDir()
-	miseProvider, err := mise.NewToolProvider(miseInstallDir, miseDataDir, false, false)
+	miseProvider, err := mise.NewToolProvider(miseInstallDir, miseDataDir, false, false, nil)
 	require.NoError(t, err)
 
 	err = miseProvider.Bootstrap()
@@ -108,7 +108,7 @@ func TestPluginRegistry_CustomPluginURL(t *testing.T) {
 func TestPluginRegistry_EmptyToolName(t *testing.T) {
 	miseInstallDir := t.TempDir()
 	miseDataDir := t.TempDir()
-	miseProvider, err := mise.NewToolProvider(miseInstallDir, miseDataDir, false, false)
+	miseProvider, err := mise.NewToolProvider(miseInstallDir, miseDataDir, false, false, nil)
 	require.NoError(t, err)
 
 	err = miseProvider.Bootstrap()

--- a/toolprovider/info.go
+++ b/toolprovider/info.go
@@ -137,7 +137,8 @@ type miseToolEntry struct {
 
 func listMiseTools(activeOnly bool, silent bool) ([]InstalledTool, error) {
 	miseInstallDir, miseDataDir := mise.Dirs(mise.GetMiseVersion())
-	miseProvider, err := mise.NewToolProvider(miseInstallDir, miseDataDir, false, silent)
+	// extraEnvs=nil: this runs as a CLI subcommand from a user's shell, so secrets are already in the process env.
+	miseProvider, err := mise.NewToolProvider(miseInstallDir, miseDataDir, false, silent, nil)
 	if err != nil {
 		return nil, fmt.Errorf("create mise provider: %w", err)
 	}

--- a/toolprovider/mise/execenv/execenv.go
+++ b/toolprovider/mise/execenv/execenv.go
@@ -27,15 +27,13 @@ type ExecEnv interface {
 
 type MiseExecEnv struct {
 	installDir string
-
-	extraEnvs map[string]string
+	ExtraEnvs  map[string]string
 }
 
-// extraEnvs: additional env vars that configure mise and are required for its operation.
 func NewMiseExecEnv(installDir string, extraEnvs map[string]string) MiseExecEnv {
 	return MiseExecEnv{
 		installDir: installDir,
-		extraEnvs:  extraEnvs,
+		ExtraEnvs:  extraEnvs,
 	}
 }
 
@@ -70,7 +68,7 @@ func (e MiseExecEnv) RunMiseWithTimeoutAndEnvs(timeout time.Duration, additional
 	executable := filepath.Join(e.installDir, "bin", "mise")
 	cmd := exec.CommandContext(ctx, executable, args...)
 	cmd.Env = os.Environ()
-	for k, v := range e.extraEnvs {
+	for k, v := range e.ExtraEnvs {
 		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", k, v))
 	}
 	for k, v := range additionalEnvs {

--- a/toolprovider/mise/mise.go
+++ b/toolprovider/mise/mise.go
@@ -48,7 +48,7 @@ type MiseToolProvider struct {
 	Silent         bool
 }
 
-func NewToolProvider(installDir string, dataDir string, useFastInstall, silent bool) (*MiseToolProvider, error) {
+func NewToolProvider(installDir string, dataDir string, useFastInstall, silent bool, extraEnvs map[string]string) (*MiseToolProvider, error) {
 	if installDir == "" {
 		return nil, errors.New("install directory must be provided")
 	}
@@ -66,21 +66,25 @@ func NewToolProvider(installDir string, dataDir string, useFastInstall, silent b
 		return nil, fmt.Errorf("create data dir at %s: %w", dataDir, err)
 	}
 
+	// https://mise.jdx.dev/configuration.html#environment-variables
+	miseEnvs := map[string]string{
+		"MISE_DATA_DIR": dataDir,
+
+		// Isolate this mise instance's "global" config from system-wide config.
+		"MISE_CONFIG_DIR":         filepath.Join(dataDir),
+		"MISE_GLOBAL_CONFIG_FILE": filepath.Join(dataDir, "config.toml"),
+		"MISE_GLOBAL_CONFIG_ROOT": dataDir,
+
+		// Enable corepack by default for Node.js installations. This mirrors the preinstalled Node versions on Bitrise stacks.
+		// https://mise.jdx.dev/lang/node.html#environment-variables
+		"MISE_NODE_COREPACK": "1",
+	}
+	for k, v := range extraEnvs {
+		miseEnvs[k] = v
+	}
+
 	return &MiseToolProvider{
-		ExecEnv: execenv.NewMiseExecEnv(installDir, map[string]string{
-			// https://mise.jdx.dev/configuration.html#environment-variables
-			"MISE_DATA_DIR": dataDir,
-
-			// Isolate this mise instance's "global" config from system-wide config.
-			"MISE_CONFIG_DIR":         filepath.Join(dataDir),
-			"MISE_GLOBAL_CONFIG_FILE": filepath.Join(dataDir, "config.toml"),
-			"MISE_GLOBAL_CONFIG_ROOT": dataDir,
-
-			// Enable corepack by default for Node.js installations. This mirrors the preinstalled Node versions on Bitrise stacks.
-			// https://mise.jdx.dev/lang/node.html#environment-variables
-			"MISE_NODE_COREPACK": "1",
-		},
-		),
+		ExecEnv:        execenv.NewMiseExecEnv(installDir, miseEnvs),
 		UseFastInstall: useFastInstall,
 		Silent:         silent,
 	}, nil

--- a/toolprovider/mise/mise_test.go
+++ b/toolprovider/mise/mise_test.go
@@ -1,0 +1,91 @@
+package mise
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/bitrise-io/bitrise/v2/toolprovider/mise/execenv"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewToolProvider_InvalidDirs(t *testing.T) {
+	tests := []struct {
+		name       string
+		installDir string
+		dataDir    string
+	}{
+		{name: "empty installDir", installDir: "", dataDir: t.TempDir()},
+		{name: "empty dataDir", installDir: t.TempDir(), dataDir: ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := NewToolProvider(tt.installDir, tt.dataDir, false, false, nil)
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestNewToolProvider_CreatesDirs(t *testing.T) {
+	base := t.TempDir()
+	installDir := filepath.Join(base, "install")
+	dataDir := filepath.Join(base, "data")
+
+	_, err := NewToolProvider(installDir, dataDir, false, false, nil)
+	require.NoError(t, err)
+
+	_, err = os.Stat(installDir)
+	assert.NoError(t, err, "installDir should be created")
+	_, err = os.Stat(dataDir)
+	assert.NoError(t, err, "dataDir should be created")
+}
+
+func TestNewToolProvider_MiseEnvsAlwaysSet(t *testing.T) {
+	dataDir := t.TempDir()
+
+	p, err := NewToolProvider(t.TempDir(), dataDir, false, false, nil)
+	require.NoError(t, err)
+
+	envs := p.ExecEnv.(execenv.MiseExecEnv).ExtraEnvs
+	assert.Equal(t, dataDir, envs["MISE_DATA_DIR"])
+	assert.Equal(t, dataDir, envs["MISE_CONFIG_DIR"])
+	assert.Equal(t, "1", envs["MISE_NODE_COREPACK"])
+}
+
+func TestNewToolProvider_ExtraEnvs(t *testing.T) {
+	tests := []struct {
+		name      string
+		extraEnvs map[string]string
+		assertFn  func(t *testing.T, envs map[string]string)
+	}{
+		{
+			name:      "nil extraEnvs",
+			extraEnvs: nil,
+			assertFn: func(t *testing.T, envs map[string]string) {
+				assert.NotContains(t, envs, "GITHUB_TOKEN")
+			},
+		},
+		{
+			name:      "extraEnvs are merged in",
+			extraEnvs: map[string]string{"GITHUB_TOKEN": "ghp_test"},
+			assertFn: func(t *testing.T, envs map[string]string) {
+				assert.Equal(t, "ghp_test", envs["GITHUB_TOKEN"])
+			},
+		},
+		{
+			name:      "extraEnvs override mise-specific envs",
+			extraEnvs: map[string]string{"MISE_NODE_COREPACK": "0"},
+			assertFn: func(t *testing.T, envs map[string]string) {
+				assert.Equal(t, "0", envs["MISE_NODE_COREPACK"])
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p, err := NewToolProvider(t.TempDir(), t.TempDir(), false, false, tt.extraEnvs)
+			require.NoError(t, err)
+			tt.assertFn(t, p.ExecEnv.(execenv.MiseExecEnv).ExtraEnvs)
+		})
+	}
+}

--- a/toolprovider/run.go
+++ b/toolprovider/run.go
@@ -18,7 +18,27 @@ import (
 	"github.com/bitrise-io/bitrise/v2/toolprovider/versionresolver"
 )
 
-func RunDeclarativeSetup(config models.BitriseDataModel, tracker analytics.Tracker, isCI bool, workflowID string, silent bool, providerOverride *string, fastInstallOverride *bool) ([]provider.EnvironmentActivation, error) {
+// knownGitHubTokenEnvVars lists the env var names that users possibly set as a valid GitHub API token.
+var knownGitHubTokenEnvVars = []string{
+	"GITHUB_TOKEN",
+	"GH_TOKEN",
+	"GITHUB_API_TOKEN",
+	"MISE_GITHUB_TOKEN",
+	"MISE_GITHUB_ENTERPRISE_TOKEN",
+}
+
+// findGitHubTokenEnv returns the first known GitHub token env var found in envs,
+// checked in priority order defined by knownGitHubTokenEnvVars.
+func findGitHubTokenEnv(envs map[string]string) (name, value string, found bool) {
+	for _, n := range knownGitHubTokenEnvVars {
+		if v, ok := envs[n]; ok {
+			return n, v, true
+		}
+	}
+	return "", "", false
+}
+
+func RunDeclarativeSetup(config models.BitriseDataModel, tracker analytics.Tracker, isCI bool, workflowID string, silent bool, providerOverride *string, fastInstallOverride *bool, envs map[string]string) ([]provider.EnvironmentActivation, error) {
 	toolRequests, err := getToolRequests(config, workflowID)
 	if err != nil {
 		return nil, fmt.Errorf("tools: %w", err)
@@ -43,10 +63,20 @@ func RunDeclarativeSetup(config models.BitriseDataModel, tracker analytics.Track
 		useFastInstall = *fastInstallOverride
 	}
 
-	return installTools(toolRequests, provider, useFastInstall, tracker, silent)
+	var extraEnvs map[string]string
+	if tokenName, tokenValue, ok := findGitHubTokenEnv(envs); ok {
+		if !silent {
+			log.Printf("Using %s for GitHub API authentication during tool setup", tokenName)
+		}
+		// Mise recognizes [a variety of env vars](// See https://mise.jdx.dev/dev-tools/github-tokens.html), but let's use
+		// a generic one because this layer is provider-agnostic.
+		extraEnvs = map[string]string{"GITHUB_TOKEN": tokenValue}
+	}
+
+	return installTools(toolRequests, provider, useFastInstall, tracker, silent, extraEnvs)
 }
 
-func installTools(toolRequests []provider.ToolRequest, providerID string, useFastInstall bool, tracker analytics.Tracker, silent bool) ([]provider.EnvironmentActivation, error) {
+func installTools(toolRequests []provider.ToolRequest, providerID string, useFastInstall bool, tracker analytics.Tracker, silent bool, extraEnvs map[string]string) ([]provider.EnvironmentActivation, error) {
 	startTime := time.Now()
 
 	if !silent {
@@ -68,7 +98,7 @@ func installTools(toolRequests []provider.ToolRequest, providerID string, useFas
 		}
 	case "mise":
 		miseInstallDir, miseDataDir := mise.Dirs(mise.GetMiseVersion())
-		toolProvider, err = mise.NewToolProvider(miseInstallDir, miseDataDir, useFastInstall, silent)
+		toolProvider, err = mise.NewToolProvider(miseInstallDir, miseDataDir, useFastInstall, silent, extraEnvs)
 		if err != nil {
 			return nil, fmt.Errorf("create mise tool provider: %w", err)
 		}
@@ -162,7 +192,8 @@ func installTools(toolRequests []provider.ToolRequest, providerID string, useFas
 
 // InstallSingleTool installs a single tool with the specified version using the given provider.
 func InstallSingleTool(toolRequest provider.ToolRequest, providerID string, useFastInstall bool, tracker analytics.Tracker, silent bool) ([]provider.EnvironmentActivation, error) {
-	return installTools([]provider.ToolRequest{toolRequest}, providerID, useFastInstall, tracker, silent)
+	// extraEnvs=nil: this runs as a CLI subcommand from a user's shell, so secrets are already in the process env.
+	return installTools([]provider.ToolRequest{toolRequest}, providerID, useFastInstall, tracker, silent, nil)
 }
 
 // GetLatestVersion queries the latest version of a tool without installing it (installed or released).
@@ -184,7 +215,8 @@ func GetLatestVersion(toolRequest provider.ToolRequest, providerID string, useFa
 		return asdfProvider.ResolveLatestVersion(toolRequest)
 	case "mise":
 		miseInstallDir, miseDataDir := mise.Dirs(mise.GetMiseVersion())
-		miseProvider, err := mise.NewToolProvider(miseInstallDir, miseDataDir, useFastInstall, silent)
+		// extraEnvs=nil: this runs as a CLI subcommand from a user's shell, so secrets are already in the process env.
+		miseProvider, err := mise.NewToolProvider(miseInstallDir, miseDataDir, useFastInstall, silent, nil)
 		if err != nil {
 			return "", fmt.Errorf("create mise tool provider: %w", err)
 		}

--- a/toolprovider/run_test.go
+++ b/toolprovider/run_test.go
@@ -1,0 +1,71 @@
+package toolprovider
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFindGitHubTokenEnv(t *testing.T) {
+	tests := []struct {
+		name          string
+		envs          map[string]string
+		expectedName  string
+		expectedValue string
+		expectedFound bool
+	}{
+		{
+			name:          "empty map",
+			envs:          map[string]string{},
+			expectedFound: false,
+		},
+		{
+			name:          "no known tokens",
+			envs:          map[string]string{"SOME_OTHER_VAR": "value"},
+			expectedFound: false,
+		},
+		{
+			name:          "GITHUB_TOKEN present",
+			envs:          map[string]string{"GITHUB_TOKEN": "ghp_abc123"},
+			expectedName:  "GITHUB_TOKEN",
+			expectedValue: "ghp_abc123",
+			expectedFound: true,
+		},
+		{
+			name:          "MISE_GITHUB_TOKEN present",
+			envs:          map[string]string{"MISE_GITHUB_TOKEN": "ghp_xyz"},
+			expectedName:  "MISE_GITHUB_TOKEN",
+			expectedValue: "ghp_xyz",
+			expectedFound: true,
+		},
+		{
+			name: "GITHUB_TOKEN takes priority over MISE_GITHUB_TOKEN",
+			envs: map[string]string{
+				"GITHUB_TOKEN":      "github_value",
+				"MISE_GITHUB_TOKEN": "mise_value",
+			},
+			expectedName:  "GITHUB_TOKEN",
+			expectedValue: "github_value",
+			expectedFound: true,
+		},
+		{
+			name: "GITHUB_TOKEN takes priority over GITHUB_API_TOKEN",
+			envs: map[string]string{
+				"GITHUB_TOKEN":     "github_value",
+				"GITHUB_API_TOKEN": "api_value",
+			},
+			expectedName:  "GITHUB_TOKEN",
+			expectedValue: "github_value",
+			expectedFound: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			name, value, found := findGitHubTokenEnv(tt.envs)
+			assert.Equal(t, tt.expectedFound, found)
+			assert.Equal(t, tt.expectedName, name)
+			assert.Equal(t, tt.expectedValue, value)
+		})
+	}
+}

--- a/toolprovider/setup.go
+++ b/toolprovider/setup.go
@@ -33,7 +33,8 @@ func RunVersionFileSetup(versionFilePaths []string, tracker analytics.Tracker, s
 		useFastInstall = *fastInstallOverride
 	}
 
-	return installTools(toolRequests, provider, useFastInstall, tracker, silent)
+	// extraEnvs=nil: this runs as a CLI subcommand from a user's shell, so secrets are already in the process env.
+	return installTools(toolRequests, provider, useFastInstall, tracker, silent, nil)
 }
 
 func makeToolRequests(versionFilePaths []string, silent bool) ([]provider.ToolRequest, error) {


### PR DESCRIPTION
## Summary

Fixes GitHub API rate limit errors during declarative tool setup by forwarding a GitHub token from Bitrise project secrets into the mise process environment.

## Context

When a workflow uses declarative tool setup (`tools:` block), regular env vars and secrets are not applies (this is not the case for CLI calls running inside a script step within a workflow). Therefore, even if a `$GITHUB_TOKEN` or similar secret is defined, it's not exposed to tool setup and the tool providers. Without authentication it's limited to 60 requests/hr.

## Changes

Declarative tool setup is invoked after collecting env vars and secrets. This PR adds a heuristic to collect common GitHub-token-like env vars, and if one is found, expose it as `$GITHUB_TOKEN` to the toolprovider exec env.