### PR TITLE
[STEP-2421] Report the StepLib inventory source on cli_step_activation

### DIFF
--- a/analytics/tracker.go
+++ b/analytics/tracker.go
@@ -117,7 +117,7 @@ type Tracker interface {
 	SendCLIWarning(message string)
 	SendCommandInfo(command, subcommand string, flags []string)
 	SendToolSetupEvent(provider string, request provider.ToolRequest, result provider.ToolInstallResult, is_successful bool, setupTime time.Duration)
-	SendStepActivationEvent(activationType activator.ActivationType, ref string, isSuccessful bool, duration time.Duration, didSteplibUpdate bool)
+	SendStepActivationEvent(stepExecutionID string, activationType activator.ActivationType, inventorySource activator.ActivationInventorySource, ref string, isSuccessful bool, duration time.Duration, didSteplibUpdate bool)
 	SendToolkitPrepareEvent(stepExecutionID string, toolkitName string, stepID string, stepVersion string, result toolkits.PrepareForStepRunResult, err error)
 	IsTracking() bool
 	Wait()
@@ -390,7 +390,7 @@ func (t tracker) SendToolSetupEvent(
 	t.tracker.Enqueue(toolSetupEventName, props)
 }
 
-func (t tracker) SendStepActivationEvent(activationType activator.ActivationType, ref string, isSuccessful bool, duration time.Duration, didSteplibUpdate bool) {
+func (t tracker) SendStepActivationEvent(stepExecutionID string, activationType activator.ActivationType, inventorySource activator.ActivationInventorySource, ref string, isSuccessful bool, duration time.Duration, didSteplibUpdate bool) {
 	if !t.stateChecker.Enabled() {
 		return
 	}
@@ -399,14 +399,18 @@ func (t tracker) SendStepActivationEvent(activationType activator.ActivationType
 	isCI := t.envRepository.Get(configs.CIModeEnvKey) == "true"
 
 	props := analytics.Properties{
-		"is_successful":   isSuccessful,
-		"step_ref":        ref,
-		"duration_ms":     duration.Milliseconds(),
-		"cli_version":     version.VERSION,
-		"is_ci":           isCI,
-		"build_slug":      buildSlug,
-		"activation_type": activationType,
+		"step_execution_id": stepExecutionID,
+		"is_successful":     isSuccessful,
+		"step_ref":          ref,
+		"duration_ms":       duration.Milliseconds(),
+		"cli_version":       version.VERSION,
+		"is_ci":             isCI,
+		"build_slug":        buildSlug,
+		"activation_type":   activationType,
 	}
+
+	// Only steplib references have an inventory: it is empty for git and path refs.
+	props.AppendIfNotEmpty("inventory_source", string(inventorySource))
 
 	if isSuccessful {
 		props["did_steplib_update"] = didSteplibUpdate

--- a/analytics/tracker.go
+++ b/analytics/tracker.go
@@ -399,14 +399,14 @@ func (t tracker) SendStepActivationEvent(stepExecutionID string, activationType 
 	isCI := t.envRepository.Get(configs.CIModeEnvKey) == "true"
 
 	props := analytics.Properties{
-		"step_execution_id": stepExecutionID,
-		"is_successful":     isSuccessful,
-		"step_ref":          ref,
-		"duration_ms":       duration.Milliseconds(),
-		"cli_version":       version.VERSION,
-		"is_ci":             isCI,
-		"build_slug":        buildSlug,
-		"activation_type":   activationType,
+		StepExecutionID:   stepExecutionID,
+		"is_successful":   isSuccessful,
+		"step_ref":        ref,
+		"duration_ms":     duration.Milliseconds(),
+		"cli_version":     version.VERSION,
+		"is_ci":           isCI,
+		"build_slug":      buildSlug,
+		"activation_type": activationType,
 	}
 
 	// Only steplib references have an inventory: it is empty for git and path refs.

--- a/analytics/tracker_test.go
+++ b/analytics/tracker_test.go
@@ -169,10 +169,10 @@ func Test_SendStepActivationEvent(t *testing.T) {
 			wantDidSteplibKey:   true,
 		},
 		{
-			name:                "Legacy activation reports git_clone",
-			inventorySource:     activator.ActivationInventorySourceGitClone,
+			name:                "Legacy activation reports steplib",
+			inventorySource:     activator.ActivationInventorySourceSteplib,
 			isSuccessful:        true,
-			wantInventorySource: "git_clone",
+			wantInventorySource: "steplib",
 			wantDidSteplibKey:   true,
 		},
 		{

--- a/analytics/tracker_test.go
+++ b/analytics/tracker_test.go
@@ -4,8 +4,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/bitrise-io/bitrise/v2/log"
 	"github.com/bitrise-io/bitrise/v2/models"
 	"github.com/bitrise-io/go-utils/v2/analytics"
+	"github.com/bitrise-io/go-utils/v2/env"
+	"github.com/bitrise-io/stepman/activator"
 	"github.com/stretchr/testify/require"
 )
 
@@ -125,6 +128,111 @@ func Test_mapStepResultToEvent(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, tt.expectedEvent, actualEvent)
 			require.Equal(t, tt.expectedExtraProps, actualProps)
+		})
+	}
+}
+
+// capturingAnalyticsTracker records what the tracker hands to the analytics client.
+type capturingAnalyticsTracker struct {
+	events []capturedEvent
+}
+
+type capturedEvent struct {
+	name  string
+	props analytics.Properties
+}
+
+func (c *capturingAnalyticsTracker) Enqueue(eventName string, properties ...analytics.Properties) {
+	merged := analytics.Properties{}
+	for _, p := range properties {
+		merged = merged.Merge(p)
+	}
+	c.events = append(c.events, capturedEvent{name: eventName, props: merged})
+}
+
+func (c *capturingAnalyticsTracker) Wait()            {}
+func (c *capturingAnalyticsTracker) IsTracking() bool { return true }
+
+func Test_SendStepActivationEvent(t *testing.T) {
+	tests := []struct {
+		name                string
+		inventorySource     activator.ActivationInventorySource
+		isSuccessful        bool
+		wantInventorySource interface{} // nil means the key must be absent
+		wantDidSteplibKey   bool
+	}{
+		{
+			name:                "StepLib API activation reports steplib_api",
+			inventorySource:     activator.ActivationInventorySourceSteplibAPI,
+			isSuccessful:        true,
+			wantInventorySource: "steplib_api",
+			wantDidSteplibKey:   true,
+		},
+		{
+			name:                "Legacy activation reports git_clone",
+			inventorySource:     activator.ActivationInventorySourceGitClone,
+			isSuccessful:        true,
+			wantInventorySource: "git_clone",
+			wantDidSteplibKey:   true,
+		},
+		{
+			// A failed activation is still attributable to a path, which is the
+			// point of reporting it: stepman sets it before any early return.
+			name:                "Failed activation still reports the inventory source",
+			inventorySource:     activator.ActivationInventorySourceSteplibAPI,
+			isSuccessful:        false,
+			wantInventorySource: "steplib_api",
+			wantDidSteplibKey:   false,
+		},
+		{
+			name:                "Path or git ref omits the inventory source",
+			inventorySource:     activator.ActivationInventorySourceNone,
+			isSuccessful:        true,
+			wantInventorySource: nil,
+			wantDidSteplibKey:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv(DisabledEnvKey, "")
+
+			envRepository := env.NewRepository()
+			analyticsTracker := &capturingAnalyticsTracker{}
+			logger := log.NewUtilsLogAdapter()
+			subject := NewTracker(analyticsTracker, envRepository, NewStateChecker(envRepository), &logger)
+
+			subject.SendStepActivationEvent(
+				"step-execution-id",
+				activator.ActivationTypeSteplibSource,
+				tt.inventorySource,
+				"git-clone@8.5.0",
+				tt.isSuccessful,
+				2*time.Second,
+				true,
+			)
+
+			require.Len(t, analyticsTracker.events, 1)
+			event := analyticsTracker.events[0]
+			require.Equal(t, "cli_step_activation", event.name)
+
+			// step_execution_id makes this event joinable with cli_toolkit_prepare.
+			require.Equal(t, "step-execution-id", event.props["step_execution_id"])
+			require.Equal(t, activator.ActivationTypeSteplibSource, event.props["activation_type"])
+			require.Equal(t, int64(2000), event.props["duration_ms"])
+			require.Equal(t, tt.isSuccessful, event.props["is_successful"])
+
+			if tt.wantInventorySource == nil {
+				require.NotContains(t, event.props, "inventory_source")
+			} else {
+				require.Equal(t, tt.wantInventorySource, event.props["inventory_source"])
+			}
+
+			if tt.wantDidSteplibKey {
+				require.Equal(t, true, event.props["did_steplib_update"])
+			} else {
+				require.NotContains(t, event.props, "did_steplib_update")
+			}
 		})
 	}
 }

--- a/analytics/tracker_test.go
+++ b/analytics/tracker_test.go
@@ -156,40 +156,50 @@ func (c *capturingAnalyticsTracker) IsTracking() bool { return true }
 func Test_SendStepActivationEvent(t *testing.T) {
 	tests := []struct {
 		name                string
+		activationType      activator.ActivationType
 		inventorySource     activator.ActivationInventorySource
 		isSuccessful        bool
 		wantInventorySource any // nil means the key must be absent
-		wantDidSteplibKey   bool
 	}{
 		{
 			name:                "StepLib API activation reports steplib_api",
+			activationType:      activator.ActivationTypeSteplibSource,
 			inventorySource:     activator.ActivationInventorySourceSteplibAPI,
 			isSuccessful:        true,
 			wantInventorySource: "steplib_api",
-			wantDidSteplibKey:   true,
 		},
 		{
 			name:                "Legacy activation reports steplib",
+			activationType:      activator.ActivationTypeSteplibSource,
 			inventorySource:     activator.ActivationInventorySourceSteplib,
 			isSuccessful:        true,
 			wantInventorySource: "steplib",
-			wantDidSteplibKey:   true,
 		},
 		{
-			// A failed activation is still attributable to a path, which is the
-			// point of reporting it: stepman sets it before any early return.
+			// The tracker must not gate the inventory source on success the way it
+			// gates did_steplib_update below: a failed activation is still
+			// attributable to a path, which is the point of reporting it. That
+			// stepman populates the field on its error paths is covered upstream,
+			// in activator.TestActivateSteplibRefStep.
 			name:                "Failed activation still reports the inventory source",
+			activationType:      activator.ActivationTypeSteplibSource,
 			inventorySource:     activator.ActivationInventorySourceSteplibAPI,
 			isSuccessful:        false,
 			wantInventorySource: "steplib_api",
-			wantDidSteplibKey:   false,
 		},
 		{
-			name:                "Path or git ref omits the inventory source",
+			name:                "Path ref omits the inventory source",
+			activationType:      activator.ActivationTypePathRef,
 			inventorySource:     activator.ActivationInventorySourceNone,
 			isSuccessful:        true,
 			wantInventorySource: nil,
-			wantDidSteplibKey:   true,
+		},
+		{
+			name:                "Git ref omits the inventory source",
+			activationType:      activator.ActivationTypeGitRef,
+			inventorySource:     activator.ActivationInventorySourceNone,
+			isSuccessful:        true,
+			wantInventorySource: nil,
 		},
 	}
 
@@ -204,7 +214,7 @@ func Test_SendStepActivationEvent(t *testing.T) {
 
 			subject.SendStepActivationEvent(
 				"step-execution-id",
-				activator.ActivationTypeSteplibSource,
+				tt.activationType,
 				tt.inventorySource,
 				"git-clone@8.5.0",
 				tt.isSuccessful,
@@ -218,7 +228,7 @@ func Test_SendStepActivationEvent(t *testing.T) {
 
 			// step_execution_id makes this event joinable with cli_toolkit_prepare.
 			require.Equal(t, "step-execution-id", event.props["step_execution_id"])
-			require.Equal(t, activator.ActivationTypeSteplibSource, event.props["activation_type"])
+			require.Equal(t, tt.activationType, event.props["activation_type"])
 			require.Equal(t, int64(2000), event.props["duration_ms"])
 			require.Equal(t, tt.isSuccessful, event.props["is_successful"])
 
@@ -228,7 +238,9 @@ func Test_SendStepActivationEvent(t *testing.T) {
 				require.Equal(t, tt.wantInventorySource, event.props["inventory_source"])
 			}
 
-			if tt.wantDidSteplibKey {
+			// did_steplib_update is reported only for successful activations, so the
+			// expectation follows isSuccessful rather than being a separate column.
+			if tt.isSuccessful {
 				require.Equal(t, true, event.props["did_steplib_update"])
 			} else {
 				require.NotContains(t, event.props, "did_steplib_update")

--- a/analytics/tracker_test.go
+++ b/analytics/tracker_test.go
@@ -158,7 +158,7 @@ func Test_SendStepActivationEvent(t *testing.T) {
 		name                string
 		inventorySource     activator.ActivationInventorySource
 		isSuccessful        bool
-		wantInventorySource interface{} // nil means the key must be absent
+		wantInventorySource any // nil means the key must be absent
 		wantDidSteplibKey   bool
 	}{
 		{

--- a/cli/run_test.go
+++ b/cli/run_test.go
@@ -2206,7 +2206,7 @@ func (n noOpTracker) SendWorkflowFinished(analytics.Properties, bool)           
 func (n noOpTracker) SendCommandInfo(string, string, []string)                            {}
 func (n noOpTracker) SendToolSetupEvent(provider string, request provider.ToolRequest, result provider.ToolInstallResult, is_successful bool, setupTime time.Duration) {
 }
-func (n noOpTracker) SendStepActivationEvent(activationType activator.ActivationType, ref string, isSuccessful bool, duration time.Duration, didSteplibUpdate bool) {
+func (n noOpTracker) SendStepActivationEvent(stepExecutionID string, activationType activator.ActivationType, inventorySource activator.ActivationInventorySource, ref string, isSuccessful bool, duration time.Duration, didSteplibUpdate bool) {
 }
 func (n noOpTracker) SendToolkitPrepareEvent(stepExecutionID string, toolkitName string, stepID string, stepVersion string, result toolkits.PrepareForStepRunResult, err error) {
 }

--- a/cli/run_util.go
+++ b/cli/run_util.go
@@ -249,7 +249,7 @@ func (r WorkflowRunner) activateAndRunStep(
 	//
 	// Activate step
 	activateStartTime := time.Now()
-	activateResult := r.activateStep(step, stepInfoPtr, stepIDData, buildRunResults, isStepLibOfflineMode)
+	activateResult := r.activateStep(stepExecutionID, step, stepInfoPtr, stepIDData, buildRunResults, isStepLibOfflineMode)
 	activateDuration := time.Since(activateStartTime)
 	if activateResult.Err != nil {
 		return newActivateAndRunStepResult(activateResult.Step, activateResult.StepInfoPtr, models.StepRunStatusCodePreparationFailed, 1, activateResult.Err, true, map[string]string{}, nil)
@@ -370,6 +370,7 @@ func newStepInfoPtr(stepID, defaultStepLibSource string, step stepmanModels.Step
 }
 
 func (r WorkflowRunner) activateStep(
+	stepExecutionID string,
 	step stepmanModels.StepModel,
 	stepInfoPtr stepmanModels.StepInfoModel,
 	stepIDData stepid.CanonicalID,
@@ -393,7 +394,9 @@ func (r WorkflowRunner) activateStep(
 	activator := newStepActivator()
 	activatedStep, err := activator.activateStep(stepIDData, isStepLibUpdated, stepDir, configs.BitriseWorkDirPath, isStepLibOfflineMode)
 	r.tracker.SendStepActivationEvent(
+		stepExecutionID,
 		activatedStep.ActivationType,
+		activatedStep.ActivationInventorySource,
 		stepIDData.IDorURI,
 		err == nil,
 		time.Since(activationStartedAt),

--- a/go.mod
+++ b/go.mod
@@ -90,3 +90,5 @@ require (
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 	gotest.tools/v3 v3.5.1 // indirect
 )
+
+replace github.com/bitrise-io/stepman => github.com/bitrise-io/stepman v0.24.2-0.20260728164249-05d182f42ff8

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/bitrise-io/go-utils v1.0.15
 	github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.36
 	github.com/bitrise-io/goinp v0.0.0-20240103152431-054ed78518ef
-	github.com/bitrise-io/stepman v0.24.1
+	github.com/bitrise-io/stepman v0.24.2
 	github.com/go-git/go-git/v5 v5.19.1
 	github.com/gofrs/uuid v4.3.1+incompatible
 	github.com/hashicorp/go-retryablehttp v0.7.8
@@ -90,5 +90,3 @@ require (
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 	gotest.tools/v3 v3.5.1 // indirect
 )
-
-replace github.com/bitrise-io/stepman => github.com/bitrise-io/stepman v0.24.2-0.20260730121732-228287fcebff

--- a/go.mod
+++ b/go.mod
@@ -91,4 +91,4 @@ require (
 	gotest.tools/v3 v3.5.1 // indirect
 )
 
-replace github.com/bitrise-io/stepman => github.com/bitrise-io/stepman v0.24.2-0.20260728164249-05d182f42ff8
+replace github.com/bitrise-io/stepman => github.com/bitrise-io/stepman v0.24.2-0.20260730121732-228287fcebff

--- a/go.sum
+++ b/go.sum
@@ -28,8 +28,8 @@ github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.36 h1:zbvo84Wun4urzBt6+tkGpYSDvA5
 github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.36/go.mod h1:5Z/vkUZ2BIY7IAVlMGns3ypRjd+J872YBSCJaLWVo/U=
 github.com/bitrise-io/goinp v0.0.0-20240103152431-054ed78518ef h1:R5FOa8RHjqZwMN9g1FQ8W7nXxQAG7iwq1Cw+mUk5S9A=
 github.com/bitrise-io/goinp v0.0.0-20240103152431-054ed78518ef/go.mod h1:27ldH2bkCdYN5CEJ6x92EK+gkd5EcDBkA7dMrSKQFYU=
-github.com/bitrise-io/stepman v0.24.2-0.20260728164249-05d182f42ff8 h1:KTqochdoJy9C1Y0+jnlZkQSbeslZeCa/DOU1XJDotxk=
-github.com/bitrise-io/stepman v0.24.2-0.20260728164249-05d182f42ff8/go.mod h1:/SdpT6yeD5UKkPz2Kqk9votwLJ1+dQt7aTb8Z5ZoPw0=
+github.com/bitrise-io/stepman v0.24.2-0.20260730121732-228287fcebff h1:3TzVbNR8FUSpmG4ErvNsy30RbVeC0TewUSnGZNL7TCo=
+github.com/bitrise-io/stepman v0.24.2-0.20260730121732-228287fcebff/go.mod h1:/SdpT6yeD5UKkPz2Kqk9votwLJ1+dQt7aTb8Z5ZoPw0=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
 github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/cloudflare/circl v1.6.4 h1:pOXuDTCEYyzydgUpQ0CQz3LsinKjiSk6nNP5Lt5K64U=

--- a/go.sum
+++ b/go.sum
@@ -28,8 +28,8 @@ github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.36 h1:zbvo84Wun4urzBt6+tkGpYSDvA5
 github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.36/go.mod h1:5Z/vkUZ2BIY7IAVlMGns3ypRjd+J872YBSCJaLWVo/U=
 github.com/bitrise-io/goinp v0.0.0-20240103152431-054ed78518ef h1:R5FOa8RHjqZwMN9g1FQ8W7nXxQAG7iwq1Cw+mUk5S9A=
 github.com/bitrise-io/goinp v0.0.0-20240103152431-054ed78518ef/go.mod h1:27ldH2bkCdYN5CEJ6x92EK+gkd5EcDBkA7dMrSKQFYU=
-github.com/bitrise-io/stepman v0.24.1 h1:qJ+6TIieXGuHlDpmS9sy4BLDHOQGCf9eKFuWABHbrIE=
-github.com/bitrise-io/stepman v0.24.1/go.mod h1:/SdpT6yeD5UKkPz2Kqk9votwLJ1+dQt7aTb8Z5ZoPw0=
+github.com/bitrise-io/stepman v0.24.2-0.20260728164249-05d182f42ff8 h1:KTqochdoJy9C1Y0+jnlZkQSbeslZeCa/DOU1XJDotxk=
+github.com/bitrise-io/stepman v0.24.2-0.20260728164249-05d182f42ff8/go.mod h1:/SdpT6yeD5UKkPz2Kqk9votwLJ1+dQt7aTb8Z5ZoPw0=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
 github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/cloudflare/circl v1.6.4 h1:pOXuDTCEYyzydgUpQ0CQz3LsinKjiSk6nNP5Lt5K64U=

--- a/go.sum
+++ b/go.sum
@@ -28,8 +28,8 @@ github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.36 h1:zbvo84Wun4urzBt6+tkGpYSDvA5
 github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.36/go.mod h1:5Z/vkUZ2BIY7IAVlMGns3ypRjd+J872YBSCJaLWVo/U=
 github.com/bitrise-io/goinp v0.0.0-20240103152431-054ed78518ef h1:R5FOa8RHjqZwMN9g1FQ8W7nXxQAG7iwq1Cw+mUk5S9A=
 github.com/bitrise-io/goinp v0.0.0-20240103152431-054ed78518ef/go.mod h1:27ldH2bkCdYN5CEJ6x92EK+gkd5EcDBkA7dMrSKQFYU=
-github.com/bitrise-io/stepman v0.24.2-0.20260730121732-228287fcebff h1:3TzVbNR8FUSpmG4ErvNsy30RbVeC0TewUSnGZNL7TCo=
-github.com/bitrise-io/stepman v0.24.2-0.20260730121732-228287fcebff/go.mod h1:/SdpT6yeD5UKkPz2Kqk9votwLJ1+dQt7aTb8Z5ZoPw0=
+github.com/bitrise-io/stepman v0.24.2 h1:qHafrAPaa2KK1rn37JlWiO6Px5SjIET32p2SQaIly+M=
+github.com/bitrise-io/stepman v0.24.2/go.mod h1:/SdpT6yeD5UKkPz2Kqk9votwLJ1+dQt7aTb8Z5ZoPw0=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
 github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/cloudflare/circl v1.6.4 h1:pOXuDTCEYyzydgUpQ0CQz3LsinKjiSk6nNP5Lt5K64U=

--- a/integrationtests/go.mod
+++ b/integrationtests/go.mod
@@ -10,7 +10,7 @@ require (
 	al.essio.dev/pkg/shellescape v1.6.0
 	github.com/bitrise-io/bitrise/v2 v2.0.0
 	github.com/bitrise-io/go-utils v1.0.15
-	github.com/bitrise-io/stepman v0.24.1
+	github.com/bitrise-io/stepman v0.24.2
 	github.com/hashicorp/go-retryablehttp v0.7.8
 	github.com/ryanuber/go-glob v1.0.0
 	github.com/stretchr/testify v1.11.1

--- a/integrationtests/go.sum
+++ b/integrationtests/go.sum
@@ -28,8 +28,8 @@ github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.36 h1:zbvo84Wun4urzBt6+tkGpYSDvA5
 github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.36/go.mod h1:5Z/vkUZ2BIY7IAVlMGns3ypRjd+J872YBSCJaLWVo/U=
 github.com/bitrise-io/goinp v0.0.0-20240103152431-054ed78518ef h1:R5FOa8RHjqZwMN9g1FQ8W7nXxQAG7iwq1Cw+mUk5S9A=
 github.com/bitrise-io/goinp v0.0.0-20240103152431-054ed78518ef/go.mod h1:27ldH2bkCdYN5CEJ6x92EK+gkd5EcDBkA7dMrSKQFYU=
-github.com/bitrise-io/stepman v0.24.1 h1:qJ+6TIieXGuHlDpmS9sy4BLDHOQGCf9eKFuWABHbrIE=
-github.com/bitrise-io/stepman v0.24.1/go.mod h1:/SdpT6yeD5UKkPz2Kqk9votwLJ1+dQt7aTb8Z5ZoPw0=
+github.com/bitrise-io/stepman v0.24.2 h1:qHafrAPaa2KK1rn37JlWiO6Px5SjIET32p2SQaIly+M=
+github.com/bitrise-io/stepman v0.24.2/go.mod h1:/SdpT6yeD5UKkPz2Kqk9votwLJ1+dQt7aTb8Z5ZoPw0=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
 github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/cloudflare/circl v1.6.4 h1:pOXuDTCEYyzydgUpQ0CQz3LsinKjiSk6nNP5Lt5K64U=

--- a/toolprovider/run_test.go
+++ b/toolprovider/run_test.go
@@ -40,7 +40,7 @@ func (c *capturingTracker) SendToolSetupEvent(providerID string, request provide
 		isSuccessful: isSuccessful,
 	})
 }
-func (c *capturingTracker) SendStepActivationEvent(activator.ActivationType, string, bool, time.Duration, bool) {
+func (c *capturingTracker) SendStepActivationEvent(string, activator.ActivationType, activator.ActivationInventorySource, string, bool, time.Duration, bool) {
 }
 func (c *capturingTracker) SendToolkitPrepareEvent(string, string, string, string, toolkits.PrepareForStepRunResult, error) {
 }

--- a/vendor/github.com/bitrise-io/stepman/activator/git_ref.go
+++ b/vendor/github.com/bitrise-io/stepman/activator/git_ref.go
@@ -21,7 +21,7 @@ func ActivateGitRefStep(
 ) (ActivatedStep, error) {
 	repo, err := git.New(activatedStepDir)
 	if err != nil {
-		return ActivatedStep{},err
+		return ActivatedStep{}, err
 	}
 
 	var cloneCmd *command.Model
@@ -39,26 +39,27 @@ even if the repository is open source!`)
 		}
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) {
-			return ActivatedStep{},fmt.Errorf("command failed with exit status %d (%s): %w", exitErr.ExitCode(), cloneCmd.PrintableCommandArgs(), errors.New(out))
+			return ActivatedStep{}, fmt.Errorf("command failed with exit status %d (%s): %w", exitErr.ExitCode(), cloneCmd.PrintableCommandArgs(), errors.New(out))
 		}
-		return ActivatedStep{},err
+		return ActivatedStep{}, err
 	}
 
 	stepYMLPath := filepath.Join(workDir, "current_step.yml")
 	if err := command.CopyFile(filepath.Join(activatedStepDir, "step.yml"), stepYMLPath); err != nil {
-		return ActivatedStep{},err
+		return ActivatedStep{}, err
 	}
 
 	stepInfo, err := stepman.QueryStepInfoFromGitStepDir(activatedStepDir, id.IDorURI, id.Version)
 	if err != nil {
-		return ActivatedStep{},err
+		return ActivatedStep{}, err
 	}
 
 	return ActivatedStep{
-		StepInfo:         stepInfo,
-		StepYMLPath:      stepYMLPath,
-		DidStepLibUpdate: false,
-		ActivationType:   ActivationTypeGitRef,
-		ExecutablePath:   "",
+		StepInfo:                  stepInfo,
+		StepYMLPath:               stepYMLPath,
+		DidStepLibUpdate:          false,
+		ActivationType:            ActivationTypeGitRef,
+		ActivationInventorySource: ActivationInventorySourceNone,
+		ExecutablePath:            "",
 	}, nil
 }

--- a/vendor/github.com/bitrise-io/stepman/activator/path_ref.go
+++ b/vendor/github.com/bitrise-io/stepman/activator/path_ref.go
@@ -55,10 +55,11 @@ func ActivatePathRefStep(
 	}
 
 	return ActivatedStep{
-		StepInfo:         stepInfo,
-		StepYMLPath:      activatedStepYMLPath,
-		DidStepLibUpdate: false,
-		ActivationType:   ActivationTypePathRef,
-		ExecutablePath:   "",
+		StepInfo:                  stepInfo,
+		StepYMLPath:               activatedStepYMLPath,
+		DidStepLibUpdate:          false,
+		ActivationType:            ActivationTypePathRef,
+		ActivationInventorySource: ActivationInventorySourceNone,
+		ExecutablePath:            "",
 	}, nil
 }

--- a/vendor/github.com/bitrise-io/stepman/activator/result.go
+++ b/vendor/github.com/bitrise-io/stepman/activator/result.go
@@ -42,8 +42,9 @@ type ActivationInventorySource string
 const (
 	// ActivationInventorySourceNone means the step was not activated from a StepLib (git or path ref).
 	ActivationInventorySourceNone ActivationInventorySource = ""
-	// ActivationInventorySourceSteplibAPI means the metadata came from the StepLib API, with no git clone.
+	// ActivationInventorySourceSteplibAPI means the metadata came from the StepLib API.
 	ActivationInventorySourceSteplibAPI ActivationInventorySource = "steplib_api"
-	// ActivationInventorySourceGitClone means the metadata came from the locally cloned StepLib and its spec.json.
-	ActivationInventorySourceGitClone ActivationInventorySource = "git_clone"
+	// ActivationInventorySourceSteplib means the metadata came from the locally set up StepLib
+	// and its generated spec.json.
+	ActivationInventorySourceSteplib ActivationInventorySource = "steplib"
 )

--- a/vendor/github.com/bitrise-io/stepman/activator/result.go
+++ b/vendor/github.com/bitrise-io/stepman/activator/result.go
@@ -9,6 +9,10 @@ type ActivatedStep struct {
 
 	ActivationType ActivationType
 
+	// ActivationInventorySource is the StepLib inventory that served the step metadata.
+	// It is ActivationInventorySourceNone for git and path references.
+	ActivationInventorySource ActivationInventorySource
+
 	// ExecutablePath is a local path to the main entrypoint of the step, ready for execution.
 	// This can be an empty string if:
 	// - step was activated from a git reference (we checked out the source dir directly)
@@ -30,4 +34,16 @@ const (
 	ActivationTypeSteplibSource     ActivationType = "steplib_source"
 	ActivationTypePathRef           ActivationType = "path"
 	ActivationTypeGitRef            ActivationType = "git"
+)
+
+// ActivationInventorySource identifies which StepLib inventory served the step metadata.
+type ActivationInventorySource string
+
+const (
+	// ActivationInventorySourceNone means the step was not activated from a StepLib (git or path ref).
+	ActivationInventorySourceNone ActivationInventorySource = ""
+	// ActivationInventorySourceSteplibAPI means the metadata came from the StepLib API, with no git clone.
+	ActivationInventorySourceSteplibAPI ActivationInventorySource = "steplib_api"
+	// ActivationInventorySourceGitClone means the metadata came from the locally cloned StepLib and its spec.json.
+	ActivationInventorySourceGitClone ActivationInventorySource = "git_clone"
 )

--- a/vendor/github.com/bitrise-io/stepman/activator/steplib/activate.go
+++ b/vendor/github.com/bitrise-io/stepman/activator/steplib/activate.go
@@ -35,7 +35,7 @@ type ResolvedStep struct {
 	StepInfo models.StepInfoModel
 }
 
-func ActivateStep(id stepid.CanonicalID, destination, destinationStepYML string, log stepman.Logger, isOfflineMode bool, libraryAPI *steplibrary.Client) (ResolvedStep, error) {
+func ActivateStep(id stepid.CanonicalID, destination, destinationStepYML string, log stepman.Logger, isOfflineMode bool, libraryAPI *steplibrary.Client, precompiledFetcher httpfetch.Client) (ResolvedStep, error) {
 	var stepInfo models.StepInfoModel
 	var resolveErr error
 	if libraryAPI != nil {
@@ -64,7 +64,7 @@ func ActivateStep(id stepid.CanonicalID, destination, destinationStepYML string,
 		}
 	}
 
-	execPath, err := downloadPrecompiled(log, stepModel, id, destination)
+	execPath, err := downloadPrecompiled(log, stepModel, id, destination, precompiledFetcher)
 	if execPath != "" {
 		return ResolvedStep{ExecPath: execPath, StepInfo: stepInfo}, err
 	}
@@ -72,7 +72,7 @@ func ActivateStep(id stepid.CanonicalID, destination, destinationStepYML string,
 	// Fall back to step source activation.
 	if libraryAPI != nil {
 		// activate the source over the API, without git clone
-		if err := activateStepSourceWithAPI(libraryAPI, id.SteplibSource, version, stepModel.Source, destination, log, isOfflineMode); err != nil {
+		if err := activateStepSourceWithAPI(libraryAPI, id.IDorURI, version, stepModel.Source, destination, log, isOfflineMode); err != nil {
 			return ResolvedStep{ExecPath: "", StepInfo: stepInfo}, err
 		}
 		return ResolvedStep{ExecPath: "", StepInfo: stepInfo}, nil
@@ -90,14 +90,14 @@ func ActivateStep(id stepid.CanonicalID, destination, destinationStepYML string,
 	return ResolvedStep{ExecPath: "", StepInfo: stepInfo}, nil
 }
 
-func downloadPrecompiled(log stepman.Logger, step models.StepModel, id stepid.CanonicalID, destination string) (string, error) {
+func downloadPrecompiled(log stepman.Logger, step models.StepModel, id stepid.CanonicalID, destination string, fetcher httpfetch.Client) (string, error) {
 	if (os.Getenv(precompiledStepsEnv) == "true" || os.Getenv(precompiledStepsEnv) == "1") && step.Executables != nil {
 		platform := fmt.Sprintf("%s-%s", runtime.GOOS, runtime.GOARCH)
 		executableForPlatform, ok := (*step.Executables)[platform]
 		if ok && executableForPlatform.Hash != "" && executableForPlatform.StorageURI != "" {
 			log.Debugf("Downloading executable for %s", platform)
 			downloadStart := time.Now()
-			execPath, err := activateStepExecutable(context.Background(), httpfetch.NewClient(log), id.IDorURI, executableForPlatform, destination, log)
+			execPath, err := activateStepExecutable(context.Background(), fetcher, id.IDorURI, executableForPlatform, destination, log)
 			if err == nil {
 				log.Debugf("Downloaded executable in %s", time.Since(downloadStart).Round(time.Millisecond))
 

--- a/vendor/github.com/bitrise-io/stepman/activator/steplib_ref.go
+++ b/vendor/github.com/bitrise-io/stepman/activator/steplib_ref.go
@@ -34,17 +34,17 @@ func ActivateSteplibRefStep(
 		DidStepLibUpdate: false,
 	}
 
-	// Set before any return: the caller keeps the partial result on error, so a
-	// failed activation stays attributable to the inventory that served it.
 	var libraryAPI *steplibrary.Client
 	if shouldUseSteplibAPI(id.SteplibSource) {
 		libraryAPI = steplibrary.New(log, bitriseSteplibAPIURL)
-		activationResult.ActivationInventorySource = ActivationInventorySourceSteplibAPI
-	} else {
-		activationResult.ActivationInventorySource = ActivationInventorySourceGitClone
 	}
 
+	// The inventory source is set here, on the same branch that dispatches, and before
+	// any return: the caller keeps the partial result on error, so a failed activation
+	// is still attributable to the inventory that served it.
 	if libraryAPI == nil {
+		activationResult.ActivationInventorySource = ActivationInventorySourceSteplib
+
 		// Old stepman preparation codepath
 		stepInfo, didUpdate, err := prepareStepLibForActivation(log, id, didStepLibUpdateInWorkflow, isOfflineMode)
 		activationResult.StepInfo = stepInfo
@@ -52,6 +52,8 @@ func ActivateSteplibRefStep(
 		if err != nil {
 			return activationResult, err
 		}
+	} else {
+		activationResult.ActivationInventorySource = ActivationInventorySourceSteplibAPI
 	}
 
 	// ActivateStep dispatches to the v2 or legacy codepath.

--- a/vendor/github.com/bitrise-io/stepman/activator/steplib_ref.go
+++ b/vendor/github.com/bitrise-io/stepman/activator/steplib_ref.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 
 	"github.com/bitrise-io/stepman/activator/steplib"
+	"github.com/bitrise-io/stepman/internal/httpfetch"
 	"github.com/bitrise-io/stepman/models"
 	"github.com/bitrise-io/stepman/stepid"
 	"github.com/bitrise-io/stepman/steplibrary"
@@ -33,9 +34,14 @@ func ActivateSteplibRefStep(
 		DidStepLibUpdate: false,
 	}
 
+	// Set before any return: the caller keeps the partial result on error, so a
+	// failed activation stays attributable to the inventory that served it.
 	var libraryAPI *steplibrary.Client
 	if shouldUseSteplibAPI(id.SteplibSource) {
 		libraryAPI = steplibrary.New(log, bitriseSteplibAPIURL)
+		activationResult.ActivationInventorySource = ActivationInventorySourceSteplibAPI
+	} else {
+		activationResult.ActivationInventorySource = ActivationInventorySourceGitClone
 	}
 
 	if libraryAPI == nil {
@@ -49,7 +55,7 @@ func ActivateSteplibRefStep(
 	}
 
 	// ActivateStep dispatches to the v2 or legacy codepath.
-	resolvedStep, err := steplib.ActivateStep(id, activatedStepDir, stepYMLPath, log, isOfflineMode, libraryAPI)
+	resolvedStep, err := steplib.ActivateStep(id, activatedStepDir, stepYMLPath, log, isOfflineMode, libraryAPI, httpfetch.NewClient(log))
 	activationResult.StepInfo = resolvedStep.StepInfo
 	activationResult.ExecutablePath = resolvedStep.ExecPath
 	if resolvedStep.ExecPath != "" {

--- a/vendor/github.com/bitrise-io/stepman/stepman/util.go
+++ b/vendor/github.com/bitrise-io/stepman/stepman/util.go
@@ -145,6 +145,14 @@ func DownloadStepSourceArchive(destDir string, downloadLocations []models.Downlo
 			}
 		case "git":
 			err := retry.Times(2).Wait(3 * time.Second).Try(func(attempt uint) error {
+				// Clone into a clean target. git clone refuses a non-empty dir, so a
+				// retry after an attempt that already populated stepPth (e.g. a clone
+				// that succeeded but failed the commit-hash check) would otherwise
+				// fail with a misleading "already exists and is not empty" error,
+				// masking the real cause.
+				if err := os.RemoveAll(destDir); err != nil {
+					return fmt.Errorf("clean %s before clone: %s", destDir, err)
+				}
 				repo, err := git.New(destDir)
 				if err != nil {
 					return err

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -79,7 +79,7 @@ github.com/bitrise-io/go-utils/v2/retryhttp
 # github.com/bitrise-io/goinp v0.0.0-20240103152431-054ed78518ef
 ## explicit; go 1.18
 github.com/bitrise-io/goinp/goinp
-# github.com/bitrise-io/stepman v0.24.1 => github.com/bitrise-io/stepman v0.24.2-0.20260730121732-228287fcebff
+# github.com/bitrise-io/stepman v0.24.2
 ## explicit; go 1.25
 github.com/bitrise-io/stepman/activator
 github.com/bitrise-io/stepman/activator/steplib
@@ -435,4 +435,3 @@ gopkg.in/yaml.v2
 gopkg.in/yaml.v3
 # gotest.tools/v3 v3.5.1
 ## explicit; go 1.17
-# github.com/bitrise-io/stepman => github.com/bitrise-io/stepman v0.24.2-0.20260730121732-228287fcebff

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -79,7 +79,7 @@ github.com/bitrise-io/go-utils/v2/retryhttp
 # github.com/bitrise-io/goinp v0.0.0-20240103152431-054ed78518ef
 ## explicit; go 1.18
 github.com/bitrise-io/goinp/goinp
-# github.com/bitrise-io/stepman v0.24.1 => github.com/bitrise-io/stepman v0.24.2-0.20260728164249-05d182f42ff8
+# github.com/bitrise-io/stepman v0.24.1 => github.com/bitrise-io/stepman v0.24.2-0.20260730121732-228287fcebff
 ## explicit; go 1.25
 github.com/bitrise-io/stepman/activator
 github.com/bitrise-io/stepman/activator/steplib
@@ -435,4 +435,4 @@ gopkg.in/yaml.v2
 gopkg.in/yaml.v3
 # gotest.tools/v3 v3.5.1
 ## explicit; go 1.17
-# github.com/bitrise-io/stepman => github.com/bitrise-io/stepman v0.24.2-0.20260728164249-05d182f42ff8
+# github.com/bitrise-io/stepman => github.com/bitrise-io/stepman v0.24.2-0.20260730121732-228287fcebff

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -79,7 +79,7 @@ github.com/bitrise-io/go-utils/v2/retryhttp
 # github.com/bitrise-io/goinp v0.0.0-20240103152431-054ed78518ef
 ## explicit; go 1.18
 github.com/bitrise-io/goinp/goinp
-# github.com/bitrise-io/stepman v0.24.1
+# github.com/bitrise-io/stepman v0.24.1 => github.com/bitrise-io/stepman v0.24.2-0.20260728164249-05d182f42ff8
 ## explicit; go 1.25
 github.com/bitrise-io/stepman/activator
 github.com/bitrise-io/stepman/activator/steplib
@@ -435,3 +435,4 @@ gopkg.in/yaml.v2
 gopkg.in/yaml.v3
 # gotest.tools/v3 v3.5.1
 ## explicit; go 1.17
+# github.com/bitrise-io/stepman => github.com/bitrise-io/stepman v0.24.2-0.20260728164249-05d182f42ff8


### PR DESCRIPTION
## Why

stepman picks between the StepLib API and the legacy git-clone path (`shouldUseSteplibAPI`, gated by `BITRISE_STEPLIB_API_ENABLE`), but both branches returned an identical `ActivatedStep`, so this repo could not tell which one ran. Every `cli_step_activation` metric was unattributable to a path — exactly what the gradual API rollout needs to watch ([STEP-2421]).

## What

Two additive properties on `cli_step_activation`; no existing property changed.

- **`inventory_source`** — `steplib_api` or `steplib`, from `activatedStep.ActivationInventorySource` (new in stepman v0.24.2). Omitted for git and path refs, which have no inventory. stepman sets it before any early return, so failed activations stay attributable too.
- **`step_execution_id`** — already sent by `cli_toolkit_prepare`, so the two can be joined for one step execution. That join separates "slow to activate" from "slow to compile". Already present in `activateAndRunStep`; threaded one level into `activateStep`.

Requires [data-events#110] (BigQuery columns) — merged, and it had to land first: the analytics service flattens properties into columns, and a mismatch drops the whole event.

## Tests

`analytics/tracker_test.go` had no activation-event coverage; it now asserts the emitted props map for API, legacy, failed, and path-ref activations, including that `inventory_source` is absent in the last case.

`go build ./...`, `go vet ./...`, `go test ./analytics/... ./cli/... ./toolprovider/...` pass, plus `go vet -tags linux_and_mac ./...` in `integrationtests/`.

## Note for review

`SendStepActivationEvent` is now at seven parameters. The follow-up in this series (step source origin, precompiled outcome, retry counters) converts it to a typed properties struct — matching `step_started`/`analytics.StepInfo` — rather than growing the list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[STEP-2421]: https://bitrise.atlassian.net/browse/STEP-2421
[data-events#110]: https://github.com/bitrise-io/data-events/pull/110
