### PR TITLE
Adds tool aliasing to catalog

### DIFF
--- a/cli/tools.go
+++ b/cli/tools.go
@@ -718,7 +718,11 @@ func toolsListTools(c *cli.Context) error {
 		fmt.Println(string(data))
 	case outputFormatPlaintext:
 		for _, t := range tools {
-			fmt.Println(t)
+			if len(t.Aliases) > 0 {
+				fmt.Printf("%s (alias: %s)\n", t.Name, strings.Join(t.Aliases, ", "))
+			} else {
+				fmt.Println(t.Name)
+			}
 		}
 	default:
 		return fmt.Errorf("invalid --format: %s", format)

--- a/toolprovider/alias/alias.go
+++ b/toolprovider/alias/alias.go
@@ -1,6 +1,10 @@
 package alias
 
-import "github.com/bitrise-io/bitrise/v2/toolprovider/provider"
+import (
+	"slices"
+
+	"github.com/bitrise-io/bitrise/v2/toolprovider/provider"
+)
 
 var toolAliasMap = map[provider.ToolID]provider.ToolID{
 	"go":   "golang",
@@ -12,4 +16,17 @@ func GetCanonicalToolID(id provider.ToolID) provider.ToolID {
 		return canonicalID
 	}
 	return id
+}
+
+// AliasesFor returns the aliases that resolve to the given canonical tool ID,
+// sorted for stable output. Returns nil if the tool has no aliases.
+func AliasesFor(canonical provider.ToolID) []provider.ToolID {
+	var aliases []provider.ToolID
+	for aliasID, canonicalID := range toolAliasMap {
+		if canonicalID == canonical {
+			aliases = append(aliases, aliasID)
+		}
+	}
+	slices.Sort(aliases)
+	return aliases
 }

--- a/toolprovider/alias/alias_test.go
+++ b/toolprovider/alias/alias_test.go
@@ -1,0 +1,29 @@
+package alias
+
+import (
+	"testing"
+
+	"github.com/bitrise-io/bitrise/v2/toolprovider/provider"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetCanonicalToolID(t *testing.T) {
+	assert.Equal(t, provider.ToolID("golang"), GetCanonicalToolID("go"))
+	assert.Equal(t, provider.ToolID("nodejs"), GetCanonicalToolID("node"))
+	// Canonical names and unknown tools are returned unchanged.
+	assert.Equal(t, provider.ToolID("golang"), GetCanonicalToolID("golang"))
+	assert.Equal(t, provider.ToolID("ruby"), GetCanonicalToolID("ruby"))
+	// Garbage/unknown input passes through untouched (no validation here).
+	assert.Equal(t, provider.ToolID("garbage-xyz"), GetCanonicalToolID("garbage-xyz"))
+}
+
+func TestAliasesFor(t *testing.T) {
+	assert.Equal(t, []provider.ToolID{"go"}, AliasesFor("golang"))
+	assert.Equal(t, []provider.ToolID{"node"}, AliasesFor("nodejs"))
+	// Tools without aliases return nil.
+	assert.Nil(t, AliasesFor("ruby"))
+	// Passing an alias (not the canonical) yields nothing.
+	assert.Nil(t, AliasesFor("go"))
+	// Garbage/unknown input yields nothing.
+	assert.Nil(t, AliasesFor("garbage-xyz"))
+}

--- a/toolprovider/list_versions.go
+++ b/toolprovider/list_versions.go
@@ -2,7 +2,6 @@ package toolprovider
 
 import (
 	"fmt"
-	"slices"
 	"strings"
 
 	"github.com/bitrise-io/bitrise/v2/toolprovider/alias"
@@ -15,8 +14,8 @@ import (
 // If versionPrefix is non-empty, only versions starting with that prefix are returned.
 func ListToolVersions(toolName string, versionPrefix string, tp provider.ToolProvider) ([]string, error) {
 	canonicalName := string(alias.GetCanonicalToolID(provider.ToolID(toolName)))
-	if !slices.Contains(SupportedTools(), canonicalName) {
-		return nil, fmt.Errorf("%q is not a supported tool. Supported tools: %v", toolName, SupportedTools())
+	if !IsSupported(toolName) {
+		return nil, fmt.Errorf("%q is not a supported tool. Supported tools: %v", toolName, canonicalToolNames())
 	}
 
 	versions, err := tp.ListReleasedVersions(provider.ToolID(canonicalName))

--- a/toolprovider/supported_tools.go
+++ b/toolprovider/supported_tools.go
@@ -1,11 +1,25 @@
 package toolprovider
 
-// SupportedTools returns the list of tools the CLI advertises and accepts
-// for the "versions" and "list-tools" commands.
-// Uses canonical names (e.g. "golang" not "go", "nodejs" not "node").
-// It is predominantly composed of mise core tools, but can include
-// others, such as flutter.
-func SupportedTools() []string {
+import (
+	"slices"
+
+	"github.com/bitrise-io/bitrise/v2/toolprovider/alias"
+	"github.com/bitrise-io/bitrise/v2/toolprovider/provider"
+)
+
+// ToolInfo describes a supported tool: its canonical name and any accepted
+// aliases (e.g. "go" for "golang", "node" for "nodejs"), which the CLI treats
+// as equivalent to the canonical name.
+type ToolInfo struct {
+	Name    string   `json:"name"`
+	Aliases []string `json:"aliases,omitempty"`
+}
+
+// canonicalToolNames is the source-of-truth list of supported tools, by canonical
+// name (e.g. "golang" not "go", "nodejs" not "node").
+// It is predominantly composed of mise core tools, but can include others, such
+// as flutter.
+func canonicalToolNames() []string {
 	return []string{
 		"bun",
 		"deno",
@@ -21,6 +35,29 @@ func SupportedTools() []string {
 		"swift",
 		"zig",
 	}
+}
+
+// SupportedTools returns the catalog of tools the CLI advertises and accepts
+// for the "versions" and "list-tools" commands, each with its canonical name
+// and accepted aliases.
+func SupportedTools() []ToolInfo {
+	names := canonicalToolNames()
+	infos := make([]ToolInfo, 0, len(names))
+	for _, name := range names {
+		var aliases []string
+		for _, aliasID := range alias.AliasesFor(provider.ToolID(name)) {
+			aliases = append(aliases, string(aliasID))
+		}
+		infos = append(infos, ToolInfo{Name: name, Aliases: aliases})
+	}
+	return infos
+}
+
+// IsSupported reports whether the given tool name is supported, resolving
+// aliases (e.g. "go", "node") to their canonical name first.
+func IsSupported(toolName string) bool {
+	canonical := string(alias.GetCanonicalToolID(provider.ToolID(toolName)))
+	return slices.Contains(canonicalToolNames(), canonical)
 }
 
 // nonMiseCoreExceptions lists tools in SupportedTools that are intentionally

--- a/toolprovider/supported_tools_test.go
+++ b/toolprovider/supported_tools_test.go
@@ -11,7 +11,10 @@ import (
 )
 
 func TestSupportedTools_MiseCoreToolConsistency(t *testing.T) {
-	supported := SupportedTools()
+	var supported []string
+	for _, tool := range SupportedTools() {
+		supported = append(supported, tool.Name)
+	}
 
 	// Build a set of mise core tools resolved to canonical names.
 	miseCoreCanonical := map[string]bool{}
@@ -43,4 +46,18 @@ func TestSupportedTools_MiseCoreToolConsistency(t *testing.T) {
 				"nonMiseCoreExceptions entry %q is not in SupportedTools — remove it from exceptions", tool)
 		}
 	})
+}
+
+func TestSupportedTools_ListsAliases(t *testing.T) {
+	byName := map[string][]string{}
+	for _, tool := range SupportedTools() {
+		byName[tool.Name] = tool.Aliases
+	}
+
+	// Tools with aliases expose them.
+	assert.Equal(t, []string{"go"}, byName["golang"])
+	assert.Equal(t, []string{"node"}, byName["nodejs"])
+
+	// Tools without aliases don't invent any.
+	assert.Nil(t, byName["ruby"])
 }


### PR DESCRIPTION
Adds alias info to the catalog subcommand

```
> go run main.go tools catalog               
bun
deno
elixir
erlang
flutter
golang (alias: go)
java
nodejs (alias: node)
python
ruby
rust
swift
zig
```
And JSON output
```
{
"tools": [
...
    {
      "name": "flutter",
      "aliases": []
    },
    {
      "name": "golang",
      "aliases": [
        "go"
      ]
    },
...
```