### PR TITLE
[STEP-2437] Bump stepman to v0.23.0, drop StepInfo out-param

### DIFF
--- a/cli/step_activator.go
+++ b/cli/step_activator.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/bitrise-io/bitrise/v2/log"
 	"github.com/bitrise-io/stepman/activator"
-	stepmanModels "github.com/bitrise-io/stepman/models"
 	"github.com/bitrise-io/stepman/stepid"
 )
 
@@ -53,8 +52,6 @@ func (a stepActivator) activateStep(
 		}
 		return activatedStep, nil
 	} else if stepIDData.SteplibSource != "" {
-		// The steplib activator mutates the passed *StepInfoModel in place, but the CLI now reads
-		// StepInfo from the returned ActivatedStep, so pass a throwaway to satisfy the signature.
 		activatedStep, err := activator.ActivateSteplibRefStep(
 			stepmanLogger,
 			stepIDData,
@@ -62,7 +59,6 @@ func (a stepActivator) activateStep(
 			workDir,
 			isStepLibUpdated,
 			isSteplibOfflineMode,
-			&stepmanModels.StepInfoModel{},
 		)
 		if err != nil {
 			// Note: we return the partial result on purpose because DidStepLibUpdate is important 

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/bitrise-io/go-utils v1.0.15
 	github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.36
 	github.com/bitrise-io/goinp v0.0.0-20240103152431-054ed78518ef
-	github.com/bitrise-io/stepman v0.21.3
+	github.com/bitrise-io/stepman v0.23.0
 	github.com/go-git/go-git/v5 v5.13.0
 	github.com/gofrs/uuid v4.3.1+incompatible
 	github.com/hashicorp/go-retryablehttp v0.7.8

--- a/go.sum
+++ b/go.sum
@@ -28,8 +28,8 @@ github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.36 h1:zbvo84Wun4urzBt6+tkGpYSDvA5
 github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.36/go.mod h1:5Z/vkUZ2BIY7IAVlMGns3ypRjd+J872YBSCJaLWVo/U=
 github.com/bitrise-io/goinp v0.0.0-20240103152431-054ed78518ef h1:R5FOa8RHjqZwMN9g1FQ8W7nXxQAG7iwq1Cw+mUk5S9A=
 github.com/bitrise-io/goinp v0.0.0-20240103152431-054ed78518ef/go.mod h1:27ldH2bkCdYN5CEJ6x92EK+gkd5EcDBkA7dMrSKQFYU=
-github.com/bitrise-io/stepman v0.21.3 h1:WR9UYbZkmvVy+o5eRXNdy0P4UclYN1kElUw63UntwKc=
-github.com/bitrise-io/stepman v0.21.3/go.mod h1:/SdpT6yeD5UKkPz2Kqk9votwLJ1+dQt7aTb8Z5ZoPw0=
+github.com/bitrise-io/stepman v0.23.0 h1:P0BRrCPq7IlcRrHmPtlwGb6JgicjNtEIo+Hcg1WU4+o=
+github.com/bitrise-io/stepman v0.23.0/go.mod h1:/SdpT6yeD5UKkPz2Kqk9votwLJ1+dQt7aTb8Z5ZoPw0=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
 github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/cloudflare/circl v1.6.1 h1:zqIqSPIndyBh1bjLVVDHMPpVKqp8Su/V+6MeDzzQBQ0=

--- a/integrationtests/go.mod
+++ b/integrationtests/go.mod
@@ -10,7 +10,7 @@ require (
 	al.essio.dev/pkg/shellescape v1.6.0
 	github.com/bitrise-io/bitrise/v2 v2.0.0
 	github.com/bitrise-io/go-utils v1.0.15
-	github.com/bitrise-io/stepman v0.21.3
+	github.com/bitrise-io/stepman v0.23.0
 	github.com/hashicorp/go-retryablehttp v0.7.8
 	github.com/ryanuber/go-glob v1.0.0
 	github.com/stretchr/testify v1.10.0

--- a/integrationtests/go.sum
+++ b/integrationtests/go.sum
@@ -28,8 +28,8 @@ github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.36 h1:zbvo84Wun4urzBt6+tkGpYSDvA5
 github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.36/go.mod h1:5Z/vkUZ2BIY7IAVlMGns3ypRjd+J872YBSCJaLWVo/U=
 github.com/bitrise-io/goinp v0.0.0-20240103152431-054ed78518ef h1:R5FOa8RHjqZwMN9g1FQ8W7nXxQAG7iwq1Cw+mUk5S9A=
 github.com/bitrise-io/goinp v0.0.0-20240103152431-054ed78518ef/go.mod h1:27ldH2bkCdYN5CEJ6x92EK+gkd5EcDBkA7dMrSKQFYU=
-github.com/bitrise-io/stepman v0.21.3 h1:WR9UYbZkmvVy+o5eRXNdy0P4UclYN1kElUw63UntwKc=
-github.com/bitrise-io/stepman v0.21.3/go.mod h1:/SdpT6yeD5UKkPz2Kqk9votwLJ1+dQt7aTb8Z5ZoPw0=
+github.com/bitrise-io/stepman v0.23.0 h1:P0BRrCPq7IlcRrHmPtlwGb6JgicjNtEIo+Hcg1WU4+o=
+github.com/bitrise-io/stepman v0.23.0/go.mod h1:/SdpT6yeD5UKkPz2Kqk9votwLJ1+dQt7aTb8Z5ZoPw0=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
 github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/cloudflare/circl v1.6.1 h1:zqIqSPIndyBh1bjLVVDHMPpVKqp8Su/V+6MeDzzQBQ0=

--- a/vendor/github.com/bitrise-io/stepman/activator/steplib/activate.go
+++ b/vendor/github.com/bitrise-io/stepman/activator/steplib/activate.go
@@ -33,6 +33,20 @@ func ActivateStep(stepLibURI, id, version, destination, destinationStepYML strin
 		return "", fmt.Errorf("failed to find step: %s", err)
 	}
 
+	execPath, err := downloadPrecompiled(log, step, id, destination)
+	if execPath != "" {
+		if err := copyStepYML(stepLibURI, id, version, destinationStepYML); err != nil {
+			return "", fmt.Errorf("copy step.yml: %s", err)
+		}
+
+		return execPath, err
+	}
+
+	err = activateStepSource(stepCollection, stepLibURI, id, version, step, destination, destinationStepYML, log, isOfflineMode)
+	return "", err
+}
+
+func downloadPrecompiled(log stepman.Logger, step models.StepModel, id string, destination string) (string, error) {
 	if (os.Getenv(precompiledStepsEnv) == "true" || os.Getenv(precompiledStepsEnv) == "1") && step.Executables != nil {
 		platform := fmt.Sprintf("%s-%s", runtime.GOOS, runtime.GOARCH)
 		executableForPlatform, ok := (*step.Executables)[platform]
@@ -43,17 +57,13 @@ func ActivateStep(stepLibURI, id, version, destination, destinationStepYML strin
 			if err == nil {
 				log.Debugf("Downloaded executable in %s", time.Since(downloadStart).Round(time.Millisecond))
 
-				if err := copyStepYML(stepLibURI, id, version, destinationStepYML); err != nil {
-					return "", fmt.Errorf("copy step.yml: %s", err)
-				}
 				return execPath, nil
 			}
 			log.Warnf("Failed to download step executable, fallback to step source activation: %s", err)
 		}
 		log.Infof("No prebuilt executable found for %s, fallback to step source activation", platform)
 	}
-	err = activateStepSource(stepCollection, stepLibURI, id, version, step, destination, destinationStepYML, log, isOfflineMode)
-	return "", err
+	return "", nil
 }
 
 func queryStepMetadata(stepLib models.StepCollectionModel, stepLibURI string, id, version string) (models.StepModel, string, error) {

--- a/vendor/github.com/bitrise-io/stepman/activator/steplib_ref.go
+++ b/vendor/github.com/bitrise-io/stepman/activator/steplib_ref.go
@@ -18,7 +18,6 @@ func ActivateSteplibRefStep(
 	workDir string,
 	didStepLibUpdateInWorkflow bool,
 	isOfflineMode bool,
-	stepInfoPtr *models.StepInfoModel,
 ) (ActivatedStep, error) {
 	stepYMLPath := filepath.Join(workDir, "current_step.yml")
 	//nolint:exhaustruct // missing fields are added down below based on activation result
@@ -44,16 +43,6 @@ func ActivateSteplibRefStep(
 	if err != nil {
 		return activationResult, err
 	}
-
-	// TODO: this is sketchy, we should clean this up, but this pointer originates in the CLI codebase
-	stepInfoPtr.ID = stepInfo.ID
-	if stepInfoPtr.Step.Title == nil || *stepInfoPtr.Step.Title == "" {
-		stepInfoPtr.Step.Title = pointers.NewStringPtr(stepInfo.ID)
-	}
-	stepInfoPtr.Version = stepInfo.Version
-	stepInfoPtr.LatestVersion = stepInfo.LatestVersion
-	stepInfoPtr.OriginalVersion = stepInfo.OriginalVersion
-	stepInfoPtr.GroupInfo = stepInfo.GroupInfo
 
 	return activationResult, nil
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -78,7 +78,7 @@ github.com/bitrise-io/go-utils/v2/retryhttp
 # github.com/bitrise-io/goinp v0.0.0-20240103152431-054ed78518ef
 ## explicit; go 1.18
 github.com/bitrise-io/goinp/goinp
-# github.com/bitrise-io/stepman v0.21.3
+# github.com/bitrise-io/stepman v0.23.0
 ## explicit; go 1.25
 github.com/bitrise-io/stepman/activator
 github.com/bitrise-io/stepman/activator/steplib


### PR DESCRIPTION
## What

Bump `github.com/bitrise-io/stepman` to `v0.23.0` and drop the throwaway `*StepInfoModel` argument at the steplib activation call site.

stepman `v0.22.0` was skipped due to a poisoned go proxy cache. v0.22.0 was released on Jun 16, but since removed. The release was due to debugging a duplicate webhook in the stepman repo.

## Why

stepman v0.23.0 removes the `*StepInfoModel` out-parameter from `activator.ActivateSteplibRefStep` (stepman [#395](https://github.com/bitrise-io/stepman/pull/395)). The CLI already reads `StepInfo` from the returned `ActivatedStep` (since #1277), so the passed `&stepmanModels.StepInfoModel{}` was a no-op placeholder kept only to satisfy the old signature.

## Changes

- `go.mod` / `go.sum` / `vendor`: stepman bumped to `v0.23.0`
- `cli/step_activator.go`: drop the `&stepmanModels.StepInfoModel{}` argument and stale comment; remove the now-unused `stepman/models` import

## Verification

- `go build ./...` — green
- `go vet ./cli/...` — clean
- `go test ./cli/...` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
