### PR TITLE
Bump stepman to v0.24.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/bitrise-io/go-utils v1.0.15
 	github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.36
 	github.com/bitrise-io/goinp v0.0.0-20240103152431-054ed78518ef
-	github.com/bitrise-io/stepman v0.24.0
+	github.com/bitrise-io/stepman v0.24.1
 	github.com/go-git/go-git/v5 v5.19.1
 	github.com/gofrs/uuid v4.3.1+incompatible
 	github.com/hashicorp/go-retryablehttp v0.7.8

--- a/go.sum
+++ b/go.sum
@@ -28,8 +28,8 @@ github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.36 h1:zbvo84Wun4urzBt6+tkGpYSDvA5
 github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.36/go.mod h1:5Z/vkUZ2BIY7IAVlMGns3ypRjd+J872YBSCJaLWVo/U=
 github.com/bitrise-io/goinp v0.0.0-20240103152431-054ed78518ef h1:R5FOa8RHjqZwMN9g1FQ8W7nXxQAG7iwq1Cw+mUk5S9A=
 github.com/bitrise-io/goinp v0.0.0-20240103152431-054ed78518ef/go.mod h1:27ldH2bkCdYN5CEJ6x92EK+gkd5EcDBkA7dMrSKQFYU=
-github.com/bitrise-io/stepman v0.24.0 h1:5wLVVV/NrL9Ad97m+7r+vXGpMp77A6NgVFvDSVFsdW8=
-github.com/bitrise-io/stepman v0.24.0/go.mod h1:/SdpT6yeD5UKkPz2Kqk9votwLJ1+dQt7aTb8Z5ZoPw0=
+github.com/bitrise-io/stepman v0.24.1 h1:qJ+6TIieXGuHlDpmS9sy4BLDHOQGCf9eKFuWABHbrIE=
+github.com/bitrise-io/stepman v0.24.1/go.mod h1:/SdpT6yeD5UKkPz2Kqk9votwLJ1+dQt7aTb8Z5ZoPw0=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
 github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/cloudflare/circl v1.6.4 h1:pOXuDTCEYyzydgUpQ0CQz3LsinKjiSk6nNP5Lt5K64U=

--- a/integrationtests/go.mod
+++ b/integrationtests/go.mod
@@ -10,7 +10,7 @@ require (
 	al.essio.dev/pkg/shellescape v1.6.0
 	github.com/bitrise-io/bitrise/v2 v2.0.0
 	github.com/bitrise-io/go-utils v1.0.15
-	github.com/bitrise-io/stepman v0.24.0
+	github.com/bitrise-io/stepman v0.24.1
 	github.com/hashicorp/go-retryablehttp v0.7.8
 	github.com/ryanuber/go-glob v1.0.0
 	github.com/stretchr/testify v1.11.1

--- a/integrationtests/go.sum
+++ b/integrationtests/go.sum
@@ -28,8 +28,8 @@ github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.36 h1:zbvo84Wun4urzBt6+tkGpYSDvA5
 github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.36/go.mod h1:5Z/vkUZ2BIY7IAVlMGns3ypRjd+J872YBSCJaLWVo/U=
 github.com/bitrise-io/goinp v0.0.0-20240103152431-054ed78518ef h1:R5FOa8RHjqZwMN9g1FQ8W7nXxQAG7iwq1Cw+mUk5S9A=
 github.com/bitrise-io/goinp v0.0.0-20240103152431-054ed78518ef/go.mod h1:27ldH2bkCdYN5CEJ6x92EK+gkd5EcDBkA7dMrSKQFYU=
-github.com/bitrise-io/stepman v0.24.0 h1:5wLVVV/NrL9Ad97m+7r+vXGpMp77A6NgVFvDSVFsdW8=
-github.com/bitrise-io/stepman v0.24.0/go.mod h1:/SdpT6yeD5UKkPz2Kqk9votwLJ1+dQt7aTb8Z5ZoPw0=
+github.com/bitrise-io/stepman v0.24.1 h1:qJ+6TIieXGuHlDpmS9sy4BLDHOQGCf9eKFuWABHbrIE=
+github.com/bitrise-io/stepman v0.24.1/go.mod h1:/SdpT6yeD5UKkPz2Kqk9votwLJ1+dQt7aTb8Z5ZoPw0=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
 github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/cloudflare/circl v1.6.4 h1:pOXuDTCEYyzydgUpQ0CQz3LsinKjiSk6nNP5Lt5K64U=

--- a/vendor/github.com/bitrise-io/stepman/activator/steplib/activate.go
+++ b/vendor/github.com/bitrise-io/stepman/activator/steplib/activate.go
@@ -12,6 +12,7 @@ import (
 	"github.com/bitrise-io/go-utils/command"
 	"github.com/bitrise-io/go-utils/pathutil"
 	"github.com/bitrise-io/go-utils/v2/fileutil"
+	"github.com/bitrise-io/stepman/internal/httpfetch"
 	"github.com/bitrise-io/stepman/models"
 	"github.com/bitrise-io/stepman/stepid"
 	"github.com/bitrise-io/stepman/steplibrary"
@@ -96,7 +97,7 @@ func downloadPrecompiled(log stepman.Logger, step models.StepModel, id stepid.Ca
 		if ok && executableForPlatform.Hash != "" && executableForPlatform.StorageURI != "" {
 			log.Debugf("Downloading executable for %s", platform)
 			downloadStart := time.Now()
-			execPath, err := activateStepExecutable(id.IDorURI, executableForPlatform, destination, log)
+			execPath, err := activateStepExecutable(context.Background(), httpfetch.NewClient(log), id.IDorURI, executableForPlatform, destination, log)
 			if err == nil {
 				log.Debugf("Downloaded executable in %s", time.Since(downloadStart).Round(time.Millisecond))
 

--- a/vendor/github.com/bitrise-io/stepman/activator/steplib/activate_executable.go
+++ b/vendor/github.com/bitrise-io/stepman/activator/steplib/activate_executable.go
@@ -1,97 +1,37 @@
 package steplib
 
 import (
-	"crypto/sha256"
-	"encoding/hex"
+	"context"
 	"errors"
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 	"strings"
 
+	"github.com/bitrise-io/stepman/internal/httpfetch"
 	"github.com/bitrise-io/stepman/models"
 	"github.com/bitrise-io/stepman/stepman"
-	"github.com/hashicorp/go-retryablehttp"
 )
 
 func activateStepExecutable(
+	ctx context.Context,
+	fetcher httpfetch.Client,
 	stepID string,
 	executable models.Executable,
 	destinationDir string,
 	logger stepman.Logger,
 ) (string, error) {
-	body, err := downloadExecutable(executable, logger)
-	if err != nil {
+	path := filepath.Join(destinationDir, stepID)
+
+	if err := downloadExecutable(ctx, fetcher, executable, path, logger); err != nil {
 		return "", err
 	}
-	defer func() {
-		if err := body.Close(); err != nil {
-			logger.Warnf("Failed to close response body: %s\n", err)
-		}
-	}()
 
-	err = os.MkdirAll(destinationDir, 0755)
-	if err != nil {
-		return "", fmt.Errorf("create directory %s: %w", destinationDir, err)
-	}
-
-	path := filepath.Join(destinationDir, stepID)
-	file, err := os.Create(path)
-	if err != nil {
-		return "", fmt.Errorf("create file %s: %w", path, err)
-	}
-	defer func() {
-		err := file.Close()
-		if err != nil {
-			logger.Warnf("Failed to close file %s: %s\n", path, err)
-		}
-	}()
-
-	_, err = io.Copy(file, body)
-	if err != nil {
-		return "", fmt.Errorf("download to %s: %w", path, err)
-	}
-
-	err = validateHash(path, executable.Hash)
-	if err != nil {
-		return "", fmt.Errorf("validate hash: %s", err)
-	}
-
-	err = os.Chmod(path, 0755)
-	if err != nil {
+	if err := os.Chmod(path, 0755); err != nil {
 		return "", fmt.Errorf("set executable permission on file: %s", err)
 	}
 
 	return path, nil
-}
-
-func validateHash(filePath string, expectedHash string) error {
-	if expectedHash == "" {
-		return fmt.Errorf("hash is empty")
-	}
-
-	if !strings.HasPrefix(expectedHash, "sha256-") {
-		return fmt.Errorf("only SHA256 hashes supported at this time, make sure to prefix the hash with `sha256-`. Found hash value: %s", expectedHash)
-	}
-
-	expectedHash = strings.TrimPrefix(expectedHash, "sha256-")
-
-	reader, err := os.Open(filePath)
-	if err != nil {
-		return err
-	}
-
-	h := sha256.New()
-	_, err = io.Copy(h, reader)
-	if err != nil {
-		return fmt.Errorf("calculate hash: %w", err)
-	}
-	actualHash := hex.EncodeToString(h.Sum(nil))
-	if actualHash != expectedHash {
-		return fmt.Errorf("hash mismatch: expected sha256-%s, got sha256-%s", expectedHash, actualHash)
-	}
-	return nil
 }
 
 func buildDownloadURLs(bases []string, executable models.Executable) ([]string, error) {
@@ -115,7 +55,7 @@ func buildDownloadURLs(bases []string, executable models.Executable) ([]string, 
 	return urls, nil
 }
 
-func downloadExecutable(executable models.Executable, logger stepman.Logger) (io.ReadCloser, error) {
+func downloadExecutable(ctx context.Context, fetcher httpfetch.Client, executable models.Executable, destPath string, logger stepman.Logger) error {
 	bases := precompiledStepsDefaultStorageURLs
 	if override := os.Getenv(precompiledStepsStorageURLsEnv); override != "" {
 		bases = strings.Split(override, ",")
@@ -123,29 +63,25 @@ func downloadExecutable(executable models.Executable, logger stepman.Logger) (io
 
 	urls, err := buildDownloadURLs(bases, executable)
 	if err != nil {
-		return nil, err
+		return err
 	}
-	return downloadFromURLs(urls, logger)
+	return downloadFromURLs(ctx, fetcher, urls, destPath, executable.Hash, logger)
 }
 
-func downloadFromURLs(urls []string, logger stepman.Logger) (io.ReadCloser, error) {
+// downloadFromURLs tries each URL in order via fetcher, verifying executable.Hash
+// on each attempt; a mismatch or failure falls through to the next mirror, logging
+// each failed attempt so a mirror silently degrading isn't invisible on fallback success.
+func downloadFromURLs(ctx context.Context, fetcher httpfetch.Client, urls []string, destPath, hash string, logger stepman.Logger) error {
 	var errs []error
 	for _, url := range urls {
-		resp, err := retryablehttp.Get(url)
-		if err == nil && resp.StatusCode < 400 {
-			return resp.Body, nil
+		err := fetcher.DownloadWithHash(ctx, destPath, url, hash)
+		if err == nil {
+			return nil
 		}
-
-		if err != nil {
-			logger.Warnf("Failed to download step from %s: %s\n", url, err)
-			errs = append(errs, fmt.Errorf("%s: %w", url, err))
-		} else {
-			if closeErr := resp.Body.Close(); closeErr != nil {
-				logger.Warnf("Failed to close response body: %s\n", closeErr)
-			}
-			logger.Warnf("Storage returned status %d for %s\n", resp.StatusCode, url)
-			errs = append(errs, fmt.Errorf("%s: status %d", url, resp.StatusCode))
-		}
+		// err already names the failing URL (fetcher wraps it in the underlying
+		// GET/status/hash-mismatch error), so it isn't repeated here.
+		logger.Warnf("Failed to download step executable: %s", err)
+		errs = append(errs, fmt.Errorf("%s: %w", url, err))
 	}
-	return nil, fmt.Errorf("failed to download executable: %w", errors.Join(errs...))
+	return fmt.Errorf("failed to download executable: %w", errors.Join(errs...))
 }

--- a/vendor/github.com/bitrise-io/stepman/activator/steplib_ref.go
+++ b/vendor/github.com/bitrise-io/stepman/activator/steplib_ref.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	bitriseSteplibURL    = "https://github.com/bitrise-io/bitrise-steplib.git"
-	bitriseSteplibAPIURL = "https://steplib.bitrise.io" // Base URL of steplib API
+	bitriseSteplibAPIURL = "https://steplib.bitrise.io/api"
 	enableSteplibAPIEnv  = "BITRISE_STEPLIB_API_ENABLE"
 )
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -79,7 +79,7 @@ github.com/bitrise-io/go-utils/v2/retryhttp
 # github.com/bitrise-io/goinp v0.0.0-20240103152431-054ed78518ef
 ## explicit; go 1.18
 github.com/bitrise-io/goinp/goinp
-# github.com/bitrise-io/stepman v0.24.0
+# github.com/bitrise-io/stepman v0.24.1
 ## explicit; go 1.25
 github.com/bitrise-io/stepman/activator
 github.com/bitrise-io/stepman/activator/steplib


### PR DESCRIPTION
Bumps `github.com/bitrise-io/stepman` from v0.24.0 to [v0.24.1](https://github.com/bitrise-io/stepman/releases/tag/v0.24.1).

## What's in v0.24.1

- Route precompiled-binary downloads through `internal/httpfetch` ([bitrise-io/stepman#409](https://github.com/bitrise-io/stepman/pull/409))
- Change Steplib API prod deployment base URL ([bitrise-io/stepman#412](https://github.com/bitrise-io/stepman/pull/412))

## Modules updated

- Main module: `go.mod`/`go.sum` bumped and `vendor/` re-synced.
- `integrationtests` module: `go.mod`/`go.sum` bumped. This module is intentionally **not** vendored (per `integrationtests/README.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
