### PR TITLE
Use checksum to avoid unnecessary upload

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -91,7 +91,7 @@ workflows:
             #!/usr/bin/env bash
             set -ex
 
-            gsutil rsync -r -d "$CATALOG_OUTPUT_DIR" gs://bitrise-cli-tool-catalog
+            gsutil rsync -r -d -c "$CATALOG_OUTPUT_DIR" gs://bitrise-cli-tool-catalog
     - slack@4:
         is_always_run: true
         run_if: .IsBuildFailed


### PR DESCRIPTION
  -c             Causes the rsync command to compute and compare checksums
                 (instead of comparing mtime) for files if the size of source
                 and destination match. This option increases local disk I/O and
                 run time if either src_url or dst_url are on the local file
                 system.