### PR TITLE
Bump stepman to v0.24.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/bitrise-io/go-utils v1.0.15
 	github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.36
 	github.com/bitrise-io/goinp v0.0.0-20240103152431-054ed78518ef
-	github.com/bitrise-io/stepman v0.23.0
+	github.com/bitrise-io/stepman v0.24.0
 	github.com/go-git/go-git/v5 v5.19.1
 	github.com/gofrs/uuid v4.3.1+incompatible
 	github.com/hashicorp/go-retryablehttp v0.7.8

--- a/go.sum
+++ b/go.sum
@@ -28,8 +28,8 @@ github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.36 h1:zbvo84Wun4urzBt6+tkGpYSDvA5
 github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.36/go.mod h1:5Z/vkUZ2BIY7IAVlMGns3ypRjd+J872YBSCJaLWVo/U=
 github.com/bitrise-io/goinp v0.0.0-20240103152431-054ed78518ef h1:R5FOa8RHjqZwMN9g1FQ8W7nXxQAG7iwq1Cw+mUk5S9A=
 github.com/bitrise-io/goinp v0.0.0-20240103152431-054ed78518ef/go.mod h1:27ldH2bkCdYN5CEJ6x92EK+gkd5EcDBkA7dMrSKQFYU=
-github.com/bitrise-io/stepman v0.23.0 h1:P0BRrCPq7IlcRrHmPtlwGb6JgicjNtEIo+Hcg1WU4+o=
-github.com/bitrise-io/stepman v0.23.0/go.mod h1:/SdpT6yeD5UKkPz2Kqk9votwLJ1+dQt7aTb8Z5ZoPw0=
+github.com/bitrise-io/stepman v0.24.0 h1:5wLVVV/NrL9Ad97m+7r+vXGpMp77A6NgVFvDSVFsdW8=
+github.com/bitrise-io/stepman v0.24.0/go.mod h1:/SdpT6yeD5UKkPz2Kqk9votwLJ1+dQt7aTb8Z5ZoPw0=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
 github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/cloudflare/circl v1.6.4 h1:pOXuDTCEYyzydgUpQ0CQz3LsinKjiSk6nNP5Lt5K64U=

--- a/integrationtests/go.mod
+++ b/integrationtests/go.mod
@@ -10,7 +10,7 @@ require (
 	al.essio.dev/pkg/shellescape v1.6.0
 	github.com/bitrise-io/bitrise/v2 v2.0.0
 	github.com/bitrise-io/go-utils v1.0.15
-	github.com/bitrise-io/stepman v0.23.0
+	github.com/bitrise-io/stepman v0.24.0
 	github.com/hashicorp/go-retryablehttp v0.7.8
 	github.com/ryanuber/go-glob v1.0.0
 	github.com/stretchr/testify v1.11.1

--- a/integrationtests/go.sum
+++ b/integrationtests/go.sum
@@ -28,8 +28,8 @@ github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.36 h1:zbvo84Wun4urzBt6+tkGpYSDvA5
 github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.36/go.mod h1:5Z/vkUZ2BIY7IAVlMGns3ypRjd+J872YBSCJaLWVo/U=
 github.com/bitrise-io/goinp v0.0.0-20240103152431-054ed78518ef h1:R5FOa8RHjqZwMN9g1FQ8W7nXxQAG7iwq1Cw+mUk5S9A=
 github.com/bitrise-io/goinp v0.0.0-20240103152431-054ed78518ef/go.mod h1:27ldH2bkCdYN5CEJ6x92EK+gkd5EcDBkA7dMrSKQFYU=
-github.com/bitrise-io/stepman v0.23.0 h1:P0BRrCPq7IlcRrHmPtlwGb6JgicjNtEIo+Hcg1WU4+o=
-github.com/bitrise-io/stepman v0.23.0/go.mod h1:/SdpT6yeD5UKkPz2Kqk9votwLJ1+dQt7aTb8Z5ZoPw0=
+github.com/bitrise-io/stepman v0.24.0 h1:5wLVVV/NrL9Ad97m+7r+vXGpMp77A6NgVFvDSVFsdW8=
+github.com/bitrise-io/stepman v0.24.0/go.mod h1:/SdpT6yeD5UKkPz2Kqk9votwLJ1+dQt7aTb8Z5ZoPw0=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
 github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/cloudflare/circl v1.6.4 h1:pOXuDTCEYyzydgUpQ0CQz3LsinKjiSk6nNP5Lt5K64U=

--- a/vendor/github.com/bitrise-io/go-utils/v2/fileutil/atime_darwin.go
+++ b/vendor/github.com/bitrise-io/go-utils/v2/fileutil/atime_darwin.go
@@ -1,0 +1,12 @@
+//go:build darwin || freebsd || netbsd || openbsd
+
+package fileutil
+
+import (
+	"syscall"
+	"time"
+)
+
+func atimeFromStat(stat *syscall.Stat_t) time.Time {
+	return time.Unix(int64(stat.Atimespec.Sec), int64(stat.Atimespec.Nsec))
+}

--- a/vendor/github.com/bitrise-io/go-utils/v2/fileutil/atime_linux.go
+++ b/vendor/github.com/bitrise-io/go-utils/v2/fileutil/atime_linux.go
@@ -1,0 +1,12 @@
+//go:build linux
+
+package fileutil
+
+import (
+	"syscall"
+	"time"
+)
+
+func atimeFromStat(stat *syscall.Stat_t) time.Time {
+	return time.Unix(int64(stat.Atim.Sec), int64(stat.Atim.Nsec))
+}

--- a/vendor/github.com/bitrise-io/go-utils/v2/fileutil/copy.go
+++ b/vendor/github.com/bitrise-io/go-utils/v2/fileutil/copy.go
@@ -1,0 +1,213 @@
+package fileutil
+
+import (
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"runtime"
+	"syscall"
+	"time"
+)
+
+// CopyFile copies a single file from src to dst.
+// Pass [CopyOptions] to modify default behavior as required, nil otherwise.
+//
+// Attention: the default behavior is different from the v1 implementation of `command.CopyFile`,
+// v1 function replaces the existing file.
+// By default, if the target file exists, this call will fail with an error.
+func (fm fileManager) CopyFile(src, dst string, opts *CopyOptions) error {
+	srcDir := filepath.Dir(src)
+	fsys := fm.osProxy.DirFS(srcDir)
+
+	return fm.CopyFileFS(fsys, filepath.Base(src), dst, opts)
+}
+
+// CopyFileFS copies a single file located at src within the source file system fsys to dst.
+// It is the excerpt from fs.CopyFS that copies a single file from an fs.FS to a dst path.
+// Pass [CopyOptions] to modify default behavior as required, nil otherwise.
+//
+// By default, if the target file exists, this call will fail with an error.
+// Use [CopyOptions.Overwrite] to replace an existing destination file instead.
+//
+// Note: ownership and access/modification time preservation rely on the source FS
+// exposing a *syscall.Stat_t via fs.FileInfo.Sys() (as os-backed file systems such as
+// os.DirFS do). When copying from in-memory file systems (e.g. embed.FS or fstest.MapFS)
+// that information is unavailable, so ownership and times are simply not preserved.
+func (fm fileManager) CopyFileFS(fsys fs.FS, src, dst string, opts *CopyOptions) error {
+	r, err := fsys.Open(src)
+	if err != nil {
+		return err
+	}
+	defer r.Close() // nolint:errcheck
+	info, err := r.Stat()
+	if err != nil {
+		return err
+	}
+	flags := os.O_CREATE | os.O_EXCL | os.O_WRONLY
+	if opts != nil && opts.Overwrite {
+		flags = os.O_CREATE | os.O_TRUNC | os.O_WRONLY
+	}
+	w, err := fm.osProxy.OpenFile(dst, flags, 0777)
+	if err != nil {
+		return err
+	}
+
+	defer w.Close() // nolint:errcheck
+	if _, err := io.Copy(w, r); err != nil {
+		return &fs.PathError{Op: "Copy", Path: dst, Err: err}
+	}
+	if err := w.Sync(); err != nil {
+		return &fs.PathError{Op: "Sync", Path: dst, Err: err}
+	}
+	if err := fm.copyOwner(info, dst); err != nil {
+		return &fs.PathError{Op: "copyOwner", Path: dst, Err: err}
+	}
+	if err := fm.copyMode(info, dst); err != nil {
+		return &fs.PathError{Op: "copyMode", Path: dst, Err: err}
+	}
+	if err := fm.copyTimes(info, dst); err != nil {
+		return &fs.PathError{Op: "copyTimes", Path: dst, Err: err}
+	}
+
+	return nil
+}
+
+// CopyDir is a convenience method for copying a directory from src to dst.
+//
+// A copy of os.CopyFS because it messes up permissions when copying files
+// from fs.FS
+//
+// CopyFS copies the file system fsys into the directory dir,
+// creating dir if necessary.
+//
+// Preserves permissions and ownership when possible.
+//
+// By default, CopyFS will not overwrite existing files. If a file name in fsys
+// already exists in the destination, CopyFS will return an error
+// such that errors.Is(err, fs.ErrExist) will be true.
+// Attention: the default behavior is different from the v1 implementation of `command.CopyFile`,
+// v1 function replaces the existing files.
+//
+// Symbolic links in dir are followed.
+//
+// New files added to fsys (including if dir is a subdirectory of fsys)
+// while CopyFS is running are not guaranteed to be copied.
+//
+// Copying stops at and returns the first error encountered.
+// Note: symlinks are preserved during the copy operation
+func (fm fileManager) CopyDir(src, dst string, opts *CopyOptions) error {
+	fsys := fm.osProxy.DirFS(src)
+	return fs.WalkDir(fsys, ".", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		newPath := filepath.Join(dst, path)
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+
+		// This is not exhausetive in the original implementation either.
+		// nolint:exhaustive
+		switch d.Type() {
+		case os.ModeDir:
+			if err := fm.osProxy.MkdirAll(newPath, 0777); err != nil {
+				return err
+			}
+			if err := fm.copyOwner(info, newPath); err != nil {
+				return err
+			}
+			if err := fm.copyMode(info, newPath); err != nil {
+				return err
+			}
+			return fm.copyTimes(info, newPath)
+
+		case os.ModeSymlink:
+			srcPath := filepath.Join(src, path)
+			target, err := fm.osProxy.Readlink(srcPath)
+			if err != nil {
+				return err
+			}
+			if err := fm.osProxy.Symlink(target, newPath); err != nil {
+				return err
+			}
+			if err := fm.copyOwner(info, newPath); err != nil {
+				return err
+			}
+			return fm.copyTimes(info, newPath)
+
+		// "normal" file
+		case 0:
+			return fm.CopyFileFS(fsys, path, newPath, opts)
+
+		default:
+			return &os.PathError{Op: "CopyFS", Path: path, Err: os.ErrInvalid}
+		}
+	})
+}
+
+// lchown ...
+func (fm fileManager) lchown(path string, uid, gid int) error {
+	return fm.osProxy.Lchown(path, uid, gid)
+}
+
+// copyOwner invokes lchown to copy ownership from srcInfo to dstPath.
+func (fm fileManager) copyOwner(srcInfo os.FileInfo, dstPath string) error {
+	if runtime.GOOS == "windows" {
+		return nil
+	}
+	stat, ok := srcInfo.Sys().(*syscall.Stat_t)
+	if !ok {
+		// Source file systems that are not backed by the OS (e.g. embed.FS or
+		// fstest.MapFS) do not expose a *syscall.Stat_t, so there is no ownership
+		// information to copy. Skip ownership preservation in that case.
+		return nil
+	}
+	// os.Lchown affects the link itself when given the link path
+	if err := fm.lchown(dstPath, int(stat.Uid), int(stat.Gid)); err != nil {
+		return fmt.Errorf("lchown(symlink) %s: %w", dstPath, err)
+	}
+	return nil
+}
+
+// chtimes ...
+func (fm fileManager) chtimes(path string, atime, mtime time.Time) error {
+	return fm.osProxy.Chtimes(path, atime, mtime)
+}
+
+// copyTimes invokes chtimes to copy access and modification times from srcInfo to dstPath.
+func (fm fileManager) copyTimes(srcInfo os.FileInfo, dstPath string) error {
+	if runtime.GOOS == "windows" {
+		// On Windows we only set mod time (atime setting optional)
+		if err := fm.chtimes(dstPath, srcInfo.ModTime(), srcInfo.ModTime()); err != nil {
+			// ignore or return depending on policy
+			return fmt.Errorf("chtimes %s: %w", dstPath, err)
+		}
+
+	} else {
+		if stat, ok := srcInfo.Sys().(*syscall.Stat_t); ok {
+			// set times (for non-symlink paths we use os.chtimes)
+			if srcInfo.Mode()&os.ModeSymlink == 0 {
+				atime := atimeFromStat(stat)
+				mtime := srcInfo.ModTime()
+				if err := fm.chtimes(dstPath, atime, mtime); err != nil {
+					return fmt.Errorf("chtimes %s: %w", dstPath, err)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// chmod ...
+func (fm fileManager) chmod(path string, mode os.FileMode) error {
+	return fm.osProxy.Chmod(path, mode)
+}
+
+// copyMode invokes chmod to copy file mode from srcInfo to dstPath.
+func (fm fileManager) copyMode(srcInfo os.FileInfo, dstPath string) error {
+	return fm.chmod(dstPath, srcInfo.Mode())
+}

--- a/vendor/github.com/bitrise-io/go-utils/v2/fileutil/fileutil.go
+++ b/vendor/github.com/bitrise-io/go-utils/v2/fileutil/fileutil.go
@@ -1,0 +1,165 @@
+package fileutil
+
+import (
+	"errors"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// CopyOptions configures a [FileManager.CopyFile] operation.
+// A nil pointer means default behavior.
+type CopyOptions struct {
+	Overwrite bool // Overwrite replaces the destination file if it already exists.
+}
+
+// FileManager ...
+type FileManager interface {
+	Open(path string) (*os.File, error)
+	OpenReaderIfExists(path string) (io.Reader, error)
+	ReadDirEntryNames(path string) ([]string, error)
+	Remove(path string) error
+	RemoveAll(path string) error
+	Write(path string, value string, perm os.FileMode) error
+	WriteBytes(path string, value []byte) error
+	FileSizeInBytes(pth string) (int64, error)
+	CopyFile(src, dst string, opts *CopyOptions) error
+	CopyFileFS(fsys fs.FS, src, dst string, opts *CopyOptions) error
+	CopyDir(src, dst string, opts *CopyOptions) error
+	Lstat(path string) (os.FileInfo, error)
+	LastNLines(s string, n int) string
+}
+
+type fileManager struct {
+	osProxy OsProxy
+}
+
+// NewFileManager ...
+func NewFileManager() FileManager {
+	return fileManager{osProxy: RealOS{}}
+}
+
+// ReadDirEntryNames reads the named directory using os.ReadDir and returns the dir entries' names.
+func (fileManager) ReadDirEntryNames(path string) ([]string, error) {
+	entries, err := os.ReadDir(path)
+	if err != nil {
+		return nil, err
+	}
+	var names []string
+	for _, entry := range entries {
+		names = append(names, entry.Name())
+	}
+	return names, nil
+}
+
+// Open ...
+func (fileManager) Open(path string) (*os.File, error) {
+	return os.Open(path)
+}
+
+// OpenReaderIfExists opens the named file using os.Open and returns an io.Reader.
+// An ErrNotExist error is absorbed and the returned io.Reader will be nil,
+// other errors from os.Open are returned as is.
+func (fileManager) OpenReaderIfExists(path string) (io.Reader, error) {
+	file, err := os.Open(path)
+	if errors.Is(err, fs.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return file, nil
+}
+
+// Remove ...
+func (fileManager) Remove(path string) error {
+	return os.Remove(path)
+}
+
+// RemoveAll ...
+func (fileManager) RemoveAll(path string) error {
+	return os.RemoveAll(path)
+}
+
+// Write ...
+func (f fileManager) Write(path string, value string, mode os.FileMode) error {
+	if err := f.ensureSavePath(path); err != nil {
+		return err
+	}
+	if err := os.WriteFile(path, []byte(value), mode); err != nil {
+		return err
+	}
+	return os.Chmod(path, mode)
+}
+
+func (fileManager) ensureSavePath(savePath string) error {
+	dirPath := filepath.Dir(savePath)
+	return os.MkdirAll(dirPath, 0700)
+}
+
+// WriteBytes ...
+func (f fileManager) WriteBytes(path string, value []byte) error {
+	return os.WriteFile(path, value, 0600)
+}
+
+// FileSizeInBytes checks if the provided path exists and return with the file size (bytes) using os.Lstat.
+func (fileManager) FileSizeInBytes(pth string) (int64, error) {
+	if pth == "" {
+		return 0, errors.New("No path provided")
+	}
+	fileInf, err := os.Stat(pth)
+	if err != nil {
+		return 0, err
+	}
+
+	return fileInf.Size(), nil
+}
+
+// Lstat implements FileManager by delegating to os.Lstat via the osProxy.
+func (fm fileManager) Lstat(path string) (os.FileInfo, error) {
+	return fm.osProxy.Lstat(path)
+}
+
+// LastNLines returns the last n lines of the given string s.
+func (fileManager) LastNLines(s string, n int) string {
+	if n <= 0 {
+		return ""
+	}
+	// normalize CRLF to LF if needed
+	if strings.Contains(s, "\r\n") {
+		s = strings.ReplaceAll(s, "\r\n", "\n")
+	}
+
+	// skip trailing newlines so we don't count empty trailing lines
+	i := len(s) - 1
+	for i >= 0 && s[i] == '\n' {
+		i--
+	}
+	if i < 0 {
+		return "" // string was all newlines
+	}
+
+	// scan backward counting '\n' occurrences
+	count := 0
+	for ; i >= 0; i-- {
+		if s[i] == '\n' {
+			count++
+			if count == n {
+				// substring after this newline is the last n lines
+				start := i + 1
+				res := s[start:]
+				// trim trailing whitespace (spaces, tabs, newlines, etc.)
+				return strings.TrimRightFunc(res, func(r rune) bool {
+					return r == ' ' || r == '\t' || r == '\n' || r == '\r' || r == '\f' || r == '\v'
+				})
+			}
+		}
+	}
+
+	// fewer than n newlines => return whole string (trim trailing whitespace)
+	return strings.TrimRightFunc(s, func(r rune) bool {
+		return r == ' ' || r == '\t' || r == '\n' || r == '\r' || r == '\f' || r == '\v'
+	})
+}

--- a/vendor/github.com/bitrise-io/go-utils/v2/fileutil/os_proxy.go
+++ b/vendor/github.com/bitrise-io/go-utils/v2/fileutil/os_proxy.go
@@ -1,0 +1,69 @@
+package fileutil
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// SysStat holds file system stat information.
+type SysStat struct {
+	Uid int
+	Gid int
+}
+
+// OsProxy defines the subset of os package functions we want to proxy.
+// Add more methods as you need them.
+type OsProxy interface {
+	Stat(name string) (os.FileInfo, error)
+	Lstat(name string) (os.FileInfo, error)
+	Readlink(name string) (string, error)
+	Symlink(oldname, newname string) error
+	Mkdir(name string, perm os.FileMode) error
+	MkdirAll(path string, perm os.FileMode) error
+	Open(name string) (*os.File, error)
+	Create(name string) (*os.File, error)
+	Remove(name string) error
+	RemoveAll(path string) error
+	Rename(oldpath, newpath string) error
+	Chmod(name string, mode os.FileMode) error
+	Chown(name string, uid, gid int) error
+	Chtimes(name string, atime, mtime time.Time) error
+	Getwd() (string, error)
+	Abs(path string) (string, error)
+	DirFS(dir string) fs.FS
+	OpenFile(name string, flag int, perm os.FileMode) (*os.File, error)
+	Lchown(name string, uid, gid int) error
+}
+
+// RealOS is the default implementation that delegates to the real os package.
+type RealOS struct{}
+
+func (RealOS) Stat(name string) (os.FileInfo, error)        { return os.Stat(name) }                //nolint:revive
+func (RealOS) Lstat(name string) (os.FileInfo, error)       { return os.Lstat(name) }               //nolint:revive
+func (RealOS) Readlink(name string) (string, error)         { return os.Readlink(name) }            //nolint:revive
+func (RealOS) Symlink(oldname, newname string) error        { return os.Symlink(oldname, newname) } //nolint:revive
+func (RealOS) Mkdir(name string, perm os.FileMode) error    { return os.Mkdir(name, perm) }         //nolint:revive
+func (RealOS) MkdirAll(path string, perm os.FileMode) error { return os.MkdirAll(path, perm) }      //nolint:revive
+func (RealOS) Open(name string) (*os.File, error)           { return os.Open(name) }                //nolint:revive
+func (RealOS) Create(name string) (*os.File, error)         { return os.Create(name) }              //nolint:revive
+func (RealOS) Remove(name string) error                     { return os.Remove(name) }              //nolint:revive
+func (RealOS) RemoveAll(path string) error                  { return os.RemoveAll(path) }           //nolint:revive
+func (RealOS) Rename(oldpath, newpath string) error         { return os.Rename(oldpath, newpath) }  //nolint:revive
+func (RealOS) Chmod(name string, mode os.FileMode) error    { return os.Chmod(name, mode) }         //nolint:revive
+func (RealOS) Chown(name string, uid, gid int) error        { return os.Chown(name, uid, gid) }     //nolint:revive
+func (RealOS) Getwd() (string, error)                       { return os.Getwd() }                   //nolint:revive
+func (RealOS) Abs(path string) (string, error)              { return filepath.Abs(path) }           //nolint:revive
+func (RealOS) DirFS(dir string) fs.FS                       { return os.DirFS(dir) }                //nolint:revive
+func (RealOS) Lchown(name string, uid, gid int) error       { return os.Lchown(name, uid, gid) }    //nolint:revive
+
+//nolint:revive
+func (RealOS) OpenFile(name string, flag int, perm os.FileMode) (*os.File, error) {
+	return os.OpenFile(name, flag, perm)
+}
+
+//nolint:revive
+func (RealOS) Chtimes(name string, atime, mtime time.Time) error {
+	return os.Chtimes(name, atime, mtime)
+}

--- a/vendor/github.com/bitrise-io/stepman/activator/steplib/activate.go
+++ b/vendor/github.com/bitrise-io/stepman/activator/steplib/activate.go
@@ -1,6 +1,7 @@
 package steplib
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -10,8 +11,12 @@ import (
 
 	"github.com/bitrise-io/go-utils/command"
 	"github.com/bitrise-io/go-utils/pathutil"
+	"github.com/bitrise-io/go-utils/v2/fileutil"
 	"github.com/bitrise-io/stepman/models"
+	"github.com/bitrise-io/stepman/stepid"
+	"github.com/bitrise-io/stepman/steplibrary"
 	"github.com/bitrise-io/stepman/stepman"
+	"gopkg.in/yaml.v2"
 )
 
 const precompiledStepsEnv = "BITRISE_EXPERIMENT_PRECOMPILED_STEPS"
@@ -22,38 +27,76 @@ var precompiledStepsDefaultStorageURLs = []string{
 	"https://storage.googleapis.com/bitrise-steplib-storage",
 }
 
-func ActivateStep(stepLibURI, id, version, destination, destinationStepYML string, log stepman.Logger, isOfflineMode bool) (string, error) {
-	stepCollection, err := stepman.ReadStepSpec(stepLibURI)
-	if err != nil {
-		return "", fmt.Errorf("failed to read %s steplib: %s", stepLibURI, err)
-	}
-
-	step, version, err := queryStepMetadata(stepCollection, stepLibURI, id, version)
-	if err != nil {
-		return "", fmt.Errorf("failed to find step: %s", err)
-	}
-
-	execPath, err := downloadPrecompiled(log, step, id, destination)
-	if execPath != "" {
-		if err := copyStepYML(stepLibURI, id, version, destinationStepYML); err != nil {
-			return "", fmt.Errorf("copy step.yml: %s", err)
-		}
-
-		return execPath, err
-	}
-
-	err = activateStepSource(stepCollection, stepLibURI, id, version, step, destination, destinationStepYML, log, isOfflineMode)
-	return "", err
+type ResolvedStep struct {
+	// ExecPath is optional: it holds the activated step executable only for
+	// precompiled executable activation, and is empty for source activation.
+	ExecPath string
+	StepInfo models.StepInfoModel
 }
 
-func downloadPrecompiled(log stepman.Logger, step models.StepModel, id string, destination string) (string, error) {
+func ActivateStep(id stepid.CanonicalID, destination, destinationStepYML string, log stepman.Logger, isOfflineMode bool, libraryAPI *steplibrary.Client) (ResolvedStep, error) {
+	var stepInfo models.StepInfoModel
+	var resolveErr error
+	if libraryAPI != nil {
+		stepInfo, resolveErr = libraryAPI.FetchStepMetadata(context.Background(), id)
+	} else {
+		// Legacy path: resolve the step from the local steplib spec (resolving the
+		// version constraint to a concrete version). This repeats the resolution
+		// already done by prepareStepLibForActivation, but keeps the legacy path
+		// self-contained instead of threading resolved info in.
+		stepInfo, resolveErr = stepman.QueryStepInfoFromLibrary(id.SteplibSource, id.IDorURI, id.Version, log)
+	}
+	if resolveErr != nil {
+		return ResolvedStep{ExecPath: "", StepInfo: models.StepInfoModel{}}, resolveErr
+	}
+	stepModel := stepInfo.Step
+	version := stepInfo.Version
+
+	// Place the step.yml at destinationStepYML once, up front.
+	if libraryAPI == nil {
+		if err := copyStepYML(id.SteplibSource, id.IDorURI, version, destinationStepYML); err != nil {
+			return ResolvedStep{ExecPath: "", StepInfo: stepInfo}, fmt.Errorf("copy step.yml: %s", err)
+		}
+	} else {
+		if err := writeStepYML(stepInfo.Step, destinationStepYML); err != nil {
+			return ResolvedStep{ExecPath: "", StepInfo: stepInfo}, err
+		}
+	}
+
+	execPath, err := downloadPrecompiled(log, stepModel, id, destination)
+	if execPath != "" {
+		return ResolvedStep{ExecPath: execPath, StepInfo: stepInfo}, err
+	}
+
+	// Fall back to step source activation.
+	if libraryAPI != nil {
+		// activate the source over the API, without git clone
+		if err := activateStepSourceWithAPI(libraryAPI, id.SteplibSource, version, stepModel.Source, destination, log, isOfflineMode); err != nil {
+			return ResolvedStep{ExecPath: "", StepInfo: stepInfo}, err
+		}
+		return ResolvedStep{ExecPath: "", StepInfo: stepInfo}, nil
+	}
+
+	// using git cloned steplib
+	stepCollection, err := stepman.ReadStepSpec(id.SteplibSource)
+	if err != nil {
+		return ResolvedStep{ExecPath: "", StepInfo: stepInfo}, fmt.Errorf("failed to read %s steplib: %s", id.SteplibSource, err)
+	}
+	if err := activateStepSource(stepCollection, id.SteplibSource, id.IDorURI, version, stepModel, destination, log, isOfflineMode); err != nil {
+		return ResolvedStep{ExecPath: "", StepInfo: stepInfo}, err
+	}
+
+	return ResolvedStep{ExecPath: "", StepInfo: stepInfo}, nil
+}
+
+func downloadPrecompiled(log stepman.Logger, step models.StepModel, id stepid.CanonicalID, destination string) (string, error) {
 	if (os.Getenv(precompiledStepsEnv) == "true" || os.Getenv(precompiledStepsEnv) == "1") && step.Executables != nil {
 		platform := fmt.Sprintf("%s-%s", runtime.GOOS, runtime.GOARCH)
 		executableForPlatform, ok := (*step.Executables)[platform]
 		if ok && executableForPlatform.Hash != "" && executableForPlatform.StorageURI != "" {
 			log.Debugf("Downloading executable for %s", platform)
 			downloadStart := time.Now()
-			execPath, err := activateStepExecutable(id, executableForPlatform, destination)
+			execPath, err := activateStepExecutable(id.IDorURI, executableForPlatform, destination, log)
 			if err == nil {
 				log.Debugf("Downloaded executable in %s", time.Since(downloadStart).Round(time.Millisecond))
 
@@ -64,27 +107,6 @@ func downloadPrecompiled(log stepman.Logger, step models.StepModel, id string, d
 		log.Infof("No prebuilt executable found for %s, fallback to step source activation", platform)
 	}
 	return "", nil
-}
-
-func queryStepMetadata(stepLib models.StepCollectionModel, stepLibURI string, id, version string) (models.StepModel, string, error) {
-	step, stepFound, versionFound := stepLib.GetStep(id, version)
-
-	if !stepFound {
-		return models.StepModel{}, "", fmt.Errorf("%s steplib does not contain %s step", stepLibURI, id)
-	}
-	if !versionFound {
-		return models.StepModel{}, "", fmt.Errorf("%s steplib does not contain %s step %s version", stepLibURI, id, version)
-	}
-
-	if version == "" {
-		latest, err := stepLib.GetLatestStepVersion(id)
-		if err != nil {
-			return models.StepModel{}, "", fmt.Errorf("failed to find latest version of %s step", id)
-		}
-		version = latest
-	}
-
-	return step, version, nil
 }
 
 func copyStepYML(libraryURL, id, version, dest string) error {
@@ -104,6 +126,20 @@ func copyStepYML(libraryURL, id, version, dest string) error {
 	if err := command.CopyFile(stepYMLSrc, dest); err != nil {
 		return fmt.Errorf("copy command failed: %s", err)
 	}
+	return nil
+}
+
+func writeStepYML(step models.StepModel, outputPath string) error {
+	stepYML, err := yaml.Marshal(step)
+	if err != nil {
+		return fmt.Errorf("marshal step model to YAML: %w", err)
+	}
+
+	fileManager := fileutil.NewFileManager()
+	if err := fileManager.WriteBytes(outputPath, stepYML); err != nil {
+		return fmt.Errorf("write step.yml: %w", err)
+	}
+
 	return nil
 }
 

--- a/vendor/github.com/bitrise-io/stepman/activator/steplib/activate_executable.go
+++ b/vendor/github.com/bitrise-io/stepman/activator/steplib/activate_executable.go
@@ -10,8 +10,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/bitrise-io/go-utils/log"
 	"github.com/bitrise-io/stepman/models"
+	"github.com/bitrise-io/stepman/stepman"
 	"github.com/hashicorp/go-retryablehttp"
 )
 
@@ -19,14 +19,15 @@ func activateStepExecutable(
 	stepID string,
 	executable models.Executable,
 	destinationDir string,
+	logger stepman.Logger,
 ) (string, error) {
-	body, err := downloadExecutable(executable)
+	body, err := downloadExecutable(executable, logger)
 	if err != nil {
 		return "", err
 	}
 	defer func() {
 		if err := body.Close(); err != nil {
-			log.Warnf("Failed to close response body: %s\n", err)
+			logger.Warnf("Failed to close response body: %s\n", err)
 		}
 	}()
 
@@ -43,7 +44,7 @@ func activateStepExecutable(
 	defer func() {
 		err := file.Close()
 		if err != nil {
-			log.Warnf("Failed to close file %s: %s\n", path, err)
+			logger.Warnf("Failed to close file %s: %s\n", path, err)
 		}
 	}()
 
@@ -114,7 +115,7 @@ func buildDownloadURLs(bases []string, executable models.Executable) ([]string, 
 	return urls, nil
 }
 
-func downloadExecutable(executable models.Executable) (io.ReadCloser, error) {
+func downloadExecutable(executable models.Executable, logger stepman.Logger) (io.ReadCloser, error) {
 	bases := precompiledStepsDefaultStorageURLs
 	if override := os.Getenv(precompiledStepsStorageURLsEnv); override != "" {
 		bases = strings.Split(override, ",")
@@ -124,10 +125,10 @@ func downloadExecutable(executable models.Executable) (io.ReadCloser, error) {
 	if err != nil {
 		return nil, err
 	}
-	return downloadFromURLs(urls)
+	return downloadFromURLs(urls, logger)
 }
 
-func downloadFromURLs(urls []string) (io.ReadCloser, error) {
+func downloadFromURLs(urls []string, logger stepman.Logger) (io.ReadCloser, error) {
 	var errs []error
 	for _, url := range urls {
 		resp, err := retryablehttp.Get(url)
@@ -136,13 +137,13 @@ func downloadFromURLs(urls []string) (io.ReadCloser, error) {
 		}
 
 		if err != nil {
-			log.Warnf("Failed to download step from %s: %s\n", url, err)
+			logger.Warnf("Failed to download step from %s: %s\n", url, err)
 			errs = append(errs, fmt.Errorf("%s: %w", url, err))
 		} else {
 			if closeErr := resp.Body.Close(); closeErr != nil {
-				log.Warnf("Failed to close response body: %s\n", closeErr)
+				logger.Warnf("Failed to close response body: %s\n", closeErr)
 			}
-			log.Warnf("Storage returned status %d for %s\n", resp.StatusCode, url)
+			logger.Warnf("Storage returned status %d for %s\n", resp.StatusCode, url)
 			errs = append(errs, fmt.Errorf("%s: status %d", url, resp.StatusCode))
 		}
 	}

--- a/vendor/github.com/bitrise-io/stepman/activator/steplib/activate_source.go
+++ b/vendor/github.com/bitrise-io/stepman/activator/steplib/activate_source.go
@@ -15,7 +15,6 @@ func activateStepSource(
 	stepLibURI, id, version string,
 	step models.StepModel,
 	destination string,
-	stepYMLDestination string,
 	log stepman.Logger,
 	isOfflineMode bool,
 ) error {
@@ -44,10 +43,6 @@ func activateStepSource(
 
 	if err := copyStep(stepCacheDir, destination); err != nil {
 		return fmt.Errorf("copy step failed: %s", err)
-	}
-
-	if err := copyStepYML(stepLibURI, id, version, stepYMLDestination); err != nil {
-		return fmt.Errorf("copy step.yml failed: %s", err)
 	}
 
 	return nil

--- a/vendor/github.com/bitrise-io/stepman/activator/steplib/source.go
+++ b/vendor/github.com/bitrise-io/stepman/activator/steplib/source.go
@@ -1,0 +1,36 @@
+package steplib
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/bitrise-io/stepman/models"
+	"github.com/bitrise-io/stepman/steplibrary"
+	"github.com/bitrise-io/stepman/stepman"
+)
+
+// activateStepSourceWithAPI materializes id@version's source into destDir
+// without cloning a git steplib.
+func activateStepSourceWithAPI(libraryAPI *steplibrary.Client, id, version string, source *models.StepSourceModel, destDir string, log stepman.Logger, isOfflineMode bool) error {
+	if isOfflineMode {
+		return errors.New("offline mode is not supported with Steplib API")
+	}
+
+	if source == nil || source.Git == "" {
+		return fmt.Errorf("step %s@%s has no source git URL to download from", id, version)
+	}
+
+	locations, err := libraryAPI.StepSourceDownloadLocations(context.Background(), id, version, source.Git)
+	if err != nil {
+		return fmt.Errorf("resolve download locations for %s@%s: %s", id, version, err)
+	}
+	if len(locations) == 0 {
+		return fmt.Errorf("step %s@%s has no download location", id, version)
+	}
+
+	if err := stepman.DownloadStepSourceArchive(destDir, locations, id, version, source.Commit, log); err != nil {
+		return fmt.Errorf("download step source %s@%s: %s", id, version, err)
+	}
+	return nil
+}

--- a/vendor/github.com/bitrise-io/stepman/activator/steplib_ref.go
+++ b/vendor/github.com/bitrise-io/stepman/activator/steplib_ref.go
@@ -2,13 +2,20 @@ package activator
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 
-	"github.com/bitrise-io/go-utils/pointers"
 	"github.com/bitrise-io/stepman/activator/steplib"
 	"github.com/bitrise-io/stepman/models"
 	"github.com/bitrise-io/stepman/stepid"
+	"github.com/bitrise-io/stepman/steplibrary"
 	"github.com/bitrise-io/stepman/stepman"
+)
+
+const (
+	bitriseSteplibURL    = "https://github.com/bitrise-io/bitrise-steplib.git"
+	bitriseSteplibAPIURL = "https://steplib.bitrise.io" // Base URL of steplib API
+	enableSteplibAPIEnv  = "BITRISE_STEPLIB_API_ENABLE"
 )
 
 func ActivateSteplibRefStep(
@@ -26,16 +33,26 @@ func ActivateSteplibRefStep(
 		DidStepLibUpdate: false,
 	}
 
-	stepInfo, didUpdate, err := prepareStepLibForActivation(log, id, didStepLibUpdateInWorkflow, isOfflineMode)
-	activationResult.DidStepLibUpdate = didUpdate
-	activationResult.StepInfo = stepInfo
-	if err != nil {
-		return activationResult, err
+	var libraryAPI *steplibrary.Client
+	if shouldUseSteplibAPI(id.SteplibSource) {
+		libraryAPI = steplibrary.New(log, bitriseSteplibAPIURL)
 	}
 
-	execPath, err := steplib.ActivateStep(id.SteplibSource, id.IDorURI, stepInfo.Version, activatedStepDir, stepYMLPath, log, isOfflineMode)
-	activationResult.ExecutablePath = execPath
-	if execPath != "" {
+	if libraryAPI == nil {
+		// Old stepman preparation codepath
+		stepInfo, didUpdate, err := prepareStepLibForActivation(log, id, didStepLibUpdateInWorkflow, isOfflineMode)
+		activationResult.StepInfo = stepInfo
+		activationResult.DidStepLibUpdate = didUpdate
+		if err != nil {
+			return activationResult, err
+		}
+	}
+
+	// ActivateStep dispatches to the v2 or legacy codepath.
+	resolvedStep, err := steplib.ActivateStep(id, activatedStepDir, stepYMLPath, log, isOfflineMode, libraryAPI)
+	activationResult.StepInfo = resolvedStep.StepInfo
+	activationResult.ExecutablePath = resolvedStep.ExecPath
+	if resolvedStep.ExecPath != "" {
 		activationResult.ActivationType = ActivationTypeSteplibExecutable
 	} else {
 		activationResult.ActivationType = ActivationTypeSteplibSource
@@ -45,6 +62,11 @@ func ActivateSteplibRefStep(
 	}
 
 	return activationResult, nil
+}
+
+func shouldUseSteplibAPI(steplibURI string) bool {
+	enableAPI := os.Getenv(enableSteplibAPIEnv) == "true" || os.Getenv(enableSteplibAPIEnv) == "1"
+	return enableAPI && steplibURI == bitriseSteplibURL
 }
 
 func prepareStepLibForActivation(
@@ -95,11 +117,6 @@ func prepareStepLibForActivation(
 			return stepInfo, didUpdate, err
 		}
 	}
-
-	if stepInfo.Step.Title == nil || *stepInfo.Step.Title == "" {
-		stepInfo.Step.Title = pointers.NewStringPtr(stepInfo.ID)
-	}
-	stepInfo.OriginalVersion = id.Version
 
 	return stepInfo, didUpdate, nil
 }

--- a/vendor/github.com/bitrise-io/stepman/cli/step_info.go
+++ b/vendor/github.com/bitrise-io/stepman/cli/step_info.go
@@ -98,6 +98,10 @@ func stepInfo(c *cli.Context) error {
 		return err
 	}
 
+	// OriginalVersion is an activation-time concept (the requested version
+	// constraint); step-info doesn't report it, so keep it out of the output.
+	stepInfo.OriginalVersion = ""
+
 	logger.Print(stepInfo)
 	return nil
 }

--- a/vendor/github.com/bitrise-io/stepman/internal/httpfetch/httpfetch.go
+++ b/vendor/github.com/bitrise-io/stepman/internal/httpfetch/httpfetch.go
@@ -1,0 +1,182 @@
+// Package httpfetch is a minimal HTTP client wrapper that exposes a streaming
+// Get plus an atomic Download (temp file in dest dir + rename). It's the
+// shared transport for stepman's V2 inventory fetches and precompiled
+// binary downloads.
+package httpfetch
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+
+	"github.com/hashicorp/go-retryablehttp"
+)
+
+// Client streams or atomically downloads HTTP resources. Implementations
+// returned by NewClient retry transient failures on both Get and Download.
+type Client interface {
+	// Get streams the body of url. The caller closes the returned reader.
+	// Non-2xx responses are returned as an error.
+	Get(ctx context.Context, url string) (io.ReadCloser, error)
+	// Download fetches url and atomically writes it to destPath. Missing
+	// parent directories are created. A temp file is created alongside
+	// destPath and renamed on success so partial downloads never appear at
+	// the final path.
+	Download(ctx context.Context, destPath, url string) error
+	// DownloadWithHash behaves like Download but also verifies that the
+	// downloaded content matches expectedHash ("sha256-<hex>"). The temp file
+	// is removed and an error is returned if the hash does not match, so a
+	// mismatched file never appears at destPath.
+	DownloadWithHash(ctx context.Context, destPath, url, expectedHash string) error
+}
+
+// Logger is the minimal logging interface Client needs; the retry adapter only
+// emits debug lines.
+type Logger interface {
+	Debugf(format string, v ...any)
+}
+
+// retryhttpLogger adapts Logger to the retryablehttp.Logger interface (Printf only).
+type retryhttpLogger struct{ l Logger }
+
+func (r *retryhttpLogger) Printf(f string, v ...any) { r.l.Debugf(f, v...) }
+
+type client struct {
+	httpClient *http.Client
+}
+
+// NewClient returns a Client backed by a retryablehttp client, so callers get
+// transient-failure retries by default. Use NewWithClient to supply a specific
+// *http.Client (e.g. a test server's client).
+func NewClient(logger Logger) Client {
+	rc := retryablehttp.NewClient()
+	rc.Logger = &retryhttpLogger{l: logger}
+	rc.ErrorHandler = retryablehttp.PassthroughErrorHandler
+	return &client{httpClient: rc.StandardClient()}
+}
+
+// NewWithClient returns a Client backed by the given httpClient, which must be
+// non-nil. Prefer NewClient unless you need a specific transport.
+func NewWithClient(httpClient *http.Client) Client {
+	return &client{httpClient: httpClient}
+}
+
+func (c *client) Get(ctx context.Context, url string) (io.ReadCloser, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build request for %s: %w", url, err)
+	}
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("GET %s: %w", url, err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		snippet, readErr := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		return nil, errors.Join(
+			&StatusError{URL: url, Code: resp.StatusCode, Body: string(bytes.TrimSpace(snippet))},
+			readErr,
+			resp.Body.Close(),
+		)
+	}
+	return resp.Body, nil
+}
+
+// StatusError is returned by Get when the server responds with a non-2xx
+// status, so callers can branch on the code (e.g. treat 404 as "not found")
+// via errors.As. Body holds a bounded snippet of the response body, which
+// usually explains the failure (a 404 page, S3's XML error, …).
+type StatusError struct {
+	URL  string
+	Code int
+	Body string
+}
+
+func (e *StatusError) Error() string {
+	return fmt.Sprintf("GET %s: unexpected status %d: %s", e.URL, e.Code, e.Body)
+}
+
+func (c *client) Download(ctx context.Context, destPath, url string) error {
+	return c.download(ctx, destPath, url, "")
+}
+
+func (c *client) DownloadWithHash(ctx context.Context, destPath, url, expectedHash string) error {
+	if expectedHash == "" {
+		return fmt.Errorf("hash is empty")
+	}
+	return c.download(ctx, destPath, url, expectedHash)
+}
+
+// download fetches url into a temp file alongside destPath and atomically
+// renames it into place. When expectedHash is non-empty the content is verified
+// against it ("sha256-<hex>") before the rename, so a mismatched or partial
+// file never lands at destPath.
+func (c *client) download(ctx context.Context, destPath, url, expectedHash string) error {
+	if err := os.MkdirAll(filepath.Dir(destPath), 0o755); err != nil {
+		return fmt.Errorf("create dest dir for %s: %w", destPath, err)
+	}
+
+	tmpPath, hash, err := c.fetchToTemp(ctx, filepath.Dir(destPath), url)
+	if err != nil {
+		return err
+	}
+	// Best-effort cleanup: on a verify/rename failure this removes the temp
+	// file; after a successful rename tmpPath is gone, so Remove fails harmlessly.
+	defer func() { _ = os.Remove(tmpPath) }()
+
+	if expectedHash != "" && hash != expectedHash {
+		return fmt.Errorf("hash mismatch (%s) expected %s, got %s", url, expectedHash, hash)
+	}
+	if err := os.Rename(tmpPath, destPath); err != nil {
+		return fmt.Errorf("rename %s to %s: %w", tmpPath, destPath, err)
+	}
+	return nil
+}
+
+// fetchToTemp streams url into a new temp file under dir and returns its path
+// and sha256 hash ("sha256-<hex>"). On error the temp file is removed and
+// path/hash are empty; on success the caller owns cleanup.
+func (c *client) fetchToTemp(ctx context.Context, dir, url string) (path string, hash string, err error) {
+	// Place the temp file alongside destPath so the final rename stays on
+	// one filesystem (cross-filesystem renames fail on most kernels).
+	tmp, err := os.CreateTemp(dir, "download-*.tmp")
+	if err != nil {
+		return "", "", fmt.Errorf("create temp file in %s: %w", dir, err)
+	}
+	defer func() {
+		// A failed Close is intentionally a hard failure: it can mean the final
+		// write never flushed to disk, so the temp file may be incomplete.
+		if closeErr := tmp.Close(); closeErr != nil {
+			err = errors.Join(err, fmt.Errorf("close %s: %w", tmp.Name(), closeErr))
+		}
+		if err != nil {
+			// Best-effort cleanup of the partial temp file; the original error is
+			// what matters, so a failed remove is intentionally ignored.
+			_ = os.Remove(tmp.Name())
+			path = ""
+			hash = ""
+		}
+	}()
+
+	body, err := c.Get(ctx, url)
+	if err != nil {
+		return "", "", err
+	}
+	defer func() {
+		if closeErr := body.Close(); closeErr != nil {
+			err = errors.Join(err, fmt.Errorf("close response body: %w", closeErr))
+		}
+	}()
+
+	h := sha256.New()
+	if _, copyErr := io.Copy(io.MultiWriter(tmp, h), body); copyErr != nil {
+		return "", "", fmt.Errorf("write to %s: %w", tmp.Name(), copyErr)
+	}
+	return tmp.Name(), "sha256-" + hex.EncodeToString(h.Sum(nil)), nil
+}

--- a/vendor/github.com/bitrise-io/stepman/models/models_methods.go
+++ b/vendor/github.com/bitrise-io/stepman/models/models_methods.go
@@ -317,28 +317,31 @@ func (collection StepCollectionModel) GetDownloadLocations(id, version string) (
 		return []DownloadLocationModel{}, errors.New("missing Source property")
 	}
 
-	locations := []DownloadLocationModel{}
-	for _, downloadLocation := range collection.DownloadLocations {
-		switch downloadLocation.Type {
-		case "zip":
-			url := downloadLocation.Src + id + "/" + version + "/step.zip"
-			location := DownloadLocationModel{
-				Type: downloadLocation.Type,
-				Src:  url,
-			}
-			locations = append(locations, location)
-		case "git":
-			location := DownloadLocationModel{
-				Type: downloadLocation.Type,
-				Src:  step.Source.Git,
-			}
-			locations = append(locations, location)
-		default:
-			return []DownloadLocationModel{}, fmt.Errorf("invalid download location (%#v) for step (%#v)", downloadLocation, id)
-		}
+	locations, err := BuildStepSourceDownloadLocations(collection.DownloadLocations, id, version, step.Source.Git)
+	if err != nil {
+		return []DownloadLocationModel{}, err
 	}
 	if len(locations) < 1 {
 		return []DownloadLocationModel{}, fmt.Errorf("no download location found for step (%#v)", id)
+	}
+	return locations, nil
+}
+
+// BuildStepSourceDownloadLocations resolves a priority order of source download locations for
+// an exact step version.
+func BuildStepSourceDownloadLocations(baseLocations []DownloadLocationModel, id, version, repoURL string) ([]DownloadLocationModel, error) {
+	locations := []DownloadLocationModel{}
+	for _, base := range baseLocations {
+		switch base.Type {
+		case "zip":
+			locations = append(locations, DownloadLocationModel{Type: "zip", Src: base.Src + id + "/" + version + "/step.zip"})
+		case "git":
+			if repoURL != "" {
+				locations = append(locations, DownloadLocationModel{Type: "git", Src: repoURL})
+			}
+		default:
+			return nil, fmt.Errorf("invalid download location type %q for step %s", base.Type, id)
+		}
 	}
 	return locations, nil
 }

--- a/vendor/github.com/bitrise-io/stepman/models/version_constraint.go
+++ b/vendor/github.com/bitrise-io/stepman/models/version_constraint.go
@@ -194,6 +194,7 @@ func latestMatchingStepVersion(constraint VersionConstraint, stepVersions StepGr
 				Patch: 0,
 			}
 			latestStep := StepModel{}
+			versionFound := false
 
 			for fullVersion, step := range stepVersions.Versions {
 				stepVersion, err := ParseSemver(fullVersion)
@@ -205,10 +206,15 @@ func latestMatchingStepVersion(constraint VersionConstraint, stepVersions StepGr
 					continue
 				}
 
-				if stepVersion.Patch > latestVersion.Patch {
+				if !versionFound || stepVersion.Patch > latestVersion.Patch {
 					latestVersion = stepVersion
 					latestStep = step
+					versionFound = true
 				}
+			}
+
+			if !versionFound {
+				return StepVersionModel{}, false
 			}
 
 			return StepVersionModel{
@@ -225,6 +231,7 @@ func latestMatchingStepVersion(constraint VersionConstraint, stepVersions StepGr
 				Patch: 0,
 			}
 			latestStep := StepModel{}
+			versionFound := false
 
 			for fullVersion, step := range stepVersions.Versions {
 				stepVersion, err := ParseSemver(fullVersion)
@@ -235,11 +242,17 @@ func latestMatchingStepVersion(constraint VersionConstraint, stepVersions StepGr
 					continue
 				}
 
-				if stepVersion.Minor > latestStepVersion.Minor ||
+				if !versionFound ||
+					stepVersion.Minor > latestStepVersion.Minor ||
 					(stepVersion.Minor == latestStepVersion.Minor && stepVersion.Patch > latestStepVersion.Patch) {
 					latestStepVersion = stepVersion
 					latestStep = step
+					versionFound = true
 				}
+			}
+
+			if !versionFound {
+				return StepVersionModel{}, false
 			}
 
 			return StepVersionModel{

--- a/vendor/github.com/bitrise-io/stepman/steplibrary/api.go
+++ b/vendor/github.com/bitrise-io/stepman/steplibrary/api.go
@@ -1,0 +1,30 @@
+package steplibrary
+
+import (
+	"context"
+
+	"github.com/bitrise-io/stepman/models"
+	"github.com/bitrise-io/stepman/steplibrary/steplibindex"
+)
+
+type ResolvedStepVersion struct {
+	ID, Version string
+}
+
+type API interface {
+	GetAllStepIDs(ctx context.Context) ([]string, error)
+	GetLatestStepVersions(ctx context.Context, id string) (steplibindex.LatestPointer, error)
+	// GetAllStepVersions returns all available versions of a step.
+	// Mirrors `index/steps/<id>/versions.json` from the V2 inventory layout.
+	GetAllStepVersions(ctx context.Context, id string) ([]string, error)
+	// GetStepGroupInfo returns version-independent step metadata
+	// (maintainer, deprecation, asset URLs). Mirrors `steps/<id>/step-info.json`.
+	GetStepGroupInfo(ctx context.Context, id string) (steplibindex.StepInfo, error)
+	// GetStepModel fetches the V2 per-version step manifest (mirrors
+	// `steps/<id>/<version>/step.json`, which serializes models.StepModel).
+	GetStepModel(ctx context.Context, step ResolvedStepVersion) (models.StepModel, error)
+	// GetStepSourceDownloadLocations returns the inventory-wide base download locations
+	// (mirrors meta.json's download_locations): a zip base and a git marker,
+	// from which per-step source URLs are built.
+	GetStepSourceDownloadLocations(ctx context.Context) ([]models.DownloadLocationModel, error)
+}

--- a/vendor/github.com/bitrise-io/stepman/steplibrary/http_api.go
+++ b/vendor/github.com/bitrise-io/stepman/steplibrary/http_api.go
@@ -1,0 +1,106 @@
+package steplibrary
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/bitrise-io/stepman/internal/httpfetch"
+	"github.com/bitrise-io/stepman/models"
+	"github.com/bitrise-io/stepman/steplibrary/steplibindex"
+)
+
+// HTTPAPI fetches the V2 inventory (step_ids/latest/versions/step-info/step.json)
+// over HTTP from a base URL.
+type HTTPAPI struct {
+	BaseURL string
+	Fetcher httpfetch.Client
+}
+
+func NewHTTPAPI(baseURL string, fetcher httpfetch.Client) *HTTPAPI {
+	return &HTTPAPI{
+		BaseURL: strings.TrimRight(baseURL, "/"),
+		Fetcher: fetcher,
+	}
+}
+
+func (h *HTTPAPI) GetAllStepIDs(ctx context.Context) ([]string, error) {
+	var out steplibindex.StepIDs
+	if err := h.fetchJSON(ctx, steplibindex.StepIDsPath().URL(), &out); err != nil {
+		return nil, err
+	}
+	return out.StepIDs, nil
+}
+
+func (h *HTTPAPI) GetLatestStepVersions(ctx context.Context, id string) (steplibindex.LatestPointer, error) {
+	p, err := steplibindex.LatestPointerPath(id)
+	if err != nil {
+		return steplibindex.LatestPointer{}, err
+	}
+	var out steplibindex.LatestPointer
+	if err := h.fetchJSON(ctx, p.URL(), &out); err != nil {
+		return steplibindex.LatestPointer{}, err
+	}
+	return out, nil
+}
+
+func (h *HTTPAPI) GetAllStepVersions(ctx context.Context, id string) ([]string, error) {
+	p, err := steplibindex.VersionsPath(id)
+	if err != nil {
+		return nil, err
+	}
+	var out steplibindex.Versions
+	if err := h.fetchJSON(ctx, p.URL(), &out); err != nil {
+		return nil, err
+	}
+	return out.Versions, nil
+}
+
+func (h *HTTPAPI) GetStepGroupInfo(ctx context.Context, id string) (steplibindex.StepInfo, error) {
+	p, err := steplibindex.StepInfoPath(id)
+	if err != nil {
+		return steplibindex.StepInfo{}, err
+	}
+	var out steplibindex.StepInfo
+	if err := h.fetchJSON(ctx, p.URL(), &out); err != nil {
+		return steplibindex.StepInfo{}, err
+	}
+	return out, nil
+}
+
+func (h *HTTPAPI) GetStepModel(ctx context.Context, step ResolvedStepVersion) (models.StepModel, error) {
+	p, err := steplibindex.StepJSONPath(step.ID, step.Version)
+	if err != nil {
+		return models.StepModel{}, err
+	}
+	var out models.StepModel
+	if err := h.fetchJSON(ctx, p.URL(), &out); err != nil {
+		return models.StepModel{}, err
+	}
+	return out, nil
+}
+
+func (h *HTTPAPI) GetStepSourceDownloadLocations(ctx context.Context) ([]models.DownloadLocationModel, error) {
+	var out steplibindex.Meta
+	if err := h.fetchJSON(ctx, steplibindex.MetaPath().URL(), &out); err != nil {
+		return nil, err
+	}
+	return out.DownloadLocations, nil
+}
+
+func (h *HTTPAPI) fetchJSON(ctx context.Context, path string, dst any) (err error) {
+	body, err := h.Fetcher.Get(ctx, h.BaseURL+path)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if cerr := body.Close(); cerr != nil && err == nil {
+			err = fmt.Errorf("close response body for %s%s: %w", h.BaseURL, path, cerr)
+		}
+	}()
+	if derr := json.NewDecoder(body).Decode(dst); derr != nil {
+		return fmt.Errorf("decode %s%s: %w", h.BaseURL, path, derr)
+	}
+	return nil
+}

--- a/vendor/github.com/bitrise-io/stepman/steplibrary/resolve_version.go
+++ b/vendor/github.com/bitrise-io/stepman/steplibrary/resolve_version.go
@@ -1,0 +1,145 @@
+package steplibrary
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path"
+	"slices"
+	"strconv"
+
+	"github.com/bitrise-io/stepman/models"
+	"github.com/bitrise-io/stepman/steplibrary/steplibindex"
+)
+
+func (c *Client) getStepVersionInfo(ctx context.Context, stepID, version string) (models.StepInfoModel, ResolvedStepVersion, error) {
+	if stepID == "" {
+		return models.StepInfoModel{}, ResolvedStepVersion{}, errors.New("missing required input: step id")
+	}
+
+	versionConstraint, err := models.ParseRequiredVersion(version)
+	if err != nil {
+		return models.StepInfoModel{}, ResolvedStepVersion{}, fmt.Errorf("invalid step version constraint: %w", err)
+	}
+	if versionConstraint.VersionLockType == models.InvalidVersionConstraint {
+		return models.StepInfoModel{}, ResolvedStepVersion{}, fmt.Errorf("invalid step version constraint: %s", version)
+	}
+
+	allSteps, err := c.api.GetAllStepIDs(ctx)
+	if err != nil {
+		return models.StepInfoModel{}, ResolvedStepVersion{}, fmt.Errorf("fetching available step IDs: %w", err)
+	}
+	if !slices.Contains(allSteps, stepID) {
+		return models.StepInfoModel{}, ResolvedStepVersion{}, fmt.Errorf("%s steplib does not contain %s step", c.inventoryURL, stepID)
+	}
+
+	latestVersions, err := c.api.GetLatestStepVersions(ctx, stepID)
+	if err != nil {
+		return models.StepInfoModel{}, ResolvedStepVersion{}, fmt.Errorf("fetching latest versions of `%s`: %w", stepID, err)
+	}
+
+	groupInfo, err := c.api.GetStepGroupInfo(ctx, stepID)
+	if err != nil {
+		return models.StepInfoModel{}, ResolvedStepVersion{}, fmt.Errorf("fetching group info of `%s`: %w", stepID, err)
+	}
+
+	resolvedVersion, err := c.resolveVersion(ctx, stepID, version, versionConstraint, latestVersions)
+	if err != nil {
+		return models.StepInfoModel{}, ResolvedStepVersion{}, err
+	}
+
+	//nolint:exhaustruct // Step and DefinitionPth aren't surfaced by the v2 API yet
+	return models.StepInfoModel{
+		Library:         c.inventoryURL,
+		ID:              stepID,
+		Version:         resolvedVersion,
+		OriginalVersion: version,
+		LatestVersion:   latestVersions.Latest,
+		GroupInfo:       toStepGroupInfoModel(groupInfo),
+	}, ResolvedStepVersion{ID: stepID, Version: resolvedVersion}, nil
+}
+
+// resolveVersion turns a parsed version constraint into a concrete version
+// string, fetching the step's version list when the constraint needs it.
+func (c *Client) resolveVersion(ctx context.Context, stepID, version string, constraint models.VersionConstraint, latestVersions steplibindex.LatestPointer) (string, error) {
+	switch constraint.VersionLockType {
+	case models.Latest:
+		return latestVersions.Latest, nil
+	case models.Fixed:
+		resolved := constraint.Version.String()
+		// Verify the pin exists now, so a typo fails clearly instead of as an
+		// opaque fetch error later.
+		allVersions, err := c.api.GetAllStepVersions(ctx, stepID)
+		if err != nil {
+			return "", fmt.Errorf("fetching all versions of `%s`: %w", stepID, err)
+		}
+		if !slices.Contains(allVersions, resolved) {
+			return "", fmt.Errorf("%s steplib does not contain %s step %s version", c.inventoryURL, stepID, resolved)
+		}
+		return resolved, nil
+	case models.MajorLocked:
+		majorKey := strconv.FormatUint(constraint.Version.Major, 10)
+		v, ok := latestVersions.LatestByMajor[majorKey]
+		if !ok {
+			return "", fmt.Errorf("%s steplib does not contain %s step with major version %s", c.inventoryURL, stepID, majorKey)
+		}
+		return v, nil
+	case models.MinorLocked:
+		allVersions, err := c.api.GetAllStepVersions(ctx, stepID)
+		if err != nil {
+			return "", fmt.Errorf("fetching all versions of `%s`: %w", stepID, err)
+		}
+		resolved, err := resolveMinorLocked(allVersions, constraint.Version)
+		if err != nil {
+			return "", fmt.Errorf("%s steplib: %w", c.inventoryURL, err)
+		}
+		return resolved, nil
+	default:
+		return "", fmt.Errorf("unknown version constraint: %s", version)
+	}
+}
+
+// toStepGroupInfoModel flattens v2's nested `deprecation` object into v1's flat
+// RemovalDate + DeprecateNotes fields.
+func toStepGroupInfoModel(info steplibindex.StepInfo) models.StepGroupInfoModel {
+	// v2 asset_urls is a []string of step-relative URLs; v1 keys them by filename
+	// (e.g. "assets/icon.svg" -> {"icon.svg": ...}).
+	var assetURLs map[string]string
+	if len(info.AssetURLs) > 0 {
+		assetURLs = make(map[string]string, len(info.AssetURLs))
+		for _, u := range info.AssetURLs {
+			assetURLs[path.Base(u)] = u
+		}
+	}
+	out := models.StepGroupInfoModel{
+		Maintainer:     info.Maintainer,
+		AssetURLs:      assetURLs,
+		RemovalDate:    "",
+		DeprecateNotes: "",
+	}
+	if info.Deprecation != nil {
+		out.RemovalDate = info.Deprecation.RemovalDate
+		out.DeprecateNotes = info.Deprecation.Notes
+	}
+	return out
+}
+
+// resolveMinorLocked picks the highest patch within `versions` matching the
+// constraint's Major+Minor. An unparseable entry is an error — versions.json is
+// expected to hold only valid semver.
+func resolveMinorLocked(versions []string, constraint models.Semver) (string, error) {
+	parsed := make([]models.Semver, 0, len(versions))
+	for _, raw := range versions {
+		sv, err := models.ParseSemver(raw)
+		if err != nil {
+			return "", fmt.Errorf("parse version %q: %w", raw, err)
+		}
+		parsed = append(parsed, sv)
+	}
+
+	best, ok := models.HighestForMajorMinor(parsed, constraint)
+	if !ok {
+		return "", fmt.Errorf("no version matches %d.%d.x", constraint.Major, constraint.Minor)
+	}
+	return best.String(), nil
+}

--- a/vendor/github.com/bitrise-io/stepman/steplibrary/steplibindex/paths.go
+++ b/vendor/github.com/bitrise-io/stepman/steplibrary/steplibindex/paths.go
@@ -1,0 +1,157 @@
+package steplibindex
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"path"
+	"strings"
+)
+
+// Paths to every file in the V2 inventory tree. There must be exactly one
+// source of truth for the layout so the generator, the HTTP reader, and the
+// validator never drift.
+//
+// Each file is one constructor returning a Path, which carries both addressing
+// modes so they can't drift from each other:
+//
+//   - FS():  the inventory-relative path as a forward-slash string — the form
+//     io/fs requires (os.DirFS, fs.ReadFile, fs.WalkDir, …). It is slash-
+//     separated on every OS, so it is built with path.Join, never
+//     filepath.Join; ids and versions are left raw (unescaped).
+//   - URL(): absolute (leading slash), with url.PathEscape applied to the
+//     dynamic id/version segments — for the HTTP reader.
+//
+// Dynamic segments (step id, version, asset file) are validated as safe single
+// path components: a constructor returns an error if a segment is empty, a
+// "."/".." traversal element, or contains a path separator or NUL. This is a
+// security boundary — the segment is interpolated into filesystem and URL paths,
+// so an unchecked separator or ".." could read or write outside the step's
+// subtree. Directories (StepDirFS, IndexStepDirFS, StepAssetDirFS) are FS-only:
+// they are path bases / walk roots, never fetched by URL.
+
+// Top-level directories inside the inventory tree. The "steps" segment under
+// index/ is the per-step index namespace — distinct from this top-level
+// source-of-truth steps/ tree — so it is written inline, not via StepsRootFS.
+const (
+	StepsRootFS = "steps"
+	IndexRootFS = "index"
+)
+
+// Path is a single file in the V2 inventory tree, addressable as a filesystem
+// path (FS) or an HTTP URL path (URL). Both forms are built together so they
+// cannot drift.
+type Path struct {
+	fs  string
+	url string
+}
+
+// FS returns the slash-separated path relative to the inventory root.
+func (p Path) FS() string { return p.fs }
+
+// URL returns the absolute, percent-escaped URL path.
+func (p Path) URL() string { return p.url }
+
+// seg is one path segment. Dynamic segments (step id, version, asset file) are
+// validated and percent-escaped in the URL form; static ones are taken verbatim.
+type seg struct {
+	v   string
+	dyn bool
+}
+
+func lit(v string) seg { return seg{v: v, dyn: false} }
+func dyn(v string) seg { return seg{v: v, dyn: true} }
+
+// validateSegment rejects a dynamic segment that is not a safe single path
+// component, so it can never escape or restructure the path it is spliced into.
+func validateSegment(s string) error {
+	switch {
+	case s == "":
+		return errors.New("path segment is empty")
+	case s == "." || s == "..":
+		return fmt.Errorf("path segment %q is a directory-traversal element", s)
+	case strings.ContainsAny(s, `/\`):
+		return fmt.Errorf("path segment %q contains a path separator", s)
+	case strings.ContainsRune(s, 0):
+		return fmt.Errorf("path segment %q contains a NUL byte", s)
+	}
+	return nil
+}
+
+// build assembles a Path from segments under the version dir (e.g. v2/),
+// validating every dynamic segment. It is the single place each layout is
+// spelled out, so the FS and URL forms are always derived from the same list.
+func build(segs ...seg) (Path, error) {
+	fsParts := []string{VersionDir()}
+	urlParts := []string{VersionDir()}
+	for _, s := range segs {
+		if s.dyn {
+			if err := validateSegment(s.v); err != nil {
+				return Path{}, err
+			}
+			urlParts = append(urlParts, url.PathEscape(s.v))
+		} else {
+			urlParts = append(urlParts, s.v)
+		}
+		fsParts = append(fsParts, s.v)
+	}
+	return Path{fs: path.Join(fsParts...), url: "/" + path.Join(urlParts...)}, nil
+}
+
+// staticPath builds a Path from static segments only; with no dynamic input
+// there is nothing to validate, so it cannot fail.
+func staticPath(segs ...string) Path {
+	joined := path.Join(append([]string{VersionDir()}, segs...)...)
+	return Path{fs: joined, url: "/" + joined}
+}
+
+// MetaPath is v2/meta.json.
+func MetaPath() Path { return staticPath("meta.json") }
+
+// StepIDsPath is v2/index/step_ids.json.
+func StepIDsPath() Path { return staticPath(IndexRootFS, "step_ids.json") }
+
+// LatestPointerPath is v2/index/steps/<id>/latest.json.
+func LatestPointerPath(stepID string) (Path, error) {
+	return build(lit(IndexRootFS), lit("steps"), dyn(stepID), lit("latest.json"))
+}
+
+// VersionsPath is v2/index/steps/<id>/versions.json.
+func VersionsPath(stepID string) (Path, error) {
+	return build(lit(IndexRootFS), lit("steps"), dyn(stepID), lit("versions.json"))
+}
+
+// StepInfoPath is v2/steps/<id>/step-info.json.
+func StepInfoPath(stepID string) (Path, error) {
+	return build(lit(StepsRootFS), dyn(stepID), lit("step-info.json"))
+}
+
+// StepJSONPath is v2/steps/<id>/<version>/step.json.
+func StepJSONPath(stepID, version string) (Path, error) {
+	return build(lit(StepsRootFS), dyn(stepID), dyn(version), lit("step.json"))
+}
+
+// StepAssetPath is v2/steps/<id>/assets/<file>.
+func StepAssetPath(stepID, file string) (Path, error) {
+	return build(lit(StepsRootFS), dyn(stepID), lit("assets"), dyn(file))
+}
+
+// StepDirFS is the v2/steps/<id>/ directory (the per-step source subtree:
+// step-info.json, assets/, and per-version dirs).
+func StepDirFS(stepID string) (string, error) {
+	p, err := build(lit(StepsRootFS), dyn(stepID))
+	return p.FS(), err
+}
+
+// IndexStepDirFS is the v2/index/steps/<id>/ directory (the per-step subtree of
+// derived index files).
+func IndexStepDirFS(stepID string) (string, error) {
+	p, err := build(lit(IndexRootFS), lit("steps"), dyn(stepID))
+	return p.FS(), err
+}
+
+// StepAssetDirFS is the v2/steps/<id>/assets directory.
+func StepAssetDirFS(stepID string) (string, error) {
+	p, err := build(lit(StepsRootFS), dyn(stepID), lit("assets"))
+	return p.FS(), err
+}

--- a/vendor/github.com/bitrise-io/stepman/steplibrary/steplibindex/steplibindex.go
+++ b/vendor/github.com/bitrise-io/stepman/steplibrary/steplibindex/steplibindex.go
@@ -1,0 +1,84 @@
+// Package steplibindex defines the Go types for the V2 step library inventory wire
+// format. It is shared between the generator (steplibrary/indexgen) and the
+// read path (steplibrary).
+//
+// The V2 layout splits the inventory into two URL prefixes (both nested under
+// the format-version dir, e.g. v2/):
+//   - steps/  — source of truth, self-contained per step, immutable per version
+//   - index/  — derived index files, regeneratable from steps/, short-TTL
+//
+// All files are JSON. Per-version step manifests (steps/<id>/<v>/step.json)
+// use models.StepModel directly; the types below describe the new
+// inventory-level and index files that have no V1 equivalent.
+//
+// Wire shape is kept stable: index and per-step collections always render as
+// [] or {} (never null) and nullable values (Deprecation, published_at) as
+// null. Optional inventory metadata (Meta.steplib_commit_sha,
+// Meta.steplib_source, Meta.download_locations) uses omitempty and is dropped
+// when empty.
+package steplibindex
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/bitrise-io/stepman/models"
+)
+
+// FormatVersion is the on-disk schema version recorded in Meta. Bump only on
+// breaking changes; additive changes (new optional fields) do not bump.
+const FormatVersion = 2
+
+// VersionDir is the inventory's top-level directory for this format version
+// (e.g. "v2"). The whole tree is rooted under it so multiple format versions
+// can be hosted side by side; readers prefix their fetch URLs with it.
+func VersionDir() string { return fmt.Sprintf("v%d", FormatVersion) }
+
+// Meta is the inventory-level metadata file at the inventory root (meta.json).
+// It is the only file that carries FormatVersion.
+type Meta struct {
+	FormatVersion     int                            `json:"format_version"`
+	UpdatedAt         time.Time                      `json:"updated_at"`
+	SteplibCommitSHA  string                         `json:"steplib_commit_sha,omitempty"`
+	SteplibSource     string                         `json:"steplib_source,omitempty"`
+	DownloadLocations []models.DownloadLocationModel `json:"download_locations,omitempty"`
+}
+
+// StepInfo is the per-step metadata file at steps/<id>/step-info.json.
+// Holds facts that span versions: maintainer, deprecation, asset list.
+// Asset URLs are relative to the file's own location for self-containment.
+// Deprecation is null for active steps; AssetURLs is [] for steps with no assets.
+type StepInfo struct {
+	Maintainer  string       `json:"maintainer"`
+	Deprecation *Deprecation `json:"deprecation"`
+	AssetURLs   []string     `json:"asset_urls"`
+}
+
+// Deprecation carries the removal_date and notes for a deprecated step.
+// A nil Deprecation on StepInfo means the step is active.
+type Deprecation struct {
+	RemovalDate string `json:"removal_date"`
+	Notes       string `json:"notes"`
+}
+
+// StepIDs is index/step_ids.json: sorted list of all step IDs in the steplib.
+type StepIDs struct {
+	StepIDs []string `json:"step_ids"`
+}
+
+// LatestPointer is index/steps/<id>/latest.json: per-step latest pointers.
+// Answers Latest and MajorLocked constraints in a single small fetch.
+type LatestPointer struct {
+	StepID        string            `json:"step_id"`
+	Latest        string            `json:"latest"`
+	LatestByMajor map[string]string `json:"latest_by_major"`
+}
+
+// Versions is index/steps/<id>/versions.json: the per-step list of version
+// strings, newest-first (so versions[0] is the latest). Per-version detail
+// (commit, published_at, ...) lives in each steps/<id>/<version>/step.json; the
+// latest pointer lives in latest.json.
+type Versions struct {
+	StepID   string   `json:"step_id"`
+	Versions []string `json:"versions"`
+}

--- a/vendor/github.com/bitrise-io/stepman/steplibrary/steplibrary.go
+++ b/vendor/github.com/bitrise-io/stepman/steplibrary/steplibrary.go
@@ -1,0 +1,51 @@
+package steplibrary
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/bitrise-io/stepman/internal/httpfetch"
+	"github.com/bitrise-io/stepman/models"
+	"github.com/bitrise-io/stepman/stepid"
+	"github.com/bitrise-io/stepman/stepman"
+)
+
+type Client struct {
+	log          stepman.Logger
+	inventoryURL string
+	api          API
+}
+
+// New builds a stepman.Client.
+// inventoryURL: the base URL of the API where metadata is fetched from.
+func New(log stepman.Logger, inventoryURL string) *Client {
+	return &Client{
+		log:          log,
+		inventoryURL: inventoryURL,
+		api:          NewHTTPAPI(inventoryURL, httpfetch.NewClient(log)),
+	}
+}
+
+func (c *Client) FetchStepMetadata(ctx context.Context, stepRef stepid.CanonicalID) (models.StepInfoModel, error) {
+	stepInfo, resolved, err := c.getStepVersionInfo(ctx, stepRef.IDorURI, stepRef.Version)
+	if err != nil {
+		return models.StepInfoModel{}, fmt.Errorf("resolve step version: %w", err)
+	}
+
+	stepModel, err := c.api.GetStepModel(ctx, resolved)
+	if err != nil {
+		return models.StepInfoModel{}, fmt.Errorf("fetch step definition: %w", err)
+	}
+	stepInfo.Step = stepModel
+
+	return stepInfo, nil
+}
+
+// StepSourceDownloadLocations returns a priority order of step source zip download locations
+func (c *Client) StepSourceDownloadLocations(ctx context.Context, id, version, sourceGit string) ([]models.DownloadLocationModel, error) {
+	bases, err := c.api.GetStepSourceDownloadLocations(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("fetch download locations: %w", err)
+	}
+	return models.BuildStepSourceDownloadLocations(bases, id, version, sourceGit)
+}

--- a/vendor/github.com/bitrise-io/stepman/stepman/step_info.go
+++ b/vendor/github.com/bitrise-io/stepman/stepman/step_info.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/bitrise-io/go-utils/command/git"
 	"github.com/bitrise-io/go-utils/pathutil"
+	"github.com/bitrise-io/go-utils/pointers"
 	"github.com/bitrise-io/go-utils/retry"
 	"github.com/bitrise-io/stepman/models"
 )
@@ -119,14 +120,25 @@ func QueryStepInfoFromLibrary(library, id, version string, log Logger) (models.S
 		return models.StepInfoModel{}, err
 	}
 
-	return models.StepInfoModel{
+	stepInfo := models.StepInfoModel{
 		Library:         library,
 		ID:              id,
 		Version:         stepVersion.Version,
-		OriginalVersion: "",
+		OriginalVersion: version,
 		LatestVersion:   stepVersion.LatestAvailableVersion,
 		GroupInfo:       groupInfo,
 		Step:            stepVersion.Step,
 		DefinitionPth:   stepDefinitionPth,
-	}, nil
+	}
+
+	return defaultStepTitle(stepInfo), nil
+}
+
+// defaultStepTitle sets the step title to the step ID when the definition omits
+// one, so callers always have a non-empty display title.
+func defaultStepTitle(info models.StepInfoModel) models.StepInfoModel {
+	if info.Step.Title == nil || *info.Step.Title == "" {
+		info.Step.Title = pointers.NewStringPtr(info.ID)
+	}
+	return info
 }

--- a/vendor/github.com/bitrise-io/stepman/stepman/util.go
+++ b/vendor/github.com/bitrise-io/stepman/stepman/util.go
@@ -124,11 +124,18 @@ func DownloadStep(collectionURI string, collection models.StepCollectionModel, i
 		return nil
 	}
 
+	return DownloadStepSourceArchive(stepPth, downloadLocations, id, version, commithash, log)
+}
+
+// DownloadStepSourceArchive fetches a step's source into destDir from the given
+// download locations in priority order.
+// commithash applies only to git source.
+func DownloadStepSourceArchive(destDir string, downloadLocations []models.DownloadLocationModel, id, version, commithash string, log Logger) error {
 	for _, downloadLocation := range downloadLocations {
 		switch downloadLocation.Type {
 		case "zip":
 			err := retry.Times(2).Wait(3 * time.Second).Try(func(attempt uint) error {
-				return command.DownloadAndUnZIP(downloadLocation.Src, stepPth)
+				return command.DownloadAndUnZIP(downloadLocation.Src, destDir)
 			})
 
 			if err != nil {
@@ -138,7 +145,7 @@ func DownloadStep(collectionURI string, collection models.StepCollectionModel, i
 			}
 		case "git":
 			err := retry.Times(2).Wait(3 * time.Second).Try(func(attempt uint) error {
-				repo, err := git.New(stepPth)
+				repo, err := git.New(destDir)
 				if err != nil {
 					return err
 				}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -69,6 +69,7 @@ github.com/bitrise-io/go-utils/urlutil
 ## explicit; go 1.21
 github.com/bitrise-io/go-utils/v2/analytics
 github.com/bitrise-io/go-utils/v2/env
+github.com/bitrise-io/go-utils/v2/fileutil
 github.com/bitrise-io/go-utils/v2/log
 github.com/bitrise-io/go-utils/v2/log/colorstring
 github.com/bitrise-io/go-utils/v2/parseutil
@@ -78,14 +79,17 @@ github.com/bitrise-io/go-utils/v2/retryhttp
 # github.com/bitrise-io/goinp v0.0.0-20240103152431-054ed78518ef
 ## explicit; go 1.18
 github.com/bitrise-io/goinp/goinp
-# github.com/bitrise-io/stepman v0.23.0
+# github.com/bitrise-io/stepman v0.24.0
 ## explicit; go 1.25
 github.com/bitrise-io/stepman/activator
 github.com/bitrise-io/stepman/activator/steplib
 github.com/bitrise-io/stepman/cli
+github.com/bitrise-io/stepman/internal/httpfetch
 github.com/bitrise-io/stepman/models
 github.com/bitrise-io/stepman/preload
 github.com/bitrise-io/stepman/stepid
+github.com/bitrise-io/stepman/steplibrary
+github.com/bitrise-io/stepman/steplibrary/steplibindex
 github.com/bitrise-io/stepman/stepman
 github.com/bitrise-io/stepman/toolkits
 github.com/bitrise-io/stepman/version


### PR DESCRIPTION
Bumps `github.com/bitrise-io/stepman` from v0.23.0 to v0.24.0.

This release includes API-native step source activation (disabled by deafult): the step source can now be activated over the Steplib API without running `SetupLibrary` (i.e. without a cloned git steplib). The legacy git-cloned steplib path should behave the same as before.

- Main module: `go.mod` / `go.sum` bumped, `vendor/` re-synced (`go mod vendor`)
- `integrationtests` module: `go.mod` / `go.sum` bumped (no vendoring — that module intentionally does not vendor, per `integrationtests/README.md`)
- `go build ./...` passes in both modules

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[STEP-2437]: https://bitrise.atlassian.net/browse/STEP-2437?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ