### PR TITLE
toolprovider: report failed tool setup analytics reliably

### DIFF
--- a/toolprovider/run.go
+++ b/toolprovider/run.go
@@ -33,6 +33,17 @@ var knownGitHubTokenEnvVars = []string{
 	"MISE_GITHUB_ENTERPRISE_TOKEN",
 }
 
+// findGitHubTokenEnv returns the first known GitHub token env var found in envs,
+// checked in priority order defined by knownGitHubTokenEnvVars.
+func findGitHubTokenEnv(envs map[string]string) (name, value string, found bool) {
+	for _, n := range knownGitHubTokenEnvVars {
+		if v, ok := envs[n]; ok {
+			return n, v, true
+		}
+	}
+	return "", "", false
+}
+
 func RunDeclarativeSetup(config models.BitriseDataModel, tracker analytics.Tracker, isCI bool, workflowID string, silent bool, providerOverride *string, fastInstallOverride *bool, envs map[string]string) ([]provider.EnvironmentActivation, error) {
 	toolRequests, err := getToolRequests(config, workflowID)
 	if err != nil {
@@ -244,15 +255,4 @@ func GetLatestVersion(toolRequest provider.ToolRequest, providerID string, useFa
 	default:
 		return "", fmt.Errorf("unsupported tool provider: %s", providerID)
 	}
-}
-
-// findGitHubTokenEnv returns the first known GitHub token env var found in envs,
-// checked in priority order defined by knownGitHubTokenEnvVars.
-func findGitHubTokenEnv(envs map[string]string) (name, value string, found bool) {
-	for _, n := range knownGitHubTokenEnvVars {
-		if v, ok := envs[n]; ok {
-			return n, v, true
-		}
-	}
-	return "", "", false
 }

--- a/toolprovider/run.go
+++ b/toolprovider/run.go
@@ -18,6 +18,12 @@ import (
 	"github.com/bitrise-io/bitrise/v2/toolprovider/versionresolver"
 )
 
+type toolSetupResult struct {
+	request   provider.ToolRequest
+	result    provider.ToolInstallResult
+	startTime time.Time
+}
+
 func RunDeclarativeSetup(config models.BitriseDataModel, tracker analytics.Tracker, isCI bool, workflowID string, silent bool, providerOverride *string, fastInstallOverride *bool) ([]provider.EnvironmentActivation, error) {
 	toolRequests, err := getToolRequests(config, workflowID)
 	if err != nil {
@@ -112,7 +118,18 @@ func installTools(toolRequests []provider.ToolRequest, providerID string, useFas
 		printToolRequests(toolRequests)
 	}
 
-	var toolInstalls []provider.ToolInstallResult
+	return installResolvedTools(toolRequests, providerID, toolProvider, tracker, silent, startTime)
+}
+
+func installResolvedTools(
+	toolRequests []provider.ToolRequest,
+	providerID string,
+	toolProvider provider.ToolProvider,
+	tracker analytics.Tracker,
+	silent bool,
+	startTime time.Time,
+) ([]provider.EnvironmentActivation, error) {
+	var toolSetups []toolSetupResult
 	for _, toolRequest := range toolRequests {
 		toolStartTime := time.Now()
 		canonicalToolID := alias.GetCanonicalToolID(toolRequest.ToolName)
@@ -124,30 +141,38 @@ func installTools(toolRequests []provider.ToolRequest, providerID string, useFas
 
 		result, err := toolProvider.InstallTool(toolRequest)
 		if err != nil {
+			tracker.SendToolSetupEvent(providerID, toolRequest, result, false, time.Since(toolStartTime))
+
 			var toolErr provider.ToolInstallError
 			if errors.As(err, &toolErr) {
 				printInstallError(toolErr)
 				return nil, fmt.Errorf("see error details above")
 			}
 
-			tracker.SendToolSetupEvent(providerID, toolRequest, result, false, time.Since(toolStartTime))
 			return nil, fmt.Errorf("install %s %s: %w", toolRequest.ToolName, toolRequest.UnparsedVersion, err)
 		}
-		toolInstalls = append(toolInstalls, result)
+
+		toolSetups = append(toolSetups, toolSetupResult{
+			request:   toolRequest,
+			result:    result,
+			startTime: toolStartTime,
+		})
+
 		duration := time.Since(toolStartTime)
 		if !silent {
 			printInstallResult(toolRequest, result, duration)
 		}
-		tracker.SendToolSetupEvent(providerID, toolRequest, result, true, duration)
 	}
 
 	var activations []provider.EnvironmentActivation
-	for _, install := range toolInstalls {
-		activation, err := toolProvider.ActivateEnv(install)
+	for _, setup := range toolSetups {
+		activation, err := toolProvider.ActivateEnv(setup.result)
 		if err != nil {
-			return nil, fmt.Errorf("activate %s: %w", install.ToolName, err)
+			tracker.SendToolSetupEvent(providerID, setup.request, setup.result, false, time.Since(setup.startTime))
+			return nil, fmt.Errorf("activate %s: %w", setup.result.ToolName, err)
 		}
 		activations = append(activations, activation)
+		tracker.SendToolSetupEvent(providerID, setup.request, setup.result, true, time.Since(setup.startTime))
 	}
 
 	if !silent {

--- a/toolprovider/run_test.go
+++ b/toolprovider/run_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/bitrise-io/go-utils/v2/analytics"
 	"github.com/bitrise-io/stepman/activator"
 	"github.com/stretchr/testify/require"
-  "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/assert"
 )
 
 type trackingCall struct {
@@ -150,6 +150,7 @@ func TestInstallResolvedToolsReportsSuccessAfterActivation(t *testing.T) {
 		result:       result,
 		isSuccessful: true,
 	}, tracker.toolSetupCalls[0])
+}
 
 func TestFindGitHubTokenEnv(t *testing.T) {
 	tests := []struct {

--- a/toolprovider/run_test.go
+++ b/toolprovider/run_test.go
@@ -1,0 +1,152 @@
+package toolprovider
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	clianalytics "github.com/bitrise-io/bitrise/v2/analytics"
+	"github.com/bitrise-io/bitrise/v2/toolprovider/provider"
+	"github.com/bitrise-io/go-utils/v2/analytics"
+	"github.com/bitrise-io/stepman/activator"
+	"github.com/stretchr/testify/require"
+)
+
+type trackingCall struct {
+	provider     string
+	request      provider.ToolRequest
+	result       provider.ToolInstallResult
+	isSuccessful bool
+}
+
+type capturingTracker struct {
+	toolSetupCalls []trackingCall
+}
+
+func (c *capturingTracker) SendWorkflowStarted(analytics.Properties, string, string) {}
+func (c *capturingTracker) SendWorkflowFinished(analytics.Properties, bool)          {}
+func (c *capturingTracker) SendStepStartedEvent(analytics.Properties, clianalytics.StepInfo, time.Duration, map[string]interface{}, map[string]string) {
+}
+func (c *capturingTracker) SendStepFinishedEvent(analytics.Properties, clianalytics.StepResult) {}
+func (c *capturingTracker) SendCLIWarning(string)                                               {}
+func (c *capturingTracker) SendCommandInfo(string, string, []string)                            {}
+func (c *capturingTracker) SendToolSetupEvent(providerID string, request provider.ToolRequest, result provider.ToolInstallResult, isSuccessful bool, setupTime time.Duration) {
+	c.toolSetupCalls = append(c.toolSetupCalls, trackingCall{
+		provider:     providerID,
+		request:      request,
+		result:       result,
+		isSuccessful: isSuccessful,
+	})
+}
+func (c *capturingTracker) SendStepActivationEvent(activator.ActivationType, string, bool, time.Duration, bool) {
+}
+func (c *capturingTracker) Wait()            {}
+func (c *capturingTracker) IsTracking() bool { return true }
+
+type fakeToolProvider struct {
+	installResult provider.ToolInstallResult
+	installErr    error
+	activation    provider.EnvironmentActivation
+	activationErr error
+}
+
+func (f fakeToolProvider) ID() string { return "fake" }
+
+func (f fakeToolProvider) Bootstrap() error { return nil }
+
+func (f fakeToolProvider) InstallTool(provider.ToolRequest) (provider.ToolInstallResult, error) {
+	return f.installResult, f.installErr
+}
+
+func (f fakeToolProvider) ActivateEnv(provider.ToolInstallResult) (provider.EnvironmentActivation, error) {
+	return f.activation, f.activationErr
+}
+
+func (f fakeToolProvider) ListReleasedVersions(provider.ToolID) ([]string, error) {
+	return nil, nil
+}
+
+func TestInstallResolvedToolsReportsToolInstallError(t *testing.T) {
+	tracker := &capturingTracker{}
+	request := provider.ToolRequest{
+		ToolName:        "nodejs",
+		UnparsedVersion: "999.0.0",
+	}
+
+	_, err := installResolvedTools([]provider.ToolRequest{request}, "mise", fakeToolProvider{
+		installErr: provider.ToolInstallError{
+			ToolName:         request.ToolName,
+			RequestedVersion: request.UnparsedVersion,
+			Cause:            "no matching version",
+		},
+	}, tracker, true, time.Now())
+
+	require.EqualError(t, err, "see error details above")
+	require.Len(t, tracker.toolSetupCalls, 1)
+	require.Equal(t, trackingCall{
+		provider: "mise",
+		request: provider.ToolRequest{
+			ToolName:        "nodejs",
+			UnparsedVersion: "999.0.0",
+		},
+		result:       provider.ToolInstallResult{},
+		isSuccessful: false,
+	}, tracker.toolSetupCalls[0])
+}
+
+func TestInstallResolvedToolsReportsActivationFailure(t *testing.T) {
+	tracker := &capturingTracker{}
+	request := provider.ToolRequest{
+		ToolName:        "golang",
+		UnparsedVersion: "1.22.0",
+	}
+	result := provider.ToolInstallResult{
+		ToolName:           "golang",
+		ConcreteVersion:    "1.22.0",
+		IsAlreadyInstalled: true,
+	}
+
+	_, err := installResolvedTools([]provider.ToolRequest{request}, "asdf", fakeToolProvider{
+		installResult: result,
+		activationErr: fmt.Errorf("activation failed"),
+	}, tracker, true, time.Now())
+
+	require.EqualError(t, err, "activate golang: activation failed")
+	require.Len(t, tracker.toolSetupCalls, 1)
+	require.Equal(t, trackingCall{
+		provider:     "asdf",
+		request:      request,
+		result:       result,
+		isSuccessful: false,
+	}, tracker.toolSetupCalls[0])
+}
+
+func TestInstallResolvedToolsReportsSuccessAfterActivation(t *testing.T) {
+	tracker := &capturingTracker{}
+	request := provider.ToolRequest{
+		ToolName:        "ruby",
+		UnparsedVersion: "3.3.0",
+	}
+	result := provider.ToolInstallResult{
+		ToolName:        "ruby",
+		ConcreteVersion: "3.3.0",
+	}
+	activation := provider.EnvironmentActivation{
+		ContributedEnvVars: map[string]string{"GEM_HOME": "/tmp/gems"},
+	}
+
+	activations, err := installResolvedTools([]provider.ToolRequest{request}, "mise", fakeToolProvider{
+		installResult: result,
+		activation:    activation,
+	}, tracker, true, time.Now())
+
+	require.NoError(t, err)
+	require.Equal(t, []provider.EnvironmentActivation{activation}, activations)
+	require.Len(t, tracker.toolSetupCalls, 1)
+	require.Equal(t, trackingCall{
+		provider:     "mise",
+		request:      request,
+		result:       result,
+		isSuccessful: true,
+	}, tracker.toolSetupCalls[0])
+}


### PR DESCRIPTION
<!--
  Thanks for contributing to the Bitrise CLI!
  Please fill this template with the details of your change.
-->

### Checklist
- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-io/bitrise/blob/master/.github/CONTRIBUTING.md)
- [ ] `README.md` is updated with the changes (if needed)
- [ ] I've run `go mod tidy` both in root and in `integrationtests/` if any dependencies have changed. <!-- Integration tests are treated separate. See `integrationtests/README.md` -->

### Version
Requires a *PATCH* [version update](https://semver.org/)

### Context
Tool setup failures were visible in CLI logs but some failure paths did not emit the `cli_tool_setup` analytics event, which made the metrics incomplete.

### Changes
- Refactored the shared tool setup flow to emit exactly one `cli_tool_setup` event per tool after the final outcome is known.
- Send failed analytics events for `provider.ToolInstallError` paths before returning the user-facing error.
- Treat activation failures as failed setup instead of reporting success immediately after install.
- Added regression tests for install-error, activation-error, and successful setup reporting.

### Investigation details
- `mise` and `asdf` both return `provider.ToolInstallError` for common user-facing install failures such as missing versions and install command failures.
- The previous implementation returned early for `ToolInstallError` after printing the error, so those failures never reached analytics.
- The previous implementation also emitted success before `ActivateEnv`, so activation failures could be misreported as successful setup.

### Decisions
- Scoped the change to post-resolution install and activation paths; bootstrap and pre-install resolution failures remain outside this event for now.
