### PR TITLE
Add --no-update flag to bitrise setup

### DIFF
--- a/bitrise/dependencies.go
+++ b/bitrise/dependencies.go
@@ -34,7 +34,7 @@ func removeEmptyNewLines(text string) string {
 }
 
 // CheckIsPluginInstalled ...
-func CheckIsPluginInstalled(name string, dependency PluginDependency) error {
+func CheckIsPluginInstalled(name string, dependency PluginDependency, noUpdate bool) error {
 	_, found, err := plugins.LoadPlugin(name)
 	if err != nil {
 		return err
@@ -65,9 +65,13 @@ func CheckIsPluginInstalled(name string, dependency PluginDependency) error {
 			}
 
 			if installedVersion.LessThan(minVersion) {
-				log.Warnf("Default plugin (%s) version (%s) is lower than required (%s), updating...", name, installedVersion.String(), minVersion.String())
-				installOrUpdate = true
-				currentVersion = dependency.MinVersion
+				if noUpdate {
+					log.Warnf("Default plugin (%s) version (%s) is lower than required (%s), skipping update (--no-update)", name, installedVersion.String(), minVersion.String())
+				} else {
+					log.Warnf("Default plugin (%s) version (%s) is lower than required (%s), updating...", name, installedVersion.String(), minVersion.String())
+					installOrUpdate = true
+					currentVersion = dependency.MinVersion
+				}
 			}
 		}
 	}
@@ -131,7 +135,7 @@ func CheckIsHomebrewInstalled() error {
 	return nil
 }
 
-func checkIsBitriseToolInstalled(toolname, minVersion string, isInstall bool) error {
+func checkIsBitriseToolInstalled(toolname, minVersion string, isInstall bool, noUpdate bool) error {
 	doInstall := func() error {
 		officialGithub := "https://github.com/bitrise-io/" + toolname
 		log.Warnf("No supported %s version found", toolname)
@@ -153,7 +157,7 @@ func checkIsBitriseToolInstalled(toolname, minVersion string, isInstall bool) er
 		}
 
 		// check again
-		return checkIsBitriseToolInstalled(toolname, minVersion, false)
+		return checkIsBitriseToolInstalled(toolname, minVersion, false, false)
 	}
 
 	// check whether installed
@@ -184,6 +188,11 @@ func checkIsBitriseToolInstalled(toolname, minVersion string, isInstall bool) er
 	}
 
 	if installedVer.LessThan(minVer) {
+		if noUpdate {
+			log.Warnf("Installed %s found but outdated (%s < %s), skipping update (--no-update)", toolname, versionOutput, minVersion)
+			log.Printf("%s %s (%s): %s", colorstring.Green("[OK]"), toolname, versionOutput, progInstallPth)
+			return nil
+		}
 		if !isInstall {
 			log.Warnf("Installed %s found, but not a supported version (%s < %s)", toolname, versionOutput, minVersion)
 			return errors.New("failed to install required version")
@@ -196,15 +205,13 @@ func checkIsBitriseToolInstalled(toolname, minVersion string, isInstall bool) er
 }
 
 // CheckIsEnvmanInstalled ...
-func CheckIsEnvmanInstalled(minEnvmanVersion string) error {
-	minVersion := minEnvmanVersion
-	return checkIsBitriseToolInstalled(tools.EnvmanToolName, minVersion, true)
+func CheckIsEnvmanInstalled(minEnvmanVersion string, noUpdate bool) error {
+	return checkIsBitriseToolInstalled(tools.EnvmanToolName, minEnvmanVersion, true, noUpdate)
 }
 
 // CheckIsStepmanInstalled ...
-func CheckIsStepmanInstalled(minStepmanVersion string) error {
-	minVersion := minStepmanVersion
-	return checkIsBitriseToolInstalled(tools.StepmanToolName, minVersion, true)
+func CheckIsStepmanInstalled(minStepmanVersion string, noUpdate bool) error {
+	return checkIsBitriseToolInstalled(tools.StepmanToolName, minStepmanVersion, true, noUpdate)
 }
 
 func checkIfBrewPackageInstalled(packageName string) bool {

--- a/bitrise/setup.go
+++ b/bitrise/setup.go
@@ -49,16 +49,16 @@ func RunSetupIfNeeded(logger log.Logger) error {
 	versionMatch, setupVersion := configs.CheckIsSetupWasDoneForVersion(version.VERSION)
 	if setupVersion == "" {
 		log.Infof("No setup was done yet, running setup now...")
-		return RunSetup(logger, version.VERSION, SetupModeMinimal, false)
+		return RunSetup(logger, version.VERSION, SetupModeMinimal, false, false)
 	}
 	if !versionMatch {
 		log.Infof("Setup was last performed for version %s, current version is %s. Re-running setup now...", setupVersion, version.VERSION)
-		return RunSetup(logger, version.VERSION, SetupModeMinimal, false)
+		return RunSetup(logger, version.VERSION, SetupModeMinimal, false, false)
 	}
 	return nil
 }
 
-func RunSetup(logger log.Logger, appVersion string, setupMode SetupMode, doCleanSetup bool) error {
+func RunSetup(logger log.Logger, appVersion string, setupMode SetupMode, doCleanSetup bool, noUpdate bool) error {
 	log.Infof("Setup Bitrise tools...")
 	log.Printf("Clean before setup: %v", doCleanSetup)
 	log.Printf("Setup mode: %s", setupMode)
@@ -78,7 +78,7 @@ func RunSetup(logger log.Logger, appVersion string, setupMode SetupMode, doClean
 		}
 	}
 
-	if err := doSetupBitriseCoreTools(); err != nil {
+	if err := doSetupBitriseCoreTools(noUpdate); err != nil {
 		return fmt.Errorf("failed to do common/platform independent setup, error: %s", err)
 	}
 
@@ -93,7 +93,7 @@ func RunSetup(logger log.Logger, appVersion string, setupMode SetupMode, doClean
 	}
 
 	if setupMode != SetupModeMinimal {
-		if err := doSetupPlugins(); err != nil {
+		if err := doSetupPlugins(noUpdate); err != nil {
 			return fmt.Errorf("failed to do Plugins setup, error: %s", err)
 		}
 	}
@@ -148,12 +148,12 @@ func doSetupToolkits(logger log.Logger) error {
 	return nil
 }
 
-func doSetupPlugins() error {
+func doSetupPlugins(noUpdate bool) error {
 	log.Print()
 	log.Infof("Checking Bitrise Plugins...")
 
 	for pluginName, pluginDependency := range PluginDependencyMap {
-		if err := CheckIsPluginInstalled(pluginName, pluginDependency); err != nil {
+		if err := CheckIsPluginInstalled(pluginName, pluginDependency, noUpdate); err != nil {
 			return fmt.Errorf("plugin (%s) failed to install: %s", pluginName, err)
 		}
 	}
@@ -161,15 +161,15 @@ func doSetupPlugins() error {
 	return nil
 }
 
-func doSetupBitriseCoreTools() error {
+func doSetupBitriseCoreTools(noUpdate bool) error {
 	log.Print()
 	log.Infof("Checking Bitrise Core tools...")
 
-	if err := CheckIsEnvmanInstalled(minEnvmanVersion); err != nil {
+	if err := CheckIsEnvmanInstalled(minEnvmanVersion, noUpdate); err != nil {
 		return fmt.Errorf("failed to install envman: %s", err)
 	}
 
-	if err := CheckIsStepmanInstalled(minStepmanVersion); err != nil {
+	if err := CheckIsStepmanInstalled(minStepmanVersion, noUpdate); err != nil {
 		return fmt.Errorf("failed to install stepman: %s", err)
 	}
 

--- a/bitrise/setup.go
+++ b/bitrise/setup.go
@@ -3,6 +3,7 @@ package bitrise
 import (
 	"errors"
 	"fmt"
+	"os"
 	"runtime"
 
 	"github.com/bitrise-io/bitrise/v2/configs"
@@ -46,6 +47,8 @@ var PluginDependencyMap = map[string]PluginDependency{
 }
 
 func RunSetupIfNeeded(logger log.Logger) error {
+	noUpdate := os.Getenv(configs.SetupNoUpdateEnvKey) == "true"
+
 	versionMatch, setupVersion := configs.CheckIsSetupWasDoneForVersion(version.VERSION)
 	if setupVersion == "" {
 		log.Infof("No setup was done yet, running setup now...")
@@ -53,7 +56,7 @@ func RunSetupIfNeeded(logger log.Logger) error {
 	}
 	if !versionMatch {
 		log.Infof("Setup was last performed for version %s, current version is %s. Re-running setup now...", setupVersion, version.VERSION)
-		return RunSetup(logger, version.VERSION, SetupModeMinimal, false, false)
+		return RunSetup(logger, version.VERSION, SetupModeMinimal, false, noUpdate)
 	}
 	return nil
 }

--- a/cli/init.go
+++ b/cli/init.go
@@ -27,7 +27,7 @@ var initCmd = cli.Command{
 				logger.Print("Running setup to install the default plugins")
 				logger.Print()
 
-				if err := bitrise.RunSetup(logger, version.VERSION, bitrise.SetupModeDefault, false); err != nil {
+				if err := bitrise.RunSetup(logger, version.VERSION, bitrise.SetupModeDefault, false, false); err != nil {
 					return fmt.Errorf("setup failed, error: %s", err)
 				}
 

--- a/cli/setup.go
+++ b/cli/setup.go
@@ -29,12 +29,17 @@ var setupCommand = cli.Command{
 			Name:  "minimal",
 			Usage: "Only installs the required tools for running in CI mode.",
 		},
+		cli.BoolFlag{
+			Name:  "no-update",
+			Usage: "Skip updating core tools (stepman/envman) and plugins if they are already installed, even if outdated.",
+		},
 	},
 }
 
 func setup(c *cli.Context) error {
 	clean := c.Bool("clean")
 	minimal := c.Bool("minimal")
+	noUpdate := c.Bool("no-update")
 
 	setupMode := bitrise.SetupModeDefault
 	if minimal {
@@ -42,7 +47,7 @@ func setup(c *cli.Context) error {
 	}
 
 	logger := log.NewLogger(log.GetGlobalLoggerOpts())
-	if err := bitrise.RunSetup(logger, c.App.Version, setupMode, clean); err != nil {
+	if err := bitrise.RunSetup(logger, c.App.Version, setupMode, clean, noUpdate); err != nil {
 		return err
 	}
 

--- a/cli/setup.go
+++ b/cli/setup.go
@@ -4,6 +4,7 @@ import (
 	"os"
 
 	"github.com/bitrise-io/bitrise/v2/bitrise"
+	"github.com/bitrise-io/bitrise/v2/configs"
 	"github.com/bitrise-io/bitrise/v2/log"
 	"github.com/urfave/cli"
 )
@@ -39,7 +40,7 @@ var setupCommand = cli.Command{
 func setup(c *cli.Context) error {
 	clean := c.Bool("clean")
 	minimal := c.Bool("minimal")
-	noUpdate := c.Bool("no-update")
+	noUpdate := c.Bool("no-update") || os.Getenv(configs.SetupNoUpdateEnvKey) == "true"
 
 	setupMode := bitrise.SetupModeDefault
 	if minimal {

--- a/cli/update.go
+++ b/cli/update.go
@@ -284,7 +284,7 @@ func update(c *cli.Context) error {
 		return err
 	}
 
-	return bitrise.RunSetup(logger, versionFlag, bitrise.SetupModeDefault, false)
+	return bitrise.RunSetup(logger, versionFlag, bitrise.SetupModeDefault, false, false)
 }
 
 // CopyFile ...

--- a/configs/configs.go
+++ b/configs/configs.go
@@ -62,6 +62,11 @@ const (
 	//  a error message (including what other Step versions are available).
 	// - Analytics will be disabled.
 	IsSteplibOfflineModeEnvKey = "BITRISE_OFFLINE_MODE"
+	// SetupNoUpdateEnvKey when set to "true", skips updating core tools (stepman/envman) and plugins
+	// during setup if they are already installed, even if their version is below the minimum required.
+	// Tools that are missing entirely are still installed. Intended for CI environments where GitHub
+	// fetches during setup are prone to rate-limiting.
+	SetupNoUpdateEnvKey = "BITRISE_SETUP_NO_UPDATE"
 
 	// --- Debug Options
 


### PR DESCRIPTION
### Checklist

- [ ] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-io/bitrise/blob/master/.github/CONTRIBUTING.md)
- [ ] `README.md` is updated with the changes (if needed)
- [ ] I've run `go mod tidy` both in root and in `integrationtests/` if any dependencies have changed.

### Version

Requires a *PATCH* version update

### Context

When the CLI is updated on-the-fly in CI, the new binary calls `bitrise setup --minimal` and is then invoked with `bitrise run`. Both paths fetch core tools (stepman/envman) and plugins directly from GitHub, which is prone to rate-limiting and other transient failures. Keeping those tools at the latest version is not critical in this context — they just need to be present on disk.

This PR is a short-term workaround until we figure out how to properly distribute core tools and plugins without using GitHub as a dependency manager.

### Changes

- Add `--no-update` flag to `bitrise setup`: skips updating already-installed tools and plugins; missing tools are still installed
- Add `BITRISE_SETUP_NO_UPDATE=true` env var as an equivalent that also covers `RunSetupIfNeeded`
- `RunSetupIfNeeded` (called at the start of `bitrise run`) now respects the env var when re-running setup due to a CLI version mismatch — which is exactly the scenario after an on-the-fly CLI update
- A fresh machine with no prior setup always installs everything, regardless of the flag or env var
- Auto-triggered setup paths that don't go through the flag (`bitrise init`, `bitrise update`) are unaffected

### Investigation details

The `--no-update` flag alone was insufficient: `RunSetupIfNeeded` fires when the saved setup version doesn't match the current CLI version, which always happens after an on-the-fly update. It runs `RunSetup` with its own parameters, bypassing the flag entirely. An environment variable is the right mechanism since it covers both code paths without hardcoding skip-update behavior into `RunSetupIfNeeded` for all callers.

### Decisions

- Both the flag and the env var are opt-in, so default behavior is unchanged.
- Intended mechanism for CI builds and updating the CLI: `bitrise setup --minimal --no-update` + `BITRISE_SETUP_NO_UPDATE=true bitrise run ...`
- Designed as a short-term escape hatch: if skipping an update causes a problem for a given CLI release, the env var can simply be unset.