### PR TITLE
Wait for event tracker shutdown before process exit

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -237,5 +237,6 @@ func before(c *cli.Context) error {
 
 func failf(format string, args ...interface{}) {
 	log.Errorf(format, args...)
+	globalTracker.Wait()
 	os.Exit(1)
 }

--- a/cli/tools.go
+++ b/cli/tools.go
@@ -345,6 +345,7 @@ func toolsSetup(c *cli.Context) error {
 		}
 
 		tracker := analytics.NewDefaultTracker()
+		defer tracker.Wait()
 		envs, err := toolprovider.RunDeclarativeSetup(config, tracker, false, workflowID, silent, providerOverride, fastInstallOverride, nil)
 		if err != nil {
 			return err
@@ -362,6 +363,7 @@ func toolsSetup(c *cli.Context) error {
 	// Setting up from all the other requested version files or auto-detecting from directory.
 	if len(versionFilePaths) > 0 || len(configFiles) == 0 {
 		tracker := analytics.NewDefaultTracker()
+		defer tracker.Wait()
 		envs, err := toolprovider.RunVersionFileSetup(versionFilePaths, tracker, silent, providerOverride, fastInstallOverride)
 		if err != nil {
 			return err


### PR DESCRIPTION
<!--
  Thanks for contributing to the Bitrise CLI!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [ ] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-io/bitrise/blob/master/.github/CONTRIBUTING.md)
- [ ] `README.md` is updated with the changes (if needed)
- [ ] I've run `go mod tidy` both in root and in `integrationtests/` if any dependencies have changed. <!-- Integration tests are treated separate. See `integrationtests/README.md` -->

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *MAJOR/MINOR/PATCH* [version update](https://semver.org/)

### Context

I just accidentally noticed that legit tool setup failures don't show up as telemetry events.

Tool setup runs immediately before the first step of the workflow, and if there is a failure, the process exits immediately.

### Changes

<!-- 
  Details are important, and help maintainers processing your PR.
  Please list additional details, for example:
  - Update dependencies
  - Make `foo` optional in `main.go`
  - `foo` now returns an `error` for better error handling
-->

### Investigation details

`tracker.Wait()` has a default timeout, so even if it hangs, it won't hang the process exit for ever: https://github.com/bitrise-io/go-utils/blob/master/analytics/track.go#L79

### Decisions

<!-- Please list decisions that were made for this change. -->