### PR TITLE
Bump stable mise, use --json flag for ls-remote calls

### DIFF
--- a/toolprovider/mise/install_test.go
+++ b/toolprovider/mise/install_test.go
@@ -134,7 +134,7 @@ func TestCanBeInstalledWithNix(t *testing.T) {
 				m.setResponse(fmt.Sprintf("plugin install %s %s", nixpkgs.PluginName, nixpkgs.PluginGitURL), "")
 				m.setResponse(fmt.Sprintf("plugin update %s", nixpkgs.PluginName), "")
 				m.setResponse("ls --installed --json --quiet ruby", "[]")
-				m.setResponse("ls-remote --quiet nixpkgs:ruby@3.3.9", "3.3.9")
+				m.setResponse("ls-remote --quiet --json nixpkgs:ruby@3.3.9", `[{"version":"3.3.9"}]`)
 			},
 			want: true,
 		},
@@ -148,7 +148,7 @@ func TestCanBeInstalledWithNix(t *testing.T) {
 				m.setResponse(fmt.Sprintf("plugin install %s %s", nixpkgs.PluginName, nixpkgs.PluginGitURL), "")
 				m.setResponse(fmt.Sprintf("plugin update %s", nixpkgs.PluginName), "")
 				m.setResponse("ls --installed --json --quiet ruby", "[]")
-				m.setResponse("ls-remote --quiet nixpkgs:ruby@3.3", "3.3.8\n3.3.9")
+				m.setResponse("ls-remote --quiet --json nixpkgs:ruby@3.3", `[{"version":"3.3.8"},{"version":"3.3.9"}]`)
 			},
 			want: true,
 		},
@@ -162,7 +162,7 @@ func TestCanBeInstalledWithNix(t *testing.T) {
 				m.setResponse(fmt.Sprintf("plugin install %s %s", nixpkgs.PluginName, nixpkgs.PluginGitURL), "")
 				m.setResponse(fmt.Sprintf("plugin update %s", nixpkgs.PluginName), "")
 				m.setResponse("ls --installed --json --quiet ruby", "[]")
-				m.setResponse("ls-remote --quiet nixpkgs:ruby@0.0.1", "")
+				m.setResponse("ls-remote --quiet --json nixpkgs:ruby@0.0.1", "[]")
 			},
 			want: false,
 		},
@@ -187,7 +187,7 @@ func TestCanBeInstalledWithNix(t *testing.T) {
 				m.setResponse(fmt.Sprintf("plugin install %s %s", nixpkgs.PluginName, nixpkgs.PluginGitURL), "")
 				m.setResponse(fmt.Sprintf("plugin update %s", nixpkgs.PluginName), "")
 				m.setResponse("ls --installed --json --quiet ruby", "[]")
-				m.setError("ls-remote --quiet nixpkgs:ruby@3.3.9", fmt.Errorf("fake error"))
+				m.setError("ls-remote --quiet --json nixpkgs:ruby@3.3.9", fmt.Errorf("fake error"))
 			},
 			want: false,
 		},

--- a/toolprovider/mise/mise.go
+++ b/toolprovider/mise/mise.go
@@ -33,13 +33,13 @@ var misePreviewChecksums = map[string]string{
 	"macos-arm64": "9d6e2bfea3e00ffb566ad1a369914cb029c32a28eb4b699e8655cf3c3d4ef87e",
 }
 
-const miseStableVersion = "v2025.12.1"
+const miseStableVersion = "v2026.3.16"
 
 var miseStableChecksums = map[string]string{
-	"linux-x64":   "0e62b1a0a8b87329d0cf24fc6af5d1c3aae0819194bea2f43fcf3f556edc9c29",
-	"linux-arm64": "35573ccc8f13895884b8e7a3365736c2942ad531ce24fc420ba0a941dbb57ce5",
-	"macos-x64":   "68b250632b1f1f29f6116ca513d1641097dfdc2cf05520ee0ca23907962b3d6f",
-	"macos-arm64": "94659ac9b7b30d149464ef4a76498182b0c5cadeccef1811ab9e75ff3d1ad159",
+	"linux-x64":   "96417e479462d9a1836654461ec4b86eba8ff4f12260c09b93800fd50c25490c",
+	"linux-arm64": "6e0362723bddec3b25923a6c7c447c3f10eba4bf6e3db6973e175fa0a60ab974",
+	"macos-x64":   "a6f6f320b547dec3eff321e301fa05268dfc73a620d35ec3292603fbab1c4c29",
+	"macos-arm64": "9d6e2bfea3e00ffb566ad1a369914cb029c32a28eb4b699e8655cf3c3d4ef87e",
 }
 
 type MiseToolProvider struct {

--- a/toolprovider/mise/resolve.go
+++ b/toolprovider/mise/resolve.go
@@ -91,17 +91,14 @@ func versionExistsLocal(execEnv execenv.ExecEnv, toolName provider.ToolID, versi
 
 // listRemoteVersions fetches all available remote versions for a tool.
 func listRemoteVersions(execEnv execenv.ExecEnv, toolName provider.ToolID) ([]string, error) {
-	output, err := execEnv.RunMiseWithTimeout(execenv.DefaultTimeout, "ls-remote", "--quiet", string(toolName))
+	output, err := execEnv.RunMiseWithTimeout(execenv.DefaultTimeout, "ls-remote", "--quiet", "--json", string(toolName))
 	if err != nil {
 		return nil, fmt.Errorf("mise ls-remote %s: %w", toolName, err)
 	}
 
-	var versions []string
-	for _, line := range strings.Split(strings.TrimSpace(string(output)), "\n") {
-		line = strings.TrimSpace(line)
-		if line != "" {
-			versions = append(versions, line)
-		}
+	versions, err := parseRemoteVersionsJSON(strings.TrimSpace(string(output)))
+	if err != nil {
+		return nil, fmt.Errorf("parsing mise ls-remote %s output: %w", toolName, err)
 	}
 	return versions, nil
 }
@@ -114,12 +111,35 @@ func versionExistsRemote(execEnv execenv.ExecEnv, toolName provider.ToolID, vers
 		versionString = fmt.Sprintf("%s@%s", toolName, version)
 	}
 
-	output, err := execEnv.RunMiseWithTimeout(execenv.DefaultTimeout, "ls-remote", "--quiet", versionString)
+	output, err := execEnv.RunMiseWithTimeout(execenv.DefaultTimeout, "ls-remote", "--quiet", "--json", versionString)
 	if err != nil {
 		return false, fmt.Errorf("mise ls-remote %s: %w", versionString, err)
 	}
 
-	return strings.TrimSpace(string(output)) != "", nil
+	versions, err := parseRemoteVersionsJSON(strings.TrimSpace(string(output)))
+	if err != nil {
+		return false, fmt.Errorf("parsing mise ls-remote %s output: %w", versionString, err)
+	}
+	return len(versions) > 0, nil
+}
+
+func parseRemoteVersionsJSON(raw string) ([]string, error) {
+	if raw == "" {
+		return nil, nil
+	}
+	var entries []struct {
+		Version string `json:"version"`
+	}
+	if err := json.Unmarshal([]byte(raw), &entries); err != nil {
+		return nil, err
+	}
+	versions := make([]string, 0, len(entries))
+	for _, e := range entries {
+		if e.Version != "" {
+			versions = append(versions, e.Version)
+		}
+	}
+	return versions, nil
 }
 
 func normalizeRequest(

--- a/toolprovider/mise/resolve_test.go
+++ b/toolprovider/mise/resolve_test.go
@@ -87,9 +87,9 @@ func miseLsInstalledCmd(tool provider.ToolID) string {
 
 func miseLsRemoteCmd(tool provider.ToolID, version string) string {
 	if version != "" && version != "latest" && version != "installed" {
-		return fmt.Sprintf("ls-remote --quiet %s@%s", tool, version)
+		return fmt.Sprintf("ls-remote --quiet --json %s@%s", tool, version)
 	}
-	return fmt.Sprintf("ls-remote --quiet %s", tool)
+	return fmt.Sprintf("ls-remote --quiet --json %s", tool)
 }
 
 var installedVersionsJSON = `[
@@ -137,6 +137,39 @@ func TestParseInstalledVersionsJSON(t *testing.T) {
 		}
 		if got != tc.exists {
 			t.Fatalf("%s: expected exists=%v got %v", tc.name, tc.exists, got)
+		}
+	}
+}
+
+func TestParseRemoteVersionsJSON(t *testing.T) {
+	cases := []struct {
+		name     string
+		input    string
+		expected []string
+		wantErr  bool
+	}{
+		{"empty string", "", nil, false},
+		{"empty array", "[]", nil, false},
+		{"single version", `[{"version":"3.3.0"}]`, []string{"3.3.0"}, false},
+		{"multiple versions", `[{"version":"3.3.0"},{"version":"3.3.1"},{"version":"3.3.2"}]`, []string{"3.3.0", "3.3.1", "3.3.2"}, false},
+		{"with created_at field", `[{"version":"2.62.0","created_at":"2024-11-14T15:40:35Z"}]`, []string{"2.62.0"}, false},
+		{"malformed JSON", `{"version":"3.3.0"}`, nil, true},
+	}
+	for _, tc := range cases {
+		got, err := parseRemoteVersionsJSON(tc.input)
+		if tc.wantErr && err == nil {
+			t.Fatalf("%s: expected error, got nil", tc.name)
+		}
+		if !tc.wantErr && err != nil {
+			t.Fatalf("%s: unexpected error: %v", tc.name, err)
+		}
+		if len(got) != len(tc.expected) {
+			t.Fatalf("%s: expected %v, got %v", tc.name, tc.expected, got)
+		}
+		for i := range got {
+			if got[i] != tc.expected[i] {
+				t.Fatalf("%s: expected %v, got %v", tc.name, tc.expected, got)
+			}
 		}
 	}
 }
@@ -385,7 +418,7 @@ func TestVersionExistsRemote(t *testing.T) {
 			toolName: "ruby",
 			version:  "3.3.0",
 			setupFake: func(m *fakeExecEnv) {
-				m.setResponse(miseLsRemoteCmd("ruby", "3.3.0"), "3.3.0\n3.3.1\n3.3.2")
+				m.setResponse(miseLsRemoteCmd("ruby", "3.3.0"), `[{"version":"3.3.0"},{"version":"3.3.1"},{"version":"3.3.2"}]`)
 			},
 			expectedExists: true,
 			wantErr:        false,
@@ -395,7 +428,7 @@ func TestVersionExistsRemote(t *testing.T) {
 			toolName: "ruby",
 			version:  "9.9.9",
 			setupFake: func(m *fakeExecEnv) {
-				m.setResponse(miseLsRemoteCmd("ruby", "9.9.9"), "")
+				m.setResponse(miseLsRemoteCmd("ruby", "9.9.9"), "[]")
 			},
 			expectedExists: false,
 			wantErr:        false,
@@ -405,7 +438,7 @@ func TestVersionExistsRemote(t *testing.T) {
 			toolName: "go",
 			version:  "latest",
 			setupFake: func(m *fakeExecEnv) {
-				m.setResponse(miseLsRemoteCmd("go", "latest"), "1.21.0\n1.22.0\n1.23.0")
+				m.setResponse(miseLsRemoteCmd("go", "latest"), `[{"version":"1.21.0"},{"version":"1.22.0"},{"version":"1.23.0"}]`)
 			},
 			expectedExists: true,
 			wantErr:        false,
@@ -415,7 +448,7 @@ func TestVersionExistsRemote(t *testing.T) {
 			toolName: "python",
 			version:  "",
 			setupFake: func(m *fakeExecEnv) {
-				m.setResponse(miseLsRemoteCmd("python", ""), "3.11.0\n3.12.0")
+				m.setResponse(miseLsRemoteCmd("python", ""), `[{"version":"3.11.0"},{"version":"3.12.0"}]`)
 			},
 			expectedExists: true,
 			wantErr:        false,


### PR DESCRIPTION
## Summary
Switch \`mise ls-remote\` calls to use the \`--json\` flag, replacing brittle line-splitting with structured JSON parsing. Also bumps the stable pinned mise version to match preview, since the old stable version predated this flag.

## Changes
- \`listRemoteVersions\` and \`versionExistsRemote\` now pass \`--json\` to \`mise ls-remote\`
- New \`parseRemoteVersionsJSON\` helper decodes the \`[{"version":"..."}]\` array; extra fields like \`created_at\` and \`rolling\` are ignored
- Test fixtures updated to JSON format; \`TestParseRemoteVersionsJSON\` added for the new helper
- Stable pinned mise bumped from \`v2025.12.1\` → \`v2026.3.16\` (same as preview): \`v2025.12.1\` was released Dec 8 2025, but \`--json\` for \`ls-remote\` landed in \`v2025.12.5\` on Dec 13 2025 via [jdx/mise#7279](https://github.com/jdx/mise/pull/7279)

## Note on GCS mirror
Per the update process in \`mise.go\`: the stable artifacts for \`v2026.3.16\` should already be mirrored to GCS since they were previously pinned for preview. No new mirror work needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)