### PR TITLE
Revert "Review CLI codebase for prebuilt step binary support"

### DIFF
--- a/cli/build_run_result_collector.go
+++ b/cli/build_run_result_collector.go
@@ -80,7 +80,7 @@ func (r buildRunResultCollector) registerStepRunResults(
 	}
 
 	if printStepHeader {
-		logStepStarted(stepInfoPtr, stepIdxPtr, stepExecutionId, stepStartTime)
+		logStepStarted(r.logger, stepInfoPtr, step, stepIdxPtr, stepExecutionId, stepStartTime)
 	}
 
 	errStr := ""

--- a/cli/run_util.go
+++ b/cli/run_util.go
@@ -246,7 +246,7 @@ func (r WorkflowRunner) activateAndRunStep(
 
 	//
 	// Run step
-	logStepStarted(stepInfoPtr, stepIDx, stepExecutionID, stepStartTime)
+	logStepStarted(r.logger, stepInfoPtr, mergedStep, stepIDx, stepExecutionID, stepStartTime)
 
 	// Evaluate run_if from step.yml default (only reached when bitrise.yml didn't set run_if).
 	if mergedStep.RunIf != nil && *mergedStep.RunIf != "" {
@@ -482,8 +482,7 @@ func (r WorkflowRunner) prepareEnvsForStepRun(
 		analytics.StepExecutionIDEnvKey: stepExecutionID,
 	})
 
-	// add an extra env to allow the next step to access the current step's working directory
-	// (for source-built steps this is the source directory, for binary steps it may not contain source code)
+	// add an extra env for the next step run to be able to access the step's source location
 	additionalEnvironments = append(additionalEnvironments, envmanModels.EnvironmentItemModel{
 		"BITRISE_STEP_SOURCE_DIR": stepDir,
 	})
@@ -1118,7 +1117,7 @@ func checkAndInstallStepDependencies(step stepmanModels.StepModel) error {
 	return nil
 }
 
-func logStepStarted(stepInfo stepmanModels.StepInfoModel, idx int, stepExcutionID string, stepStartTime time.Time) {
+func logStepStarted(logger log.Logger, stepInfo stepmanModels.StepInfoModel, step stepmanModels.StepModel, idx int, stepExcutionID string, stepStartTime time.Time) {
 	title := ""
 	if stepInfo.Step.Title != nil && *stepInfo.Step.Title != "" {
 		title = *stepInfo.Step.Title
@@ -1131,6 +1130,7 @@ func logStepStarted(stepInfo stepmanModels.StepInfoModel, idx int, stepExcutionI
 		ID:          stepInfo.ID,
 		Version:     stepInfo.Version,
 		Collection:  stepInfo.Library,
+		Toolkit:     toolkits.ToolkitForStep(step, logger).ToolkitName(),
 		StartTime:   stepStartTime.Format(time.RFC3339),
 	}
 	log.PrintStepStartedEvent(params)

--- a/log/event_print.go
+++ b/log/event_print.go
@@ -39,6 +39,7 @@ func generateStepStartedHeaderLines(params StepStartedParams) []string {
 	lines = append(lines, getHeaderSubsection("id", params.ID))
 	lines = append(lines, getHeaderSubsection("version", params.Version))
 	lines = append(lines, getHeaderSubsection("collection", params.Collection))
+	lines = append(lines, getHeaderSubsection("toolkit", params.Toolkit))
 	lines = append(lines, getHeaderSubsection("time", params.StartTime))
 	lines = append(lines, separator)
 	lines = append(lines, stepLogStartIndicator)

--- a/log/event_print_test.go
+++ b/log/event_print_test.go
@@ -27,6 +27,7 @@ func TestStepHeaderPrinting(t *testing.T) {
 				ID:          "xcode-test",
 				Version:     "4.1.2",
 				Collection:  "Steplib",
+				Toolkit:     "Go",
 				StartTime:   "2022-10-19T10:28:33Z ",
 			},
 			expectedOutput: []string{
@@ -36,6 +37,7 @@ func TestStepHeaderPrinting(t *testing.T) {
 				"| id: xcode-test                                                               |",
 				"| version: 4.1.2                                                               |",
 				"| collection: Steplib                                                          |",
+				"| toolkit: Go                                                                  |",
 				"| time: 2022-10-19T10:28:33Z                                                   |",
 				"+------------------------------------------------------------------------------+",
 				"|                                                                              |",
@@ -50,6 +52,7 @@ func TestStepHeaderPrinting(t *testing.T) {
 				ID:          "this-is-the-step-this-is-the-step-this-is-the-step-this-is-the-step-this-is-the-step-this-is-the-step-this-is-the-step-this-is-the-step",
 				Version:     "1.1.2",
 				Collection:  "Steplib",
+				Toolkit:     "Go",
 				StartTime:   "Now",
 			},
 			expectedOutput: []string{
@@ -59,6 +62,7 @@ func TestStepHeaderPrinting(t *testing.T) {
 				"| id: this-is-the-step-this-is-the-step-this-is-the-step-this-is-the-step-t... |",
 				"| version: 1.1.2                                                               |",
 				"| collection: Steplib                                                          |",
+				"| toolkit: Go                                                                  |",
 				"| time: Now                                                                    |",
 				"+------------------------------------------------------------------------------+",
 				"|                                                                              |",
@@ -73,6 +77,7 @@ func TestStepHeaderPrinting(t *testing.T) {
 				ID:          "https://github.com/org/repo",
 				Version:     "",
 				Collection:  "Git",
+				Toolkit:     "",
 				StartTime:   "42",
 			},
 			expectedOutput: []string{
@@ -82,6 +87,7 @@ func TestStepHeaderPrinting(t *testing.T) {
 				"| id: https://github.com/org/repo                                              |",
 				"| version:                                                                     |",
 				"| collection: Git                                                              |",
+				"| toolkit:                                                                     |",
 				"| time: 42                                                                     |",
 				"+------------------------------------------------------------------------------+",
 				"|                                                                              |",

--- a/log/models.go
+++ b/log/models.go
@@ -10,6 +10,7 @@ type StepStartedParams struct {
 	ID          string `json:"id"`
 	Version     string `json:"version"`
 	Collection  string `json:"collection"`
+	Toolkit     string `json:"toolkit"`
 	StartTime   string `json:"start_time"`
 }
 

--- a/log/models_test.go
+++ b/log/models_test.go
@@ -23,9 +23,10 @@ func TestStepStartedEventSerialisesToTheExpectedJsonMessage(t *testing.T) {
 				ID:          "Id",
 				Version:     "Version",
 				Collection:  "Collection",
+				Toolkit:     "Toolkit",
 				StartTime:   "StartTime",
 			},
-			expectedOutput: "{\"uuid\":\"ExecutionId\",\"idx\":0,\"title\":\"Title\",\"id\":\"Id\",\"version\":\"Version\",\"collection\":\"Collection\",\"start_time\":\"StartTime\"}",
+			expectedOutput: "{\"uuid\":\"ExecutionId\",\"idx\":0,\"title\":\"Title\",\"id\":\"Id\",\"version\":\"Version\",\"collection\":\"Collection\",\"toolkit\":\"Toolkit\",\"start_time\":\"StartTime\"}",
 		},
 		{
 			name: "Empty fields are kept",
@@ -36,9 +37,10 @@ func TestStepStartedEventSerialisesToTheExpectedJsonMessage(t *testing.T) {
 				ID:          "Id",
 				Version:     "",
 				Collection:  "Collection",
+				Toolkit:     "",
 				StartTime:   "StartTime",
 			},
-			expectedOutput: "{\"uuid\":\"ExecutionId\",\"idx\":0,\"title\":\"Title\",\"id\":\"Id\",\"version\":\"\",\"collection\":\"Collection\",\"start_time\":\"StartTime\"}",
+			expectedOutput: "{\"uuid\":\"ExecutionId\",\"idx\":0,\"title\":\"Title\",\"id\":\"Id\",\"version\":\"\",\"collection\":\"Collection\",\"toolkit\":\"\",\"start_time\":\"StartTime\"}",
 		},
 	}
 


### PR DESCRIPTION
Reverts bitrise-io/bitrise#1269

The `toolkit` field in the JSON log output turned out to be load-bearing, let's revert this temporarily.