### PR TITLE
Evaluate run_if before step activation

### DIFF
--- a/cli/run_test.go
+++ b/cli/run_test.go
@@ -232,6 +232,57 @@ step_bundles:
 	require.Equal(t, 2, len(buildRunResults.SkippedSteps)) // run_if_test_2.script; run_if_test_2.run_if_test_3.script
 }
 
+// TestStepRunIfBeforeActivation verifies that a run_if expression set in bitrise.yml is
+// evaluated before step activation. It uses a path:: step pointing to a nonexistent directory:
+// - when run_if is false, the step is skipped (SkippedWithRunIf) before activation is attempted
+// - when run_if is true, activation IS attempted and fails (PreparationFailed), proving the
+//   step was not skipped and that the pre-activation check correctly passes through
+func TestStepRunIfBeforeActivation(t *testing.T) {
+	tests := []struct {
+		name       string
+		runIf      string
+		wantSkip   bool
+		wantFailed bool
+	}{
+		{
+			name:       "false literal skips before activation",
+			runIf:      "false",
+			wantSkip:   true,
+			wantFailed: false,
+		},
+		{
+			name:       "true literal proceeds to activation",
+			runIf:      "true",
+			wantSkip:   false,
+			wantFailed: true, // nonexistent path → PreparationFailed
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			configStr := fmt.Sprintf(`
+format_version: 1.3.0
+default_step_lib_source: "https://github.com/bitrise-io/bitrise-steplib.git"
+workflows:
+  test:
+    steps:
+    - path::/nonexistent/step/path:
+        run_if: "%s"
+`, tt.runIf)
+			config, warnings, err := bitrise.ConfigModelFromYAMLBytes([]byte(configStr))
+			require.NoError(t, err)
+			require.Empty(t, warnings)
+			require.NoError(t, configs.InitPaths())
+
+			runConfig := RunConfig{Config: config, Workflow: "test"}
+			runner := NewWorkflowRunner(runConfig, nil, noOpTracker{})
+			buildRunResults, _ := runner.runWorkflows()
+			require.Equal(t, tt.wantSkip, len(buildRunResults.SkippedSteps) > 0)
+			require.Equal(t, tt.wantFailed, len(buildRunResults.FailedSteps) > 0)
+		})
+	}
+}
+
 func TestStepOutputsInTemplate(t *testing.T) {
 	inventoryStr := `
 envs:

--- a/cli/run_util.go
+++ b/cli/run_util.go
@@ -212,6 +212,25 @@ func (r WorkflowRunner) activateAndRunStep(
 		}
 	}
 
+	// Evaluate run_if before activation when it's explicitly set in bitrise.yml.
+	// If not set, the step.yml default may apply and can only be checked post-activation.
+	if step.RunIf != nil && *step.RunIf != "" {
+		runIfEnvList, err := envman.ConvertToEnvsJSONModel(environments, true, false, &envmanEnv.DefaultEnvironmentSource{})
+		if err != nil {
+			err = fmt.Errorf("EnvmanReadEnvList failed, err: %s", err)
+			return newActivateAndRunStepResult(step, stepInfoPtr, models.StepRunStatusCodePreparationFailed, 1, err, true, map[string]string{}, nil)
+		}
+
+		isRun, err := bitrise.EvaluateTemplateToBool(*step.RunIf, configs.IsCIMode, configs.IsPullRequestMode, buildRunResults, runIfEnvList)
+		if err != nil {
+			return newActivateAndRunStepResult(step, stepInfoPtr, models.StepRunStatusCodePreparationFailed, 1, err, true, map[string]string{}, nil)
+		}
+		if !isRun {
+			stepInfoPtr.Step.RunIf = pointers.NewStringPtr(*step.RunIf)
+			return newActivateAndRunStepResult(step, stepInfoPtr, models.StepRunStatusCodeSkippedWithRunIf, 0, nil, true, map[string]string{}, nil)
+		}
+	}
+
 	//
 	// Activate step
 	activateStartTime := time.Now()
@@ -229,7 +248,7 @@ func (r WorkflowRunner) activateAndRunStep(
 	// Run step
 	logStepStarted(r.logger, stepInfoPtr, mergedStep, stepIDx, stepExecutionID, stepStartTime)
 
-	// Evaluate run conditions
+	// Evaluate run_if from step.yml default (only reached when bitrise.yml didn't set run_if).
 	if mergedStep.RunIf != nil && *mergedStep.RunIf != "" {
 		runIfEnvList, err := envman.ConvertToEnvsJSONModel(environments, true, false, &envmanEnv.DefaultEnvironmentSource{})
 		if err != nil {


### PR DESCRIPTION
<!--
  Thanks for contributing to the Bitrise CLI!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [ ] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-io/bitrise/blob/master/.github/CONTRIBUTING.md)
- [ ] `README.md` is updated with the changes (if needed)
- [ ] I've run `go mod tidy` both in root and in `integrationtests/` if any dependencies have changed. <!-- Integration tests are treated separate. See `integrationtests/README.md` -->

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *MAJOR/MINOR/PATCH* [version update](https://semver.org/)

### Context

Step `run_if` expressions can be defined in 2 places:

1. In the `step.yml`, used when the step author has a good idea when a step should be skipped. Examples: [Activate SSH key](https://github.com/bitrise-steplib/steps-activate-ssh-key/blob/master/step.yml#L48), [cache steps](https://github.com/bitrise-steplib/bitrise-step-restore-gradle-cache/blob/main/step.yml#L29).
2. In the workflow definition ("step callsite"), used when the owner of the workflow wants to either override the default `run_if` expression of the step, or when the skip condition is a custom expression in the context of the workflow/project.

At the moment, step `run_if` expressions are evaluated after activating the step, so the source code / binary needs to be downloaded even if there is a `run_if` expression at the callsite (case 2 above) evaluating to `false`.

### Changes

Try to avoid unnecessary step activations by evaluating `run_if` expressions both before and after step activation:
1. Before step activation: this evaluates the expression from the callsite (case 2 above). If it evaluates to `true`, there is no need to activate the step, just skip it.
2. After step activation (existing behavior): at this point, we have access to `step.yml` (case 1), so evaluate that expression as well.

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->