### PR TITLE
Consume StepInfo from activator return value (STEP-2437)

### DIFF
--- a/cli/run_util.go
+++ b/cli/run_util.go
@@ -376,7 +376,7 @@ func (r WorkflowRunner) activateStep(
 
 	activationStartedAt := time.Now()
 	activator := newStepActivator()
-	activatedStep, err := activator.activateStep(stepIDData, isStepLibUpdated, stepDir, configs.BitriseWorkDirPath, &stepInfoPtr, isStepLibOfflineMode)
+	activatedStep, err := activator.activateStep(stepIDData, isStepLibUpdated, stepDir, configs.BitriseWorkDirPath, isStepLibOfflineMode)
 	r.tracker.SendStepActivationEvent(
 		activatedStep.ActivationType,
 		stepIDData.IDorURI,
@@ -390,6 +390,15 @@ func (r WorkflowRunner) activateStep(
 	if err != nil {
 		return newActivateStepResult(stepmanModels.StepModel{}, stepInfoPtr, stepDir, "", err)
 	}
+
+	// Fill the presentation step info (shown in the step header boxes) from stepman's result.
+	// Since stepman v0.21.3 this is populated for every activation type, so no guard is needed.
+	// ID and Title are left as newStepInfoPtr seeded them (the bitrise.yml reference, e.g. "./"
+	// for a path step) so we keep the relative ref rather than stepman's absolute path.
+	stepInfoPtr.Version = activatedStep.StepInfo.Version
+	stepInfoPtr.LatestVersion = activatedStep.StepInfo.LatestVersion
+	stepInfoPtr.OriginalVersion = activatedStep.StepInfo.OriginalVersion
+	stepInfoPtr.GroupInfo = activatedStep.StepInfo.GroupInfo
 
 	// Fill step info with default step info, if exist
 	mergedStep := step

--- a/cli/step_activator.go
+++ b/cli/step_activator.go
@@ -22,7 +22,6 @@ func (a stepActivator) activateStep(
 	isStepLibUpdated bool,
 	stepDir string, // $TMPDIR/bitrise/step_src
 	workDir string, // $TMPDIR/bitrise
-	stepInfoPtr *stepmanModels.StepInfoModel,
 	isSteplibOfflineMode bool,
 ) (activator.ActivatedStep, error) {
 	stepmanLogger := log.NewLogger(log.GetGlobalLoggerOpts())
@@ -54,6 +53,8 @@ func (a stepActivator) activateStep(
 		}
 		return activatedStep, nil
 	} else if stepIDData.SteplibSource != "" {
+		// The steplib activator mutates the passed *StepInfoModel in place, but the CLI now reads
+		// StepInfo from the returned ActivatedStep, so pass a throwaway to satisfy the signature.
 		activatedStep, err := activator.ActivateSteplibRefStep(
 			stepmanLogger,
 			stepIDData,
@@ -61,7 +62,7 @@ func (a stepActivator) activateStep(
 			workDir,
 			isStepLibUpdated,
 			isSteplibOfflineMode,
-			stepInfoPtr,
+			&stepmanModels.StepInfoModel{},
 		)
 		if err != nil {
 			// Note: we return the partial result on purpose because DidStepLibUpdate is important 

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/bitrise-io/go-utils v1.0.15
 	github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.36
 	github.com/bitrise-io/goinp v0.0.0-20240103152431-054ed78518ef
-	github.com/bitrise-io/stepman v0.21.2
+	github.com/bitrise-io/stepman v0.21.3
 	github.com/go-git/go-git/v5 v5.13.0
 	github.com/gofrs/uuid v4.3.1+incompatible
 	github.com/hashicorp/go-retryablehttp v0.7.8

--- a/go.sum
+++ b/go.sum
@@ -28,8 +28,8 @@ github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.36 h1:zbvo84Wun4urzBt6+tkGpYSDvA5
 github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.36/go.mod h1:5Z/vkUZ2BIY7IAVlMGns3ypRjd+J872YBSCJaLWVo/U=
 github.com/bitrise-io/goinp v0.0.0-20240103152431-054ed78518ef h1:R5FOa8RHjqZwMN9g1FQ8W7nXxQAG7iwq1Cw+mUk5S9A=
 github.com/bitrise-io/goinp v0.0.0-20240103152431-054ed78518ef/go.mod h1:27ldH2bkCdYN5CEJ6x92EK+gkd5EcDBkA7dMrSKQFYU=
-github.com/bitrise-io/stepman v0.21.2 h1:g6N8ToRSyAZWnld5wr+5XqzqZao5hMW8nXXD2gGteHA=
-github.com/bitrise-io/stepman v0.21.2/go.mod h1:/SdpT6yeD5UKkPz2Kqk9votwLJ1+dQt7aTb8Z5ZoPw0=
+github.com/bitrise-io/stepman v0.21.3 h1:WR9UYbZkmvVy+o5eRXNdy0P4UclYN1kElUw63UntwKc=
+github.com/bitrise-io/stepman v0.21.3/go.mod h1:/SdpT6yeD5UKkPz2Kqk9votwLJ1+dQt7aTb8Z5ZoPw0=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
 github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/cloudflare/circl v1.6.1 h1:zqIqSPIndyBh1bjLVVDHMPpVKqp8Su/V+6MeDzzQBQ0=

--- a/integrationtests/go.mod
+++ b/integrationtests/go.mod
@@ -10,7 +10,7 @@ require (
 	al.essio.dev/pkg/shellescape v1.6.0
 	github.com/bitrise-io/bitrise/v2 v2.0.0
 	github.com/bitrise-io/go-utils v1.0.15
-	github.com/bitrise-io/stepman v0.21.2
+	github.com/bitrise-io/stepman v0.21.3
 	github.com/hashicorp/go-retryablehttp v0.7.8
 	github.com/ryanuber/go-glob v1.0.0
 	github.com/stretchr/testify v1.10.0

--- a/integrationtests/go.sum
+++ b/integrationtests/go.sum
@@ -28,8 +28,8 @@ github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.36 h1:zbvo84Wun4urzBt6+tkGpYSDvA5
 github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.36/go.mod h1:5Z/vkUZ2BIY7IAVlMGns3ypRjd+J872YBSCJaLWVo/U=
 github.com/bitrise-io/goinp v0.0.0-20240103152431-054ed78518ef h1:R5FOa8RHjqZwMN9g1FQ8W7nXxQAG7iwq1Cw+mUk5S9A=
 github.com/bitrise-io/goinp v0.0.0-20240103152431-054ed78518ef/go.mod h1:27ldH2bkCdYN5CEJ6x92EK+gkd5EcDBkA7dMrSKQFYU=
-github.com/bitrise-io/stepman v0.21.2 h1:g6N8ToRSyAZWnld5wr+5XqzqZao5hMW8nXXD2gGteHA=
-github.com/bitrise-io/stepman v0.21.2/go.mod h1:/SdpT6yeD5UKkPz2Kqk9votwLJ1+dQt7aTb8Z5ZoPw0=
+github.com/bitrise-io/stepman v0.21.3 h1:WR9UYbZkmvVy+o5eRXNdy0P4UclYN1kElUw63UntwKc=
+github.com/bitrise-io/stepman v0.21.3/go.mod h1:/SdpT6yeD5UKkPz2Kqk9votwLJ1+dQt7aTb8Z5ZoPw0=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
 github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/cloudflare/circl v1.6.1 h1:zqIqSPIndyBh1bjLVVDHMPpVKqp8Su/V+6MeDzzQBQ0=

--- a/integrationtests/steps/step_title_merge/bitrise.yml
+++ b/integrationtests/steps/step_title_merge/bitrise.yml
@@ -1,0 +1,53 @@
+format_version: "11"
+default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
+
+workflows:
+  # No workflow title -> the step.yml title is merged in, per activation type.
+  # path: "path::./" -> "Local Title From Step YML"
+  path_merged_title:
+    steps:
+    - path::./: {}
+
+  # steplib: "script" -> "Script"
+  steplib_merged_title:
+    steps:
+    - script:
+        inputs:
+        - content: echo "steplib step ran"
+
+  # git: "git::...steps-script.git@master" -> "Script"
+  git_merged_title:
+    steps:
+    - git::https://github.com/bitrise-steplib/steps-script.git@master:
+        inputs:
+        - content: echo "git step ran"
+
+  # Title source matrix, (step.yml title) x (workflow title):
+  # SET x SET -> workflow title wins.
+  explicit_title:
+    steps:
+    - path::./:
+        title: Explicit Workflow Title
+
+  # EMPTY x SET -> workflow title is shown.
+  workflow_title_no_step_title:
+    steps:
+    - path::./step_no_title:
+        title: Workflow Title Without Step Title
+
+  # EMPTY x EMPTY -> nothing to merge, falls back to the reference ("path::./step_no_title").
+  # (SET x EMPTY is covered by *_merged_title above.)
+  no_title_at_all:
+    steps:
+    - path::./step_no_title: {}
+
+  # Activation fails (missing path), no title -> falls back to the reference, build fails.
+  activation_error:
+    steps:
+    - path::./this-path-does-not-exist: {}
+
+  # Activation fails (missing path) but a workflow title is set -> the failing step keeps that title.
+  activation_error_with_title:
+    steps:
+    - path::./this-path-does-not-exist:
+        title: Title For A Failing Step

--- a/integrationtests/steps/step_title_merge/step.sh
+++ b/integrationtests/steps/step_title_merge/step.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+echo "step title merge test step ran with example_input: ${example_input}"

--- a/integrationtests/steps/step_title_merge/step.yml
+++ b/integrationtests/steps/step_title_merge/step.yml
@@ -1,0 +1,16 @@
+title: Local Title From Step YML
+summary: Step used to verify step title merging in the step header.
+description: |-
+  This step defines its title here in step.yml. When a workflow references it without
+  setting its own title, the runner should display this title instead of the raw step
+  reference (e.g. `path::./`).
+type_tags:
+- script
+is_always_run: false
+is_skippable: false
+run_if: ""
+inputs:
+- example_input: example value
+  opts:
+    title: Example input
+outputs: []

--- a/integrationtests/steps/step_title_merge/step_no_title/step.sh
+++ b/integrationtests/steps/step_title_merge/step_no_title/step.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+echo "no-title step ran with example_input: ${example_input}"

--- a/integrationtests/steps/step_title_merge/step_no_title/step.yml
+++ b/integrationtests/steps/step_title_merge/step_no_title/step.yml
@@ -1,0 +1,15 @@
+summary: Step with no title in its step.yml, used to verify title fallback behavior.
+description: |-
+  This step intentionally does NOT define a title in step.yml. It is used to verify what the
+  runner displays when the step.yml title is empty, both when the bitrise.yml sets a title and
+  when it doesn't.
+type_tags:
+- script
+is_always_run: false
+is_skippable: false
+run_if: ""
+inputs:
+- example_input: example value
+  opts:
+    title: Example input
+outputs: []

--- a/integrationtests/steps/step_title_merge_test.go
+++ b/integrationtests/steps/step_title_merge_test.go
@@ -1,0 +1,94 @@
+//go:build linux_and_mac
+// +build linux_and_mac
+
+package steps
+
+import (
+	"testing"
+
+	"github.com/bitrise-io/bitrise/v2/integrationtests/internal/testhelpers"
+	"github.com/bitrise-io/go-utils/command"
+	"github.com/stretchr/testify/require"
+)
+
+// Test_StepTitleMerging covers the step title merging in WorkflowRunner.activateStep across all
+// activation types (path, steplib, git): with no explicit workflow title, the step.yml title is
+// shown; an explicit workflow title wins; and on activation failure the title falls back to the
+// reference seeded by newStepInfoPtr.
+func Test_StepTitleMerging(t *testing.T) {
+	configPth := "bitrise.yml"
+
+	run := func(workflow string) (string, error) {
+		cmd := command.New(testhelpers.BinPath(), "run", workflow, "--config", configPth)
+		cmd.SetDir("step_title_merge")
+		return cmd.RunAndReturnTrimmedCombinedOutput()
+	}
+
+	t.Log("path activation: merges the step.yml title when the workflow doesn't set one")
+	{
+		out, err := run("path_merged_title")
+		require.NoError(t, err, out)
+		// The step.yml title is shown in the step header box instead of the raw "path::./" reference.
+		require.Contains(t, out, "Local Title From Step YML", out)
+	}
+
+	t.Log("steplib activation: merges the step.yml title when the workflow doesn't set one")
+	{
+		out, err := run("steplib_merged_title")
+		require.NoError(t, err, out)
+		// The steplib step.yml title ("Script") is shown instead of the raw step id ("script").
+		require.Contains(t, out, "Script", out)
+	}
+
+	t.Log("git activation: merges the step.yml title when the workflow doesn't set one")
+	{
+		out, err := run("git_merged_title")
+		require.NoError(t, err, out)
+		// The git step.yml title ("Script") is shown instead of the raw "git::..." reference.
+		require.Contains(t, out, "Script", out)
+	}
+
+	t.Log("step.yml title + bitrise.yml title: keeps the explicit workflow title")
+	{
+		out, err := run("explicit_title")
+		require.NoError(t, err, out)
+		require.Contains(t, out, "Explicit Workflow Title", out)
+		require.NotContains(t, out, "Local Title From Step YML", out)
+	}
+
+	t.Log("empty step.yml title + bitrise.yml title: shows the workflow title")
+	{
+		out, err := run("workflow_title_no_step_title")
+		require.NoError(t, err, out)
+		require.Contains(t, out, "Workflow Title Without Step Title", out)
+	}
+
+	t.Log("empty step.yml title + empty bitrise.yml title: falls back to the step reference")
+	{
+		out, err := run("no_title_at_all")
+		require.NoError(t, err, out)
+		// Nothing to merge from either side, so the defaulted reference title is shown.
+		require.Contains(t, out, "path::./step_no_title", out)
+	}
+
+	t.Log("activation failure, no title: falls back to the step reference")
+	{
+		out, err := run("activation_error")
+		// Activation fails, so the build fails with a non-zero exit code.
+		require.Error(t, err, out)
+		require.Contains(t, out, "the provided directory doesn't exist", out)
+		// activateStep returns before the step info is filled from the activation result, so the
+		// header/summary keep the defaulted step reference as the title and no step.yml title is merged.
+		require.Contains(t, out, "path::./this-path-does-not-exist", out)
+		require.NotContains(t, out, "Local Title From Step YML", out)
+	}
+
+	t.Log("activation failure, title set: keeps the explicit title on the failing step")
+	{
+		out, err := run("activation_error_with_title")
+		require.Error(t, err, out)
+		require.Contains(t, out, "the provided directory doesn't exist", out)
+		// The explicit bitrise.yml title (seeded by newStepInfoPtr) is shown for the failing step.
+		require.Contains(t, out, "Title For A Failing Step", out)
+	}
+}

--- a/vendor/github.com/bitrise-io/stepman/activator/steplib/activate.go
+++ b/vendor/github.com/bitrise-io/stepman/activator/steplib/activate.go
@@ -39,9 +39,13 @@ func ActivateStep(stepLibURI, id, version, destination, destinationStepYML strin
 		if ok && executableForPlatform.Hash != "" && executableForPlatform.StorageURI != "" {
 			log.Debugf("Downloading executable for %s", platform)
 			downloadStart := time.Now()
-			execPath, err := activateStepExecutable(stepLibURI, id, version, executableForPlatform, destination, destinationStepYML)
+			execPath, err := activateStepExecutable(id, executableForPlatform, destination)
 			if err == nil {
 				log.Debugf("Downloaded executable in %s", time.Since(downloadStart).Round(time.Millisecond))
+
+				if err := copyStepYML(stepLibURI, id, version, destinationStepYML); err != nil {
+					return "", fmt.Errorf("copy step.yml: %s", err)
+				}
 				return execPath, nil
 			}
 			log.Warnf("Failed to download step executable, fallback to step source activation: %s", err)

--- a/vendor/github.com/bitrise-io/stepman/activator/steplib/activate_executable.go
+++ b/vendor/github.com/bitrise-io/stepman/activator/steplib/activate_executable.go
@@ -16,12 +16,9 @@ import (
 )
 
 func activateStepExecutable(
-	stepLibURI string,
 	stepID string,
-	version string,
 	executable models.Executable,
 	destinationDir string,
-	destinationStepYML string,
 ) (string, error) {
 	body, err := downloadExecutable(executable)
 	if err != nil {
@@ -63,10 +60,6 @@ func activateStepExecutable(
 	err = os.Chmod(path, 0755)
 	if err != nil {
 		return "", fmt.Errorf("set executable permission on file: %s", err)
-	}
-
-	if err := copyStepYML(stepLibURI, stepID, version, destinationStepYML); err != nil {
-		return "", fmt.Errorf("copy step.yml: %s", err)
 	}
 
 	return path, nil

--- a/vendor/github.com/bitrise-io/stepman/activator/steplib_ref.go
+++ b/vendor/github.com/bitrise-io/stepman/activator/steplib_ref.go
@@ -29,6 +29,7 @@ func ActivateSteplibRefStep(
 
 	stepInfo, didUpdate, err := prepareStepLibForActivation(log, id, didStepLibUpdateInWorkflow, isOfflineMode)
 	activationResult.DidStepLibUpdate = didUpdate
+	activationResult.StepInfo = stepInfo
 	if err != nil {
 		return activationResult, err
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -78,7 +78,7 @@ github.com/bitrise-io/go-utils/v2/retryhttp
 # github.com/bitrise-io/goinp v0.0.0-20240103152431-054ed78518ef
 ## explicit; go 1.18
 github.com/bitrise-io/goinp/goinp
-# github.com/bitrise-io/stepman v0.21.2
+# github.com/bitrise-io/stepman v0.21.3
 ## explicit; go 1.25
 github.com/bitrise-io/stepman/activator
 github.com/bitrise-io/stepman/activator/steplib


### PR DESCRIPTION
Bump stepman to v0.21.3, which now populates ActivatedStep.StepInfo for every activation type (steplib, git, local path). The CLI reads the step info from that return value instead of relying on the activator mutating a passed-in *StepInfoModel, so the steplib-only activation-type guard is gone and the pointer parameter is dropped from stepActivator.activateStep.

ID and Title are kept as newStepInfoPtr seeded them so path steps keep their relative reference (e.g. "./") rather than stepman's absolute path. Verified behaviour-preserving against prod 2.40.6 across all activation types and title-source combinations.

Add e2e tests (integrationtests/steps/step_title_merge) covering title merging for path/steplib/git, the (step.yml title) x (workflow title) matrix, and activation failures with and without a title.

<!--
  Thanks for contributing to the Bitrise CLI!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-io/bitrise/blob/master/.github/CONTRIBUTING.md)
- [x] `README.md` is updated with the changes (if needed)
- [x] I've run `go mod tidy` both in root and in `integrationtests/` if any dependencies have changed. <!-- Integration tests are treated separate. See `integrationtests/README.md` -->

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *PATCH* [version update](https://semver.org/)

### Context

<!--- 
  One sentence summary on why the change is needed.
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->

<!-- Please link the issue that the PR fixes.
Resolves: #GITHUB_ISSUE_ID or https://link_to_the_issue_on_discuss.bitrise.io.
-->

### Changes

<!-- 
  Details are important, and help maintainers processing your PR.
  Please list additional details, for example:
  - Update dependencies
  - Make `foo` optional in `main.go`
  - `foo` now returns an `error` for better error handling
-->

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->