### PR TITLE
Update Mise version

### DIFF
--- a/toolprovider/mise/mise.go
+++ b/toolprovider/mise/mise.go
@@ -24,13 +24,13 @@ import (
 // 3. Verify checksums
 // 4. Update version string and checksums below
 // 5. IMPORTANT, DO NOT FORGET: Mirror artifacts to GCS bucket (see bootstrap.go) in case github.com goes down
-const misePreviewVersion = "v2026.3.16"
+const misePreviewVersion = "v2026.5.12"
 
 var misePreviewChecksums = map[string]string{
-	"linux-x64":   "96417e479462d9a1836654461ec4b86eba8ff4f12260c09b93800fd50c25490c",
-	"linux-arm64": "6e0362723bddec3b25923a6c7c447c3f10eba4bf6e3db6973e175fa0a60ab974",
-	"macos-x64":   "a6f6f320b547dec3eff321e301fa05268dfc73a620d35ec3292603fbab1c4c29",
-	"macos-arm64": "9d6e2bfea3e00ffb566ad1a369914cb029c32a28eb4b699e8655cf3c3d4ef87e",
+	"linux-x64":   "bd0930c0b619f51ddb60e32e5cce18a5533567b2f1ba9fc4875b9f39a2bb3ed8",
+	"linux-arm64": "67c2bd96da9c6da030db4174b2dd0f8e6636c25519b23a15f0b734556e6e5ee0",
+	"macos-x64":   "dcab53de40bbd42c10607d64081e9df328c4885db30b41c4421f27e18b8f7efa",
+	"macos-arm64": "5b883c868a0748dd0c595d30fd000ec5138dfabdeef2c30222866ebf34af1ae3",
 }
 
 const miseStableVersion = "v2026.3.16"

--- a/toolprovider/mise/mise.go
+++ b/toolprovider/mise/mise.go
@@ -78,6 +78,10 @@ func NewToolProvider(installDir string, dataDir string, useFastInstall, silent b
 		// Enable corepack by default for Node.js installations. This mirrors the preinstalled Node versions on Bitrise stacks.
 		// https://mise.jdx.dev/lang/node.html#environment-variables
 		"MISE_NODE_COREPACK": "1",
+
+		// Older Python versions predate attestation support in astral-sh/python-build-standalone,
+		// so verification fails for any such version (e.g. 3.11.4).
+		"MISE_PYTHON_GITHUB_ATTESTATIONS": "false",
 	}
 	for k, v := range extraEnvs {
 		miseEnvs[k] = v


### PR DESCRIPTION
## What

Updates pinned Mise version(s):
- Preview: v2026.3.16 → v2026.5.12
- Stable:  v2026.3.16 (unchanged)

Risk: **medium** - 22 releases in range; ls-remote JSON output format changed (removed default false fields), but our parser only reads `version` field so no impact.

## Changes affecting our work (declarative tool setup)

- [v2026.4.13](https://github.com/jdx/mise/releases/tag/v2026.4.13)
  - `MISE_FETCH_REMOTE_VERSIONS_CACHE` ignored by GitHub, GitLab, and Forgejo backends — now uses the shared setting, matching other backends
- [v2026.4.16](https://github.com/jdx/mise/releases/tag/v2026.4.16)
  - Runtime symlink paths for fuzzy versions — PATH entries now use requested-version symlink (e.g. `.../installs/python/3.14/bin`) rather than concrete patch directory
  - npm `install_before` respected for dist-tag resolution
- [v2026.4.17](https://github.com/jdx/mise/releases/tag/v2026.4.17)
  - `install_before` respected in backend latest lookups; forwarded to pipx/uv installs
- [v2026.4.18](https://github.com/jdx/mise/releases/tag/v2026.4.18)
  - Stale version listings for package-registry backends fixed (npm, pipx, cargo, gem, go now query upstream directly)
  - Concurrent lockfile save race condition fixed (common in CI with parallel installs)
- [v2026.4.22](https://github.com/jdx/mise/releases/tag/v2026.4.22)
  - `install_before` setting renamed to `minimum_release_age`; old name preserved as deprecated alias
- [v2026.4.25](https://github.com/jdx/mise/releases/tag/v2026.4.25)
  - `mise ls-remote --json` no longer emits `"rolling":false,"prerelease":false` on every entry (our parser only reads `version`, no impact)
- [v2026.5.0](https://github.com/jdx/mise/releases/tag/v2026.5.0)
  - `shorthands_file` setting deprecated (warning in 2026.6.0, removal in 2026.12.0)
- [v2026.5.12](https://github.com/jdx/mise/releases/tag/v2026.5.12)
  - `--before` flag renamed to `--minimum-release-age` on install/use/upgrade/latest; old `--before` retained as hidden alias

## Releases in range

- [v2026.4.11](https://github.com/jdx/mise/releases/tag/v2026.4.11) - Task dependency templates and npm semver range support
- [v2026.4.12](https://github.com/jdx/mise/releases/tag/v2026.4.12) - OS/arch filtering, task confirmation defaults, and npm supply chain improvements
- [v2026.4.13](https://github.com/jdx/mise/releases/tag/v2026.4.13) - Remote version cache, Go install_before, and task tool objects
- [v2026.4.14](https://github.com/jdx/mise/releases/tag/v2026.4.14) - Fix GitHub attestation verification for some tools
- [v2026.4.15](https://github.com/jdx/mise/releases/tag/v2026.4.15) - Windows path separator fix and improved GitHub token detection
- [v2026.4.16](https://github.com/jdx/mise/releases/tag/v2026.4.16) - Tera templates in inline tasks, raw_args passthrough, and runtime symlink paths
- [v2026.4.17](https://github.com/jdx/mise/releases/tag/v2026.4.17) - install_before fixes, lockfile repair, and new registry tools
- [v2026.4.18](https://github.com/jdx/mise/releases/tag/v2026.4.18) - Deps management, aube support, and vfox plugin dependencies
- [v2026.4.19](https://github.com/jdx/mise/releases/tag/v2026.4.19) - OCI images, aqua templates, and more resilient installs
- [v2026.4.20](https://github.com/jdx/mise/releases/tag/v2026.4.20) - Lockfile cleanup and path: fixes
- [v2026.4.21](https://github.com/jdx/mise/releases/tag/v2026.4.21) - untrust command and prune lockfile fixes (publish failed; fixes shipped in v2026.4.22)
- [v2026.4.22](https://github.com/jdx/mise/releases/tag/v2026.4.22) - Repaired latest resolution and clearer deps output
- [v2026.4.23](https://github.com/jdx/mise/releases/tag/v2026.4.23) - Pre-releases, libc preference, and a Node musl fix
- [v2026.4.24](https://github.com/jdx/mise/releases/tag/v2026.4.24) - Resilient downloads and global pre-release opt-in
- [v2026.4.25](https://github.com/jdx/mise/releases/tag/v2026.4.25) - Sharper task tooling and lockfile fixes
- [v2026.4.27](https://github.com/jdx/mise/releases/tag/v2026.4.27) - npm install args, smarter watch, and a macOS shim recursion fix
- [v2026.4.28](https://github.com/jdx/mise/releases/tag/v2026.4.28) - Remote tasks pinned by commit SHA
- [v2026.5.0](https://github.com/jdx/mise/releases/tag/v2026.5.0) - Conda graduates, smarter prereleases, and Windows POSIX tasks
- [v2026.5.1](https://github.com/jdx/mise/releases/tag/v2026.5.1) - Aqua cosign and a reshim rescue
- [v2026.5.10](https://github.com/jdx/mise/releases/tag/v2026.5.10) - AWS SSO for s3 backends
- [v2026.5.11](https://github.com/jdx/mise/releases/tag/v2026.5.11) - Provenance verification at lock time
- [v2026.5.12](https://github.com/jdx/mise/releases/tag/v2026.5.12) - minimum-release-age, global edit, and install_env fixes

## Full diff

[Compare v2026.3.16…v2026.5.12](https://github.com/jdx/mise/compare/v2026.3.16...v2026.5.12)

## Verification

- SHA256 verified against `SHASUMS256.txt`. All 4 platforms match.
- Artifacts present at `gs://mise-release-mirror/v2026.5.12/`.