### PR TITLE
Review CLI codebase for prebuilt step binary support

### DIFF
--- a/cli/build_run_result_collector.go
+++ b/cli/build_run_result_collector.go
@@ -80,7 +80,7 @@ func (r buildRunResultCollector) registerStepRunResults(
 	}
 
 	if printStepHeader {
-		logStepStarted(r.logger, stepInfoPtr, step, stepIdxPtr, stepExecutionId, stepStartTime)
+		logStepStarted(stepInfoPtr, stepIdxPtr, stepExecutionId, stepStartTime)
 	}
 
 	errStr := ""

--- a/cli/run_util.go
+++ b/cli/run_util.go
@@ -246,7 +246,7 @@ func (r WorkflowRunner) activateAndRunStep(
 
 	//
 	// Run step
-	logStepStarted(r.logger, stepInfoPtr, mergedStep, stepIDx, stepExecutionID, stepStartTime)
+	logStepStarted(stepInfoPtr, stepIDx, stepExecutionID, stepStartTime)
 
 	// Evaluate run_if from step.yml default (only reached when bitrise.yml didn't set run_if).
 	if mergedStep.RunIf != nil && *mergedStep.RunIf != "" {
@@ -482,7 +482,8 @@ func (r WorkflowRunner) prepareEnvsForStepRun(
 		analytics.StepExecutionIDEnvKey: stepExecutionID,
 	})
 
-	// add an extra env for the next step run to be able to access the step's source location
+	// add an extra env to allow the next step to access the current step's working directory
+	// (for source-built steps this is the source directory, for binary steps it may not contain source code)
 	additionalEnvironments = append(additionalEnvironments, envmanModels.EnvironmentItemModel{
 		"BITRISE_STEP_SOURCE_DIR": stepDir,
 	})
@@ -1117,7 +1118,7 @@ func checkAndInstallStepDependencies(step stepmanModels.StepModel) error {
 	return nil
 }
 
-func logStepStarted(logger log.Logger, stepInfo stepmanModels.StepInfoModel, step stepmanModels.StepModel, idx int, stepExcutionID string, stepStartTime time.Time) {
+func logStepStarted(stepInfo stepmanModels.StepInfoModel, idx int, stepExcutionID string, stepStartTime time.Time) {
 	title := ""
 	if stepInfo.Step.Title != nil && *stepInfo.Step.Title != "" {
 		title = *stepInfo.Step.Title
@@ -1130,7 +1131,6 @@ func logStepStarted(logger log.Logger, stepInfo stepmanModels.StepInfoModel, ste
 		ID:          stepInfo.ID,
 		Version:     stepInfo.Version,
 		Collection:  stepInfo.Library,
-		Toolkit:     toolkits.ToolkitForStep(step, logger).ToolkitName(),
 		StartTime:   stepStartTime.Format(time.RFC3339),
 	}
 	log.PrintStepStartedEvent(params)

--- a/log/event_print.go
+++ b/log/event_print.go
@@ -39,7 +39,6 @@ func generateStepStartedHeaderLines(params StepStartedParams) []string {
 	lines = append(lines, getHeaderSubsection("id", params.ID))
 	lines = append(lines, getHeaderSubsection("version", params.Version))
 	lines = append(lines, getHeaderSubsection("collection", params.Collection))
-	lines = append(lines, getHeaderSubsection("toolkit", params.Toolkit))
 	lines = append(lines, getHeaderSubsection("time", params.StartTime))
 	lines = append(lines, separator)
 	lines = append(lines, stepLogStartIndicator)

--- a/log/event_print_test.go
+++ b/log/event_print_test.go
@@ -27,7 +27,6 @@ func TestStepHeaderPrinting(t *testing.T) {
 				ID:          "xcode-test",
 				Version:     "4.1.2",
 				Collection:  "Steplib",
-				Toolkit:     "Go",
 				StartTime:   "2022-10-19T10:28:33Z ",
 			},
 			expectedOutput: []string{
@@ -37,7 +36,6 @@ func TestStepHeaderPrinting(t *testing.T) {
 				"| id: xcode-test                                                               |",
 				"| version: 4.1.2                                                               |",
 				"| collection: Steplib                                                          |",
-				"| toolkit: Go                                                                  |",
 				"| time: 2022-10-19T10:28:33Z                                                   |",
 				"+------------------------------------------------------------------------------+",
 				"|                                                                              |",
@@ -52,7 +50,6 @@ func TestStepHeaderPrinting(t *testing.T) {
 				ID:          "this-is-the-step-this-is-the-step-this-is-the-step-this-is-the-step-this-is-the-step-this-is-the-step-this-is-the-step-this-is-the-step",
 				Version:     "1.1.2",
 				Collection:  "Steplib",
-				Toolkit:     "Go",
 				StartTime:   "Now",
 			},
 			expectedOutput: []string{
@@ -62,7 +59,6 @@ func TestStepHeaderPrinting(t *testing.T) {
 				"| id: this-is-the-step-this-is-the-step-this-is-the-step-this-is-the-step-t... |",
 				"| version: 1.1.2                                                               |",
 				"| collection: Steplib                                                          |",
-				"| toolkit: Go                                                                  |",
 				"| time: Now                                                                    |",
 				"+------------------------------------------------------------------------------+",
 				"|                                                                              |",
@@ -77,7 +73,6 @@ func TestStepHeaderPrinting(t *testing.T) {
 				ID:          "https://github.com/org/repo",
 				Version:     "",
 				Collection:  "Git",
-				Toolkit:     "",
 				StartTime:   "42",
 			},
 			expectedOutput: []string{
@@ -87,7 +82,6 @@ func TestStepHeaderPrinting(t *testing.T) {
 				"| id: https://github.com/org/repo                                              |",
 				"| version:                                                                     |",
 				"| collection: Git                                                              |",
-				"| toolkit:                                                                     |",
 				"| time: 42                                                                     |",
 				"+------------------------------------------------------------------------------+",
 				"|                                                                              |",

--- a/log/models.go
+++ b/log/models.go
@@ -10,7 +10,6 @@ type StepStartedParams struct {
 	ID          string `json:"id"`
 	Version     string `json:"version"`
 	Collection  string `json:"collection"`
-	Toolkit     string `json:"toolkit"`
 	StartTime   string `json:"start_time"`
 }
 

--- a/log/models_test.go
+++ b/log/models_test.go
@@ -23,10 +23,9 @@ func TestStepStartedEventSerialisesToTheExpectedJsonMessage(t *testing.T) {
 				ID:          "Id",
 				Version:     "Version",
 				Collection:  "Collection",
-				Toolkit:     "Toolkit",
 				StartTime:   "StartTime",
 			},
-			expectedOutput: "{\"uuid\":\"ExecutionId\",\"idx\":0,\"title\":\"Title\",\"id\":\"Id\",\"version\":\"Version\",\"collection\":\"Collection\",\"toolkit\":\"Toolkit\",\"start_time\":\"StartTime\"}",
+			expectedOutput: "{\"uuid\":\"ExecutionId\",\"idx\":0,\"title\":\"Title\",\"id\":\"Id\",\"version\":\"Version\",\"collection\":\"Collection\",\"start_time\":\"StartTime\"}",
 		},
 		{
 			name: "Empty fields are kept",
@@ -37,10 +36,9 @@ func TestStepStartedEventSerialisesToTheExpectedJsonMessage(t *testing.T) {
 				ID:          "Id",
 				Version:     "",
 				Collection:  "Collection",
-				Toolkit:     "",
 				StartTime:   "StartTime",
 			},
-			expectedOutput: "{\"uuid\":\"ExecutionId\",\"idx\":0,\"title\":\"Title\",\"id\":\"Id\",\"version\":\"\",\"collection\":\"Collection\",\"toolkit\":\"\",\"start_time\":\"StartTime\"}",
+			expectedOutput: "{\"uuid\":\"ExecutionId\",\"idx\":0,\"title\":\"Title\",\"id\":\"Id\",\"version\":\"\",\"collection\":\"Collection\",\"start_time\":\"StartTime\"}",
 		},
 	}
 


### PR DESCRIPTION
### Checklist
- [ ] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-io/bitrise/blob/master/.github/CONTRIBUTING.md)
- [ ] `README.md` is updated with the changes (if needed)
- [ ] I've run `go mod tidy` both in root and in `integrationtests/` if any dependencies have changed.

### Version
Requires a *PATCH* version update

### Context

Review CLI code that was written with source-built Go steps in mind and update anything that is misleading or incorrect now that Bitrise supports prebuilt step binaries.

Part of [STEP-2114](https://bitrise.atlassian.net/browse/STEP-2114).

### Changes

- Remove the `toolkit` row from the step started header log — for prebuilt binary steps the toolkit is bypassed entirely during execution, so showing e.g. `toolkit: bash` is wrong. Removed the field from `StepStartedParams` and simplified `logStepStarted` accordingly.
- Update the `BITRISE_STEP_SOURCE_DIR` comment: it described the env var as "the step's source location", which is inaccurate for binary steps where the directory only contains a downloaded executable, not source code.
- Fix the `trackToolkitPrepare` comment: replaced "precompiled binary" (now used specifically for `Executables`-based binary steps) with `binary_location` (the Swift toolkit field that comment was actually referring to).

### Investigation details

During the review, two broader issues were found that are out of scope here:
- The `BITRISE_STEP_SOURCE_DIR` **env var name** is misleading for binary steps — renaming it requires a deprecation plan due to it being a public API
- `bitrise setup` still bootstraps Go/Bash/Swift toolkits even when all steps in a workflow are binary — toolkit installation could potentially be deferred to first use

### Decisions

- Removed the toolkit field entirely from the step header rather than showing `binary` for binary steps — the field was legacy information that adds noise regardless of step type.

[STEP-2114]: https://bitrise.atlassian.net/browse/STEP-2114?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ