### PR TITLE
adds workflow to populate catalog bucket

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -26,8 +26,6 @@ pipelines:
 
 workflows:
   publish_tool_catalog:
-    tools:
-      golang: 1.23:installed
     meta:
       bitrise.io:
         stack: ubuntu-noble-24.04-bitrise-2025-android

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -32,7 +32,9 @@ workflows:
         machine_type_id: standard
     steps:
     - bundle::setup_repo: {}
-    - bundle::install_dependencies: {}
+    - bundle::install_dependencies:
+        inputs:
+        - IGNORE_CUSTOM_GOLANG: "true" 
     - authenticate-with-gcp@0:
         inputs:
         - client_config: "$GCP_CLIENT_CONFIG"

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -51,7 +51,7 @@ workflows:
               bitrise tools versions "$item" --format json | jq --arg ts "$timestamp" '. + {timestamp: $ts}' > "output/$item.json"
             done < <(bitrise tools catalog)
 
-            gsutil rsync -r -d ./output gs://bitrise-cli-tool-catalog_staging
+            gsutil rsync -r -d ./output gs://bitrise-cli-tool-catalog
   release:
     triggers:
       tag:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -26,6 +26,8 @@ pipelines:
 
 workflows:
   publish_tool_catalog:
+    tools:
+      golang: 1.26:installed
     meta:
       bitrise.io:
         stack: ubuntu-noble-24.04-bitrise-2025-android

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -25,6 +25,33 @@ pipelines:
       test_binary_build_linux: {}
 
 workflows:
+  publish_tool_catalog:
+    meta:
+      bitrise.io:
+        stack: ubuntu-noble-24.04-bitrise-2025-android
+        machine_type_id: standard
+    steps:
+    - bundle::setup_repo: {}
+    - authenticate-with-gcp@0:
+        inputs:
+        - client_config: "$GCP_CLIENT_CONFIG"
+        - audience: https://iam.googleapis.com/projects/739834771422/locations/global/workloadIdentityPools/bitrise-ci/providers/bitrise-oidc
+        - verbose: true
+    - script@1:
+        inputs:
+        - content: |-
+            #!/usr/bin/env bash
+            set -ex
+
+            mkdir -p output
+            timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+            bitrise tools catalog --format json | jq --arg ts "$timestamp" '. + {timestamp: $ts}' > output/catalog.json
+
+            while IFS= read -r item; do
+              bitrise tools versions "$item" --format json | jq --arg ts "$timestamp" '. + {timestamp: $ts}' > "output/$item.json"
+            done < <(bitrise tools catalog)
+
+            gsutil rsync -r -d ./output gs://bitrise-cli-tool-catalog_staging
   release:
     triggers:
       tag:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -35,7 +35,7 @@ workflows:
     - authenticate-with-gcp@0:
         inputs:
         - client_config: "$GCP_CLIENT_CONFIG"
-        - audience: https://iam.googleapis.com/projects/739834771422/locations/global/workloadIdentityPools/bitrise-ci/providers/bitrise-oidc
+        - audience: https://iam.googleapis.com/projects/813711872101/locations/global/workloadIdentityPools/bitrise-ci/providers/bitrise-oidc
         - verbose: true
     - script@1:
         inputs:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -32,6 +32,7 @@ workflows:
         machine_type_id: standard
     steps:
     - bundle::setup_repo: {}
+    - bundle::install_dependencies: {}
     - authenticate-with-gcp@0:
         inputs:
         - client_config: "$GCP_CLIENT_CONFIG"

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -50,8 +50,49 @@ workflows:
             while IFS= read -r item; do
               bitrise tools versions "$item" --format json | jq --arg ts "$timestamp" '. + {timestamp: $ts}' > "output/$item.json"
             done < <(bitrise tools catalog)
+    - script@1:
+        title: Validate JSON files
+        inputs:
+        - content: |-
+            #!/usr/bin/env bash
+            set -e
+
+            validation_failed=false
+
+            for file in output/*; do
+              filename=$(basename "$file")
+              if [[ "$filename" != *.json ]]; then
+                echo "ERROR: File '$filename' does not have .json extension"
+                validation_failed=true
+                continue
+              fi
+
+              if ! jq empty "$file" 2>/dev/null; then
+                echo "ERROR: File '$filename' is not valid JSON"
+                validation_failed=true
+              fi
+            done
+
+            if [[ "$validation_failed" == "true" ]]; then
+              echo "JSON validation failed"
+              exit 1
+            fi
+
+            echo "All files are valid JSON"
+    - script@1:
+        title: Upload to GCS
+        inputs:
+        - content: |-
+            #!/usr/bin/env bash
+            set -ex
 
             gsutil rsync -r -d ./output gs://bitrise-cli-tool-catalog
+    - slack@4:
+        is_always_run: true
+        run_if: .IsBuildFailed
+        inputs:
+        - workspace_slack_integration_id: $SLACK_WORKSPACE_CONNECTION_ID
+        - pretext_on_error: "*publish_tool_catalog failed*\n<$BITRISE_BUILD_URL|View Build>"
   release:
     triggers:
       tag:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -27,7 +27,7 @@ pipelines:
 workflows:
   publish_tool_catalog:
     tools:
-      golang: 1.26:installed
+      golang: 1.23:installed
     meta:
       bitrise.io:
         stack: ubuntu-noble-24.04-bitrise-2025-android


### PR DESCRIPTION
Ticket: https://bitrise.atlassian.net/browse/BE-2056
Associated cloud update: https://github.com/bitrise-io/internal-platform-services/pull/2120

Background: the workflow defined here will run on a cron to periodically update the list of supported tool versions. This will power a UI-based way of setting the tool versions for a build. Until now this has been exclusively YML-based.