### PR TITLE
Collect toolkit prepare timing and cache hit telemetry

### DIFF
--- a/analytics/tracker.go
+++ b/analytics/tracker.go
@@ -15,6 +15,7 @@ import (
 	"github.com/bitrise-io/go-utils/v2/env"
 	utilslog "github.com/bitrise-io/go-utils/v2/log"
 	"github.com/bitrise-io/stepman/activator"
+	"github.com/bitrise-io/stepman/toolkits"
 )
 
 const (
@@ -33,6 +34,7 @@ const (
 	cliCommandEventName            = "cli_command"
 	toolSetupEventName             = "cli_tool_setup"
 	stepActivationEventName        = "cli_step_activation"
+	toolkitPrepareEventName        = "cli_toolkit_prepare"
 
 	workflowNameProperty          = "workflow_name"
 	workflowTitleProperty         = "workflow_title"
@@ -116,6 +118,7 @@ type Tracker interface {
 	SendCommandInfo(command, subcommand string, flags []string)
 	SendToolSetupEvent(provider string, request provider.ToolRequest, result provider.ToolInstallResult, is_successful bool, setupTime time.Duration)
 	SendStepActivationEvent(activationType activator.ActivationType, ref string, isSuccessful bool, duration time.Duration, didSteplibUpdate bool)
+	SendToolkitPrepareEvent(stepExecutionID string, toolkitName string, stepID string, stepVersion string, result toolkits.PrepareForStepRunResult, err error)
 	IsTracking() bool
 	Wait()
 }
@@ -394,12 +397,12 @@ func (t tracker) SendStepActivationEvent(activationType activator.ActivationType
 	isCI := t.envRepository.Get(configs.CIModeEnvKey) == "true"
 
 	props := analytics.Properties{
-		"is_successful": isSuccessful,
-		"step_ref":      ref,
-		"duration_ms":   duration.Milliseconds(),
-		"cli_version":   version.VERSION,
-		"is_ci":         isCI,
-		"build_slug":    buildSlug,
+		"is_successful":   isSuccessful,
+		"step_ref":        ref,
+		"duration_ms":     duration.Milliseconds(),
+		"cli_version":     version.VERSION,
+		"is_ci":           isCI,
+		"build_slug":      buildSlug,
 		"activation_type": activationType,
 	}
 
@@ -408,4 +411,32 @@ func (t tracker) SendStepActivationEvent(activationType activator.ActivationType
 	}
 
 	t.tracker.Enqueue(stepActivationEventName, props)
+}
+
+func (t tracker) SendToolkitPrepareEvent(stepExecutionID string, toolkitName string, stepID string, stepVersion string, result toolkits.PrepareForStepRunResult, err error) {
+	if !t.stateChecker.Enabled() {
+		return
+	}
+
+	buildSlug := t.envRepository.Get(buildSlugEnvKey)
+	isCI := t.envRepository.Get(configs.CIModeEnvKey) == "true"
+
+	props := analytics.Properties{
+		"step_execution_id": stepExecutionID,
+		"toolkit_name":      toolkitName,
+		"step_id":           stepID,
+		"step_version":      stepVersion,
+		"duration_ms":       result.PrepareDuration.Milliseconds(),
+		"cache_hit":         result.CacheHit,
+		"is_successful":     true,
+		"build_slug":        buildSlug,
+		"cli_version":       version.VERSION,
+		"ci_mode":           isCI,
+	}
+	if err != nil {
+		props["is_successful"] = false
+		props.AppendIfNotEmpty("error_message", err.Error())
+	}
+
+	t.tracker.Enqueue(toolkitPrepareEventName, props)
 }

--- a/analytics/tracker.go
+++ b/analytics/tracker.go
@@ -431,7 +431,7 @@ func (t tracker) SendToolkitPrepareEvent(stepExecutionID string, toolkitName str
 		"is_successful":     true,
 		"build_slug":        buildSlug,
 		"cli_version":       version.VERSION,
-		"ci_mode":           isCI,
+		"is_ci":             isCI,
 	}
 	if err != nil {
 		props["is_successful"] = false

--- a/bitrise/setup.go
+++ b/bitrise/setup.go
@@ -127,9 +127,11 @@ func doSetupToolkits(logger log.Logger) error {
 
 		if isInstallRequired {
 			log.Warnf("No installed/suitable %s found, installing toolkit ...", toolkitName)
-			if err := aCoreTK.Install(); err != nil {
+			installResult, err := aCoreTK.Install()
+			if err != nil {
 				return fmt.Errorf("failed to install toolkit (%s), error: %s", toolkitName, err)
 			}
+			log.Debugf("Toolkit %s installed in %s", toolkitName, installResult.InstallDuration)
 
 			isInstallRequired, checkResult, err = aCoreTK.Check()
 			if err != nil {

--- a/cli/run_test.go
+++ b/cli/run_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/bitrise-io/go-utils/pathutil"
 	"github.com/bitrise-io/go-utils/v2/analytics"
 	"github.com/bitrise-io/stepman/activator"
+	"github.com/bitrise-io/stepman/toolkits"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -2109,6 +2110,8 @@ func (n noOpTracker) SendCommandInfo(string, string, []string)                  
 func (n noOpTracker) SendToolSetupEvent(provider string, request provider.ToolRequest, result provider.ToolInstallResult, is_successful bool, setupTime time.Duration) {
 }
 func (n noOpTracker) SendStepActivationEvent(activationType activator.ActivationType, ref string, isSuccessful bool, duration time.Duration, didSteplibUpdate bool) {
+}
+func (n noOpTracker) SendToolkitPrepareEvent(stepExecutionID string, toolkitName string, stepID string, stepVersion string, result toolkits.PrepareForStepRunResult, err error) {
 }
 func (n noOpTracker) Wait()            {}
 func (n noOpTracker) IsTracking() bool { return false }

--- a/cli/run_util.go
+++ b/cli/run_util.go
@@ -642,9 +642,11 @@ func (r WorkflowRunner) executeStep(
 		toolkitForStep := toolkits.ToolkitForStep(step, r.logger)
 		toolkitName := toolkitForStep.ToolkitName()
 
-		if err := toolkitForStep.PrepareForStepRun(step, sIDData, stepAbsDirPath); err != nil {
+		prepareResult, prepareErr := toolkitForStep.PrepareForStepRun(step, sIDData, stepAbsDirPath)
+		r.tracker.SendToolkitPrepareEvent(stepUUID, toolkitName, sIDData.IDorURI, sIDData.Version, prepareResult, prepareErr)
+		if prepareErr != nil {
 			return 1, fmt.Errorf("failed to prepare the step for execution through the required toolkit (%s), error: %s",
-				toolkitName, err)
+				toolkitName, prepareErr)
 		}
 
 		cmdFromToolkit, err := toolkitForStep.StepRunCommandArguments(step, sIDData, stepAbsDirPath)

--- a/cli/run_util.go
+++ b/cli/run_util.go
@@ -643,11 +643,7 @@ func (r WorkflowRunner) executeStep(
 		toolkitName := toolkitForStep.ToolkitName()
 
 		prepareResult, prepareErr := toolkitForStep.PrepareForStepRun(step, sIDData, stepAbsDirPath)
-		// Skip the event for no-op toolkits (e.g. bash, swift with no precompiled binary)
-		// where duration is always 0 and cache_hit is always false, which would be misleading.
-		if prepareErr != nil || prepareResult.PrepareDuration > 0 {
-			r.tracker.SendToolkitPrepareEvent(stepUUID, toolkitName, sIDData.IDorURI, sIDData.Version, prepareResult, prepareErr)
-		}
+		trackToolkitPrepare(r.tracker, stepUUID, toolkitName, sIDData, prepareResult, prepareErr)
 		if prepareErr != nil {
 			return 1, fmt.Errorf("failed to prepare the step for execution through the required toolkit (%s), error: %s",
 				toolkitName, prepareErr)
@@ -1152,6 +1148,15 @@ func addTestMetadata(testDirPath string, testResultStepInfo models.TestResultSte
 		}
 	}
 	return nil
+}
+
+// trackToolkitPrepare sends a toolkit prepare telemetry event, but skips no-op toolkits
+// (e.g. bash, swift without a precompiled binary) where duration is always 0 and cache_hit
+// is always false, which would produce misleading data.
+func trackToolkitPrepare(tracker analytics.Tracker, stepUUID, toolkitName string, sIDData stepid.CanonicalID, result toolkits.PrepareForStepRunResult, err error) {
+	if err != nil || result.PrepareDuration > 0 {
+		tracker.SendToolkitPrepareEvent(stepUUID, toolkitName, sIDData.IDorURI, sIDData.Version, result, err)
+	}
 }
 
 func secretEnvKeysEnvironment(keys []string) envmanModels.EnvironmentItemModel {

--- a/cli/run_util.go
+++ b/cli/run_util.go
@@ -643,7 +643,11 @@ func (r WorkflowRunner) executeStep(
 		toolkitName := toolkitForStep.ToolkitName()
 
 		prepareResult, prepareErr := toolkitForStep.PrepareForStepRun(step, sIDData, stepAbsDirPath)
-		r.tracker.SendToolkitPrepareEvent(stepUUID, toolkitName, sIDData.IDorURI, sIDData.Version, prepareResult, prepareErr)
+		// Skip the event for no-op toolkits (e.g. bash, swift with no precompiled binary)
+		// where duration is always 0 and cache_hit is always false, which would be misleading.
+		if prepareErr != nil || prepareResult.PrepareDuration > 0 {
+			r.tracker.SendToolkitPrepareEvent(stepUUID, toolkitName, sIDData.IDorURI, sIDData.Version, prepareResult, prepareErr)
+		}
 		if prepareErr != nil {
 			return 1, fmt.Errorf("failed to prepare the step for execution through the required toolkit (%s), error: %s",
 				toolkitName, prepareErr)

--- a/cli/run_util_test.go
+++ b/cli/run_util_test.go
@@ -2,8 +2,10 @@ package cli
 
 import (
 	"encoding/base64"
+	"errors"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/bitrise-io/bitrise/v2/bitrise"
 	"github.com/bitrise-io/bitrise/v2/configs"
@@ -12,6 +14,9 @@ import (
 	"github.com/bitrise-io/go-utils/fileutil"
 	"github.com/bitrise-io/go-utils/pathutil"
 	"github.com/bitrise-io/go-utils/pointers"
+	"github.com/bitrise-io/stepman/stepid"
+	"github.com/bitrise-io/stepman/toolkits"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -367,6 +372,92 @@ envs:
 	opts, err := env.GetOptions()
 	require.NoError(t, err)
 	require.Equal(t, true, *opts.IsExpand)
+}
+
+type toolkitPrepareCall struct {
+	stepExecutionID string
+	toolkitName     string
+	stepID          string
+	stepVersion     string
+	result          toolkits.PrepareForStepRunResult
+	err             error
+}
+
+type toolkitCapturingTracker struct {
+	noOpTracker
+	calls []toolkitPrepareCall
+}
+
+func (c *toolkitCapturingTracker) SendToolkitPrepareEvent(stepExecutionID, toolkitName, stepID, stepVersion string, result toolkits.PrepareForStepRunResult, err error) {
+	c.calls = append(c.calls, toolkitPrepareCall{
+		stepExecutionID: stepExecutionID,
+		toolkitName:     toolkitName,
+		stepID:          stepID,
+		stepVersion:     stepVersion,
+		result:          result,
+		err:             err,
+	})
+}
+
+
+func TestTrackToolkitPrepare(t *testing.T) {
+	tests := []struct {
+		name         string
+		result       toolkits.PrepareForStepRunResult
+		err          error
+		expectsEvent bool
+	}{
+		{
+			name:         "bash no-op: zero duration, no error → no event",
+			result:       toolkits.PrepareForStepRunResult{PrepareDuration: 0, CacheHit: false},
+			err:          nil,
+			expectsEvent: false,
+		},
+		{
+			name:         "go compile: nonzero duration → event fired",
+			result:       toolkits.PrepareForStepRunResult{PrepareDuration: 500 * time.Millisecond, CacheHit: false},
+			err:          nil,
+			expectsEvent: true,
+		},
+		{
+			name:         "go cache hit: nonzero duration → event fired",
+			result:       toolkits.PrepareForStepRunResult{PrepareDuration: 2 * time.Millisecond, CacheHit: true},
+			err:          nil,
+			expectsEvent: true,
+		},
+		{
+			name:         "prepare error with zero duration → event still fired",
+			result:       toolkits.PrepareForStepRunResult{PrepareDuration: 0, CacheHit: false},
+			err:          errors.New("compile failed"),
+			expectsEvent: true,
+		},
+		{
+			name:         "prepare error with nonzero duration → event still fired",
+			result:       toolkits.PrepareForStepRunResult{PrepareDuration: 200 * time.Millisecond, CacheHit: false},
+			err:          errors.New("compile failed"),
+			expectsEvent: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tracker := &toolkitCapturingTracker{}
+			sIDData := stepid.CanonicalID{IDorURI: "my-step", Version: "1.0.0"}
+			trackToolkitPrepare(tracker, "exec-uuid", "go", sIDData, tt.result, tt.err)
+
+			if tt.expectsEvent {
+				assert.Len(t, tracker.calls, 1)
+				assert.Equal(t, "exec-uuid", tracker.calls[0].stepExecutionID)
+				assert.Equal(t, "go", tracker.calls[0].toolkitName)
+				assert.Equal(t, "my-step", tracker.calls[0].stepID)
+				assert.Equal(t, "1.0.0", tracker.calls[0].stepVersion)
+				assert.Equal(t, tt.result, tracker.calls[0].result)
+				assert.Equal(t, tt.err, tracker.calls[0].err)
+			} else {
+				assert.Empty(t, tracker.calls)
+			}
+		})
+	}
 }
 
 func TestAddTestMetadata(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/bitrise-io/go-utils v1.0.15
 	github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.33
 	github.com/bitrise-io/goinp v0.0.0-20240103152431-054ed78518ef
-	github.com/bitrise-io/stepman v0.19.2
+	github.com/bitrise-io/stepman v0.19.3-0.20260518131528-699cf9d74f6e
 	github.com/go-git/go-git/v5 v5.13.0
 	github.com/gofrs/uuid v4.3.1+incompatible
 	github.com/hashicorp/go-retryablehttp v0.7.8

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/bitrise-io/go-utils v1.0.15
 	github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.33
 	github.com/bitrise-io/goinp v0.0.0-20240103152431-054ed78518ef
-	github.com/bitrise-io/stepman v0.19.3-0.20260518131528-699cf9d74f6e
+	github.com/bitrise-io/stepman v0.20.0
 	github.com/go-git/go-git/v5 v5.13.0
 	github.com/gofrs/uuid v4.3.1+incompatible
 	github.com/hashicorp/go-retryablehttp v0.7.8

--- a/go.sum
+++ b/go.sum
@@ -28,10 +28,8 @@ github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.33 h1:2Skyp4yg8aNKLr5GB5amM9UK9n1
 github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.33/go.mod h1:3XUplo0dOWc3DqT2XA2SeHToDSg7+j1y1HTHibT2H68=
 github.com/bitrise-io/goinp v0.0.0-20240103152431-054ed78518ef h1:R5FOa8RHjqZwMN9g1FQ8W7nXxQAG7iwq1Cw+mUk5S9A=
 github.com/bitrise-io/goinp v0.0.0-20240103152431-054ed78518ef/go.mod h1:27ldH2bkCdYN5CEJ6x92EK+gkd5EcDBkA7dMrSKQFYU=
-github.com/bitrise-io/stepman v0.19.0 h1:WI3SR2FmTRyi6X6TzLAMSDI4IP3gj5AtTUQnGkQlOe4=
-github.com/bitrise-io/stepman v0.19.0/go.mod h1:mLf8IHAulZM8AFhwR8TNB+/vH0w/UZq8UTnGKBEcCQM=
-github.com/bitrise-io/stepman v0.19.2 h1:V0pAVdONpjIGz2VcgQX4OeVMLz/NEU0dd22Fl25JmPE=
-github.com/bitrise-io/stepman v0.19.2/go.mod h1:mLf8IHAulZM8AFhwR8TNB+/vH0w/UZq8UTnGKBEcCQM=
+github.com/bitrise-io/stepman v0.20.0 h1:QSlvb9dkWsP7iu3RACewcBujYhdrUvc/fmUgP2HFzvM=
+github.com/bitrise-io/stepman v0.20.0/go.mod h1:mLf8IHAulZM8AFhwR8TNB+/vH0w/UZq8UTnGKBEcCQM=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
 github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/cloudflare/circl v1.6.1 h1:zqIqSPIndyBh1bjLVVDHMPpVKqp8Su/V+6MeDzzQBQ0=

--- a/integrationtests/go.mod
+++ b/integrationtests/go.mod
@@ -10,7 +10,7 @@ require (
 	al.essio.dev/pkg/shellescape v1.6.0
 	github.com/bitrise-io/bitrise/v2 v2.0.0
 	github.com/bitrise-io/go-utils v1.0.15
-	github.com/bitrise-io/stepman v0.19.3-0.20260518131528-699cf9d74f6e
+	github.com/bitrise-io/stepman v0.20.0
 	github.com/hashicorp/go-retryablehttp v0.7.8
 	github.com/ryanuber/go-glob v1.0.0
 	github.com/stretchr/testify v1.10.0

--- a/integrationtests/go.mod
+++ b/integrationtests/go.mod
@@ -10,7 +10,7 @@ require (
 	al.essio.dev/pkg/shellescape v1.6.0
 	github.com/bitrise-io/bitrise/v2 v2.0.0
 	github.com/bitrise-io/go-utils v1.0.15
-	github.com/bitrise-io/stepman v0.19.2
+	github.com/bitrise-io/stepman v0.19.3-0.20260518131528-699cf9d74f6e
 	github.com/hashicorp/go-retryablehttp v0.7.8
 	github.com/ryanuber/go-glob v1.0.0
 	github.com/stretchr/testify v1.10.0

--- a/integrationtests/go.sum
+++ b/integrationtests/go.sum
@@ -28,8 +28,8 @@ github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.33 h1:2Skyp4yg8aNKLr5GB5amM9UK9n1
 github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.33/go.mod h1:3XUplo0dOWc3DqT2XA2SeHToDSg7+j1y1HTHibT2H68=
 github.com/bitrise-io/goinp v0.0.0-20240103152431-054ed78518ef h1:R5FOa8RHjqZwMN9g1FQ8W7nXxQAG7iwq1Cw+mUk5S9A=
 github.com/bitrise-io/goinp v0.0.0-20240103152431-054ed78518ef/go.mod h1:27ldH2bkCdYN5CEJ6x92EK+gkd5EcDBkA7dMrSKQFYU=
-github.com/bitrise-io/stepman v0.19.3-0.20260518131528-699cf9d74f6e h1:P34mdZ2ZNYpW937Gx4vHMiAA1qmylKcjpbcR1SCN+WM=
-github.com/bitrise-io/stepman v0.19.3-0.20260518131528-699cf9d74f6e/go.mod h1:mLf8IHAulZM8AFhwR8TNB+/vH0w/UZq8UTnGKBEcCQM=
+github.com/bitrise-io/stepman v0.20.0 h1:QSlvb9dkWsP7iu3RACewcBujYhdrUvc/fmUgP2HFzvM=
+github.com/bitrise-io/stepman v0.20.0/go.mod h1:mLf8IHAulZM8AFhwR8TNB+/vH0w/UZq8UTnGKBEcCQM=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
 github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/cloudflare/circl v1.6.1 h1:zqIqSPIndyBh1bjLVVDHMPpVKqp8Su/V+6MeDzzQBQ0=

--- a/integrationtests/go.sum
+++ b/integrationtests/go.sum
@@ -28,10 +28,8 @@ github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.33 h1:2Skyp4yg8aNKLr5GB5amM9UK9n1
 github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.33/go.mod h1:3XUplo0dOWc3DqT2XA2SeHToDSg7+j1y1HTHibT2H68=
 github.com/bitrise-io/goinp v0.0.0-20240103152431-054ed78518ef h1:R5FOa8RHjqZwMN9g1FQ8W7nXxQAG7iwq1Cw+mUk5S9A=
 github.com/bitrise-io/goinp v0.0.0-20240103152431-054ed78518ef/go.mod h1:27ldH2bkCdYN5CEJ6x92EK+gkd5EcDBkA7dMrSKQFYU=
-github.com/bitrise-io/stepman v0.19.0 h1:WI3SR2FmTRyi6X6TzLAMSDI4IP3gj5AtTUQnGkQlOe4=
-github.com/bitrise-io/stepman v0.19.0/go.mod h1:mLf8IHAulZM8AFhwR8TNB+/vH0w/UZq8UTnGKBEcCQM=
-github.com/bitrise-io/stepman v0.19.2 h1:V0pAVdONpjIGz2VcgQX4OeVMLz/NEU0dd22Fl25JmPE=
-github.com/bitrise-io/stepman v0.19.2/go.mod h1:mLf8IHAulZM8AFhwR8TNB+/vH0w/UZq8UTnGKBEcCQM=
+github.com/bitrise-io/stepman v0.19.3-0.20260518131528-699cf9d74f6e h1:P34mdZ2ZNYpW937Gx4vHMiAA1qmylKcjpbcR1SCN+WM=
+github.com/bitrise-io/stepman v0.19.3-0.20260518131528-699cf9d74f6e/go.mod h1:mLf8IHAulZM8AFhwR8TNB+/vH0w/UZq8UTnGKBEcCQM=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
 github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/cloudflare/circl v1.6.1 h1:zqIqSPIndyBh1bjLVVDHMPpVKqp8Su/V+6MeDzzQBQ0=

--- a/toolprovider/run_test.go
+++ b/toolprovider/run_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/bitrise-io/bitrise/v2/toolprovider/provider"
 	"github.com/bitrise-io/go-utils/v2/analytics"
 	"github.com/bitrise-io/stepman/activator"
+	"github.com/bitrise-io/stepman/toolkits"
 	"github.com/stretchr/testify/require"
     "github.com/stretchr/testify/assert"
 )
@@ -40,6 +41,8 @@ func (c *capturingTracker) SendToolSetupEvent(providerID string, request provide
 	})
 }
 func (c *capturingTracker) SendStepActivationEvent(activator.ActivationType, string, bool, time.Duration, bool) {
+}
+func (c *capturingTracker) SendToolkitPrepareEvent(string, string, string, string, toolkits.PrepareForStepRunResult, error) {
 }
 func (c *capturingTracker) Wait()            {}
 func (c *capturingTracker) IsTracking() bool { return true }

--- a/vendor/github.com/bitrise-io/stepman/toolkits/bash.go
+++ b/vendor/github.com/bitrise-io/stepman/toolkits/bash.go
@@ -41,16 +41,16 @@ func (toolkit BashToolkit) Bootstrap() error {
 	return nil
 }
 
-func (toolkit BashToolkit) Install() error {
-	return nil
+func (toolkit BashToolkit) Install() (InstallResult, error) {
+	return InstallResult{}, nil
 }
 
 func (toolkit BashToolkit) ToolkitName() string {
 	return "bash"
 }
 
-func (toolkit BashToolkit) PrepareForStepRun(_ models.StepModel, _ stepid.CanonicalID, _ string) error {
-	return nil
+func (toolkit BashToolkit) PrepareForStepRun(_ models.StepModel, _ stepid.CanonicalID, _ string) (PrepareForStepRunResult, error) {
+	return PrepareForStepRunResult{}, nil
 }
 
 func (toolkit BashToolkit) StepRunCommandArguments(step models.StepModel, sIDData stepid.CanonicalID, stepAbsDirPath string) ([]string, error) {

--- a/vendor/github.com/bitrise-io/stepman/toolkits/golang.go
+++ b/vendor/github.com/bitrise-io/stepman/toolkits/golang.go
@@ -298,23 +298,23 @@ func (toolkit GoToolkit) PrepareForStepRun(step models.StepModel, sIDData stepid
 
 	// it's not cached, so compile it
 	if step.Toolkit == nil {
-		return PrepareForStepRunResult{PrepareDuration: time.Since(start)}, errors.New("no toolkit information specified in step")
+		return PrepareForStepRunResult{CacheHit: false, PrepareDuration: time.Since(start)}, errors.New("no toolkit information specified in step")
 	}
 	if step.Toolkit.Go == nil {
-		return PrepareForStepRunResult{PrepareDuration: time.Since(start)}, errors.New("no toolkit.go information specified in step")
+		return PrepareForStepRunResult{CacheHit: false, PrepareDuration: time.Since(start)}, errors.New("no toolkit.go information specified in step")
 	}
 
 	isInstallRequired, _, goConfig, err := selectGoConfiguration(toolkit.logger)
 	if err != nil {
-		return PrepareForStepRunResult{PrepareDuration: time.Since(start)}, fmt.Errorf("select an appropriate Go installation for compiling the Step: %s", err)
+		return PrepareForStepRunResult{CacheHit: false, PrepareDuration: time.Since(start)}, fmt.Errorf("select an appropriate Go installation for compiling the Step: %s", err)
 	}
 	if isInstallRequired {
-		return PrepareForStepRunResult{PrepareDuration: time.Since(start)}, fmt.Errorf("select an appropriate Go installation for compiling the Step: %s",
+		return PrepareForStepRunResult{CacheHit: false, PrepareDuration: time.Since(start)}, fmt.Errorf("select an appropriate Go installation for compiling the Step: %s",
 			"found Go version is older than required. Please run 'bitrise setup' to check and install the required version")
 	}
 
 	if err := goBuildStep(toolkit.logger, newDefaultRunner(toolkit.logger), goConfig, step.Toolkit.Go.PackageName, stepAbsDirPath, fullStepBinPath); err != nil {
-		return PrepareForStepRunResult{PrepareDuration: time.Since(start)}, err
+		return PrepareForStepRunResult{CacheHit: false, PrepareDuration: time.Since(start)}, err
 	}
 	return PrepareForStepRunResult{CacheHit: false, PrepareDuration: time.Since(start)}, nil
 }

--- a/vendor/github.com/bitrise-io/stepman/toolkits/golang.go
+++ b/vendor/github.com/bitrise-io/stepman/toolkits/golang.go
@@ -193,7 +193,9 @@ func installGoTar(logger stepman.Logger, goTarGzPath string) error {
 	return nil
 }
 
-func (toolkit GoToolkit) Install() error {
+func (toolkit GoToolkit) Install() (InstallResult, error) {
+	start := time.Now()
+
 	versionStr := minGoVersionForToolkit
 	osStr := runtime.GOOS
 	archStr := runtime.GOARCH
@@ -205,35 +207,33 @@ func (toolkit GoToolkit) Install() error {
 
 	goTmpDirPath := goToolkitTmpDirPath()
 	if err := pathutil.EnsureDirExist(goTmpDirPath); err != nil {
-		return fmt.Errorf("create Toolkits TMP directory: %s", err)
+		return InstallResult{InstallDuration: time.Since(start)}, fmt.Errorf("create Toolkits TMP directory: %s", err)
 	}
 
 	localFileName := "go." + extentionStr
 	goArchiveDownloadPath := filepath.Join(goTmpDirPath, localFileName)
 
-	var downloadErr error
-
 	toolkit.logger.Infof("=> Downloading ...")
-	downloadErr = retry.Times(2).Wait(5 * time.Second).Try(func(attempt uint) error {
+	downloadErr := retry.Times(2).Wait(5 * time.Second).Try(func(attempt uint) error {
 		if attempt > 0 {
 			toolkit.logger.Warnf("==> Download failed, retrying ...")
 		}
 		return downloadFile(downloadURL, goArchiveDownloadPath)
 	})
 	if downloadErr != nil {
-		return fmt.Errorf("download Go toolkit: %s", downloadErr)
+		return InstallResult{InstallDuration: time.Since(start)}, fmt.Errorf("download Go toolkit: %s", downloadErr)
 	}
 
 	toolkit.logger.Infof("=> Installing ...")
 	if err := installGoTar(toolkit.logger, goArchiveDownloadPath); err != nil {
-		return fmt.Errorf("install Go toolkit: %s", err)
+		return InstallResult{InstallDuration: time.Since(start)}, fmt.Errorf("install Go toolkit: %s", err)
 	}
 	if err := os.Remove(goArchiveDownloadPath); err != nil {
-		return fmt.Errorf("remove the downloaded Go archive at %s: %s", goArchiveDownloadPath, err)
+		return InstallResult{InstallDuration: time.Since(start)}, fmt.Errorf("remove the downloaded Go archive at %s: %s", goArchiveDownloadPath, err)
 	}
 	toolkit.logger.Infof("=> Installing DONE")
 
-	return nil
+	return InstallResult{InstallDuration: time.Since(start)}, nil
 }
 
 func goBuildStep(logger stepman.Logger, cmdRunner commandRunner, goConfig GoConfigurationModel, packageName, stepAbsDirPath, outputBinPath string) error {
@@ -283,7 +283,8 @@ func stepBinaryCacheFullPath(sIDData stepid.CanonicalID) string {
 }
 
 // PrepareForStepRun ...
-func (toolkit GoToolkit) PrepareForStepRun(step models.StepModel, sIDData stepid.CanonicalID, stepAbsDirPath string) error {
+func (toolkit GoToolkit) PrepareForStepRun(step models.StepModel, sIDData stepid.CanonicalID, stepAbsDirPath string) (PrepareForStepRunResult, error) {
+	start := time.Now()
 	fullStepBinPath := stepBinaryCacheFullPath(sIDData)
 
 	// try to use cached binary, if possible
@@ -291,28 +292,31 @@ func (toolkit GoToolkit) PrepareForStepRun(step models.StepModel, sIDData stepid
 		if exists, err := pathutil.IsPathExists(fullStepBinPath); err != nil {
 			toolkit.logger.Warnf("Failed to check cached binary for step, error: %s", err)
 		} else if exists {
-			return nil
+			return PrepareForStepRunResult{CacheHit: true, PrepareDuration: time.Since(start)}, nil
 		}
 	}
 
 	// it's not cached, so compile it
 	if step.Toolkit == nil {
-		return errors.New("no toolkit information specified in step")
+		return PrepareForStepRunResult{PrepareDuration: time.Since(start)}, errors.New("no toolkit information specified in step")
 	}
 	if step.Toolkit.Go == nil {
-		return errors.New("no toolkit.go information specified in step")
+		return PrepareForStepRunResult{PrepareDuration: time.Since(start)}, errors.New("no toolkit.go information specified in step")
 	}
 
 	isInstallRequired, _, goConfig, err := selectGoConfiguration(toolkit.logger)
 	if err != nil {
-		return fmt.Errorf("select an appropriate Go installation for compiling the Step: %s", err)
+		return PrepareForStepRunResult{PrepareDuration: time.Since(start)}, fmt.Errorf("select an appropriate Go installation for compiling the Step: %s", err)
 	}
 	if isInstallRequired {
-		return fmt.Errorf("select an appropriate Go installation for compiling the Step: %s",
+		return PrepareForStepRunResult{PrepareDuration: time.Since(start)}, fmt.Errorf("select an appropriate Go installation for compiling the Step: %s",
 			"found Go version is older than required. Please run 'bitrise setup' to check and install the required version")
 	}
 
-	return goBuildStep(toolkit.logger, newDefaultRunner(toolkit.logger), goConfig, step.Toolkit.Go.PackageName, stepAbsDirPath, fullStepBinPath)
+	if err := goBuildStep(toolkit.logger, newDefaultRunner(toolkit.logger), goConfig, step.Toolkit.Go.PackageName, stepAbsDirPath, fullStepBinPath); err != nil {
+		return PrepareForStepRunResult{PrepareDuration: time.Since(start)}, err
+	}
+	return PrepareForStepRunResult{CacheHit: false, PrepareDuration: time.Since(start)}, nil
 }
 
 // === Toolkit: Step Run ===

--- a/vendor/github.com/bitrise-io/stepman/toolkits/swift.go
+++ b/vendor/github.com/bitrise-io/stepman/toolkits/swift.go
@@ -49,15 +49,15 @@ func (toolkit SwiftToolkit) PrepareForStepRun(step models.StepModel, _ stepid.Ca
 	start := time.Now()
 	err := downloadFile(binaryLocation, executablePath)
 	if err != nil {
-		return PrepareForStepRunResult{PrepareDuration: time.Since(start)}, fmt.Errorf("download precompiled step binary: %s", err)
+		return PrepareForStepRunResult{CacheHit: false, PrepareDuration: time.Since(start)}, fmt.Errorf("download precompiled step binary: %s", err)
 	}
 
 	err = os.Chmod(executablePath, 0755)
 	if err != nil {
-		return PrepareForStepRunResult{PrepareDuration: time.Since(start)}, err
+		return PrepareForStepRunResult{CacheHit: false, PrepareDuration: time.Since(start)}, err
 	}
 
-	return PrepareForStepRunResult{PrepareDuration: time.Since(start)}, nil
+	return PrepareForStepRunResult{CacheHit: false, PrepareDuration: time.Since(start)}, nil
 }
 
 func (toolkit SwiftToolkit) StepRunCommandArguments(step models.StepModel, sIDData stepid.CanonicalID, stepAbsDirPath string) ([]string, error) {

--- a/vendor/github.com/bitrise-io/stepman/toolkits/swift.go
+++ b/vendor/github.com/bitrise-io/stepman/toolkits/swift.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"time"
 
 	"github.com/bitrise-io/stepman/models"
 	"github.com/bitrise-io/stepman/stepid"
@@ -17,8 +18,8 @@ func (toolkit SwiftToolkit) Bootstrap() error {
 	return nil
 }
 
-func (toolkit SwiftToolkit) Install() error {
-	return nil
+func (toolkit SwiftToolkit) Install() (InstallResult, error) {
+	return InstallResult{}, nil
 }
 
 func (toolkit SwiftToolkit) ToolkitName() string {
@@ -37,25 +38,26 @@ func (toolkit SwiftToolkit) IsToolAvailableInPATH() bool {
 	return len(binPath) > 0
 }
 
-func (toolkit SwiftToolkit) PrepareForStepRun(step models.StepModel, _ stepid.CanonicalID, stepAbsDirPath string) error {
+func (toolkit SwiftToolkit) PrepareForStepRun(step models.StepModel, _ stepid.CanonicalID, stepAbsDirPath string) (PrepareForStepRunResult, error) {
 	binaryLocation := step.Toolkit.Swift.BinaryLocation
 	if binaryLocation == "" {
-		return nil
+		return PrepareForStepRunResult{}, nil
 	}
 
 	executablePath := filepath.Join(stepAbsDirPath, step.Toolkit.Swift.ExecutableName)
-	
+
+	start := time.Now()
 	err := downloadFile(binaryLocation, executablePath)
 	if err != nil {
-		return fmt.Errorf("download precompiled step binary: %s", err)
+		return PrepareForStepRunResult{PrepareDuration: time.Since(start)}, fmt.Errorf("download precompiled step binary: %s", err)
 	}
 
 	err = os.Chmod(executablePath, 0755)
 	if err != nil {
-		return err
+		return PrepareForStepRunResult{PrepareDuration: time.Since(start)}, err
 	}
 
-	return nil
+	return PrepareForStepRunResult{PrepareDuration: time.Since(start)}, nil
 }
 
 func (toolkit SwiftToolkit) StepRunCommandArguments(step models.StepModel, sIDData stepid.CanonicalID, stepAbsDirPath string) ([]string, error) {

--- a/vendor/github.com/bitrise-io/stepman/toolkits/toolkit.go
+++ b/vendor/github.com/bitrise-io/stepman/toolkits/toolkit.go
@@ -6,11 +6,23 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/bitrise-io/stepman/models"
 	"github.com/bitrise-io/stepman/stepid"
 	"github.com/bitrise-io/stepman/stepman"
 )
+
+type InstallResult struct {
+	InstallDuration time.Duration
+}
+
+type PrepareForStepRunResult struct {
+	PrepareDuration time.Duration
+
+	// CacheHit should indicate if PrepareDuration was shorter because of a cache hit or similar optimizations.
+	CacheHit        bool
+}
 
 type ToolkitCheckResult struct {
 	Path    string
@@ -28,7 +40,7 @@ type Toolkit interface {
 	Check() (bool, ToolkitCheckResult, error)
 
 	// Install the toolkit
-	Install() error
+	Install() (InstallResult, error)
 
 	// Check whether the toolkit's tool (e.g. Go, Ruby, Bash, ...) is available
 	// and "usable"" without any bootstrapping.
@@ -57,7 +69,7 @@ type Toolkit interface {
 	// the toolkit should/can be "enforced" here (e.g. during the compilation),
 	// BUT ONLY for this function! E.g. don't call `os.Setenv` or something similar
 	// which would affect other functions, just pass the required envs to the compilation command!
-	PrepareForStepRun(step models.StepModel, sIDData stepid.CanonicalID, stepAbsDirPath string) error
+	PrepareForStepRun(step models.StepModel, sIDData stepid.CanonicalID, stepAbsDirPath string) (PrepareForStepRunResult, error)
 
 	// StepRunCommandArguments ...
 	StepRunCommandArguments(step models.StepModel, sIDData stepid.CanonicalID, stepAbsDirPath string) ([]string, error)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -78,7 +78,7 @@ github.com/bitrise-io/go-utils/v2/retryhttp
 # github.com/bitrise-io/goinp v0.0.0-20240103152431-054ed78518ef
 ## explicit; go 1.18
 github.com/bitrise-io/goinp/goinp
-# github.com/bitrise-io/stepman v0.19.3-0.20260518131528-699cf9d74f6e
+# github.com/bitrise-io/stepman v0.20.0
 ## explicit; go 1.25
 github.com/bitrise-io/stepman/activator
 github.com/bitrise-io/stepman/activator/steplib

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -78,7 +78,7 @@ github.com/bitrise-io/go-utils/v2/retryhttp
 # github.com/bitrise-io/goinp v0.0.0-20240103152431-054ed78518ef
 ## explicit; go 1.18
 github.com/bitrise-io/goinp/goinp
-# github.com/bitrise-io/stepman v0.19.2
+# github.com/bitrise-io/stepman v0.19.3-0.20260518131528-699cf9d74f6e
 ## explicit; go 1.25
 github.com/bitrise-io/stepman/activator
 github.com/bitrise-io/stepman/activator/steplib


### PR DESCRIPTION
### Checklist
- [ ] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-io/bitrise/blob/master/.github/CONTRIBUTING.md)
- [ ] `README.md` is updated with the changes (if needed)
- [ ] I've run `go mod tidy` both in root and in `integrationtests/` if any dependencies have changed.

### Version
Requires a *PATCH* version update

### Context

Add telemetry for Go toolkit step binary preparation to measure compilation latency and cache hit rates.

### Changes

- Bump `stepman` dependency to pick up the updated `Toolkit` interface, which now returns `PrepareForStepRunResult` (with `PrepareDuration` and `CacheHit`) and `InstallResult` (with `InstallDuration`) from `PrepareForStepRun` and `Install` respectively
- Add `SendToolkitPrepareEvent` to the `Tracker` interface
- Log Go toolkit install duration at debug level in `setup.go`

### Decisions

- `cache_hit` is a separate field rather than derived from duration — a fast compile and a cache hit are indistinguishable from timing alone
- Duration is populated on all paths including errors, so latency can be correlated with outcome independently
- `step_execution_id` is included to allow joining this event with `step_started`/`step_finished` events