### PR TITLE
Let a build raise the env var size limits before it starts

### DIFF
--- a/cli/env_var_limit_override_test.go
+++ b/cli/env_var_limit_override_test.go
@@ -57,6 +57,48 @@ func TestApplyEnvVarLimitOverrides(t *testing.T) {
 			environments: []envmanModels.EnvironmentItemModel{{key: ""}},
 			want:         "512",
 		},
+		{
+			name: "valid app env overrides valid secret",
+			environments: []envmanModels.EnvironmentItemModel{
+				{key: "512"},
+				{key: "1024"},
+			},
+			want: "1024",
+		},
+		{
+			name: "invalid app env does not discard a valid secret",
+			environments: []envmanModels.EnvironmentItemModel{
+				{key: "512"},
+				{key: "not-a-number"},
+			},
+			want: "512",
+		},
+		{
+			name:       "invalid app env does not discard a valid secret, process env set",
+			processEnv: "256",
+			environments: []envmanModels.EnvironmentItemModel{
+				{key: "512"},
+				{key: "-1"},
+			},
+			want: "512",
+		},
+		{
+			name: "invalid secret is skipped in favor of a valid app env",
+			environments: []envmanModels.EnvironmentItemModel{
+				{key: "not-a-number"},
+				{key: "1024"},
+			},
+			want: "1024",
+		},
+		{
+			name:       "all overrides invalid, process env stands",
+			processEnv: "256",
+			environments: []envmanModels.EnvironmentItemModel{
+				{key: "not-a-number"},
+				{key: "-5"},
+			},
+			want: "256",
+		},
 	}
 
 	for _, tt := range tests {

--- a/cli/env_var_limit_override_test.go
+++ b/cli/env_var_limit_override_test.go
@@ -1,0 +1,76 @@
+package cli
+
+import (
+	"os"
+	"testing"
+
+	"github.com/bitrise-io/bitrise/v2/log"
+	"github.com/bitrise-io/envman/v2/envman"
+	envmanModels "github.com/bitrise-io/envman/v2/models"
+	"github.com/stretchr/testify/require"
+)
+
+func TestApplyEnvVarLimitOverrides(t *testing.T) {
+	runner := WorkflowRunner{logger: log.NewLogger(log.GetGlobalLoggerOpts())}
+	key := envman.EnvListBytesLimitInKBEnvKey
+
+	tests := []struct {
+		name         string
+		processEnv   string
+		environments []envmanModels.EnvironmentItemModel
+		want         string
+	}{
+		{
+			name:         "app env sets the override",
+			environments: []envmanModels.EnvironmentItemModel{{key: "1024"}},
+			want:         "1024",
+		},
+		{
+			name:       "app env wins over process env",
+			processEnv: "512",
+			environments: []envmanModels.EnvironmentItemModel{
+				{"UNRELATED": "x"},
+				{key: "1024"},
+			},
+			want: "1024",
+		},
+		{
+			name:         "process env is left untouched when no build env sets it",
+			processEnv:   "512",
+			environments: []envmanModels.EnvironmentItemModel{{"UNRELATED": "x"}},
+			want:         "512",
+		},
+		{
+			name:         "invalid build env is skipped, process env stands",
+			processEnv:   "512",
+			environments: []envmanModels.EnvironmentItemModel{{key: "not-a-number"}},
+			want:         "512",
+		},
+		{
+			name:         "negative build env is skipped",
+			environments: []envmanModels.EnvironmentItemModel{{key: "-1"}},
+			want:         "",
+		},
+		{
+			name:         "empty build env value does not override process env",
+			processEnv:   "512",
+			environments: []envmanModels.EnvironmentItemModel{{key: ""}},
+			want:         "512",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.processEnv != "" {
+				require.NoError(t, os.Setenv(key, tt.processEnv))
+			} else {
+				require.NoError(t, os.Unsetenv(key))
+			}
+			t.Cleanup(func() { require.NoError(t, os.Unsetenv(key)) })
+
+			runner.applyEnvVarLimitOverrides(tt.environments)
+
+			require.Equal(t, tt.want, os.Getenv(key))
+		})
+	}
+}

--- a/cli/run.go
+++ b/cli/run.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/signal"
 	"sort"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -23,6 +24,7 @@ import (
 	"github.com/bitrise-io/bitrise/v2/plugins"
 	"github.com/bitrise-io/bitrise/v2/toolprovider"
 	"github.com/bitrise-io/bitrise/v2/tools"
+	"github.com/bitrise-io/envman/v2/envman"
 	envmanModels "github.com/bitrise-io/envman/v2/models"
 	"github.com/bitrise-io/go-utils/colorstring"
 	coreanalytics "github.com/bitrise-io/go-utils/v2/analytics"
@@ -259,7 +261,12 @@ func (r WorkflowRunner) runWorkflows() (models.BuildRunResultsModel, error) {
 		targetWorkflow.Title = r.config.Workflow
 	}
 
+	// App level environment
+	environments := append(r.config.Secrets, r.config.Config.App.Environments...)
+
 	// Envman setup
+	r.applyEnvVarLimitOverrides(environments)
+
 	if err := os.Setenv(configs.EnvstorePathEnvKey, configs.OutputEnvstorePath); err != nil {
 		return models.BuildRunResultsModel{}, fmt.Errorf("failed to set %s env: %w", configs.EnvstorePathEnvKey, err)
 	}
@@ -271,9 +278,6 @@ func (r WorkflowRunner) runWorkflows() (models.BuildRunResultsModel, error) {
 	if err := tools.EnvmanInit(configs.OutputEnvstorePath, false); err != nil {
 		return models.BuildRunResultsModel{}, fmt.Errorf("failed to run envman init: %w", err)
 	}
-
-	// App level environment
-	environments := append(r.config.Secrets, r.config.Config.App.Environments...)
 
 	if err := os.Setenv("BITRISE_TRIGGERED_WORKFLOW_ID", r.config.Workflow); err != nil {
 		return models.BuildRunResultsModel{}, fmt.Errorf("failed to set BITRISE_TRIGGERED_WORKFLOW_ID env: %w", err)
@@ -365,6 +369,45 @@ func (r WorkflowRunner) runWorkflows() (models.BuildRunResultsModel, error) {
 	}
 
 	return buildRunResults, nil
+}
+
+// applyEnvVarLimitOverrides promotes an env size limit configured through a
+// build env (inventory secret or app env) into the process environment, where
+// envman reads it before the first `envman add`. This is the only point a build
+// can raise the limit from: a script step cannot, because the list-size check
+// runs while preparing that step's own environment, so a build already oversized
+// on its first step could never lift the limit from inside the run.
+//
+// Precedence is process env < secret < app env; an invalid value is skipped so
+// it falls back to whatever envman would otherwise use.
+func (r WorkflowRunner) applyEnvVarLimitOverrides(environments []envmanModels.EnvironmentItemModel) {
+	values := map[string]string{
+		envman.EnvBytesLimitInKBEnvKey:     os.Getenv(envman.EnvBytesLimitInKBEnvKey),
+		envman.EnvListBytesLimitInKBEnvKey: os.Getenv(envman.EnvListBytesLimitInKBEnvKey),
+	}
+
+	for _, env := range environments {
+		key, value, err := env.GetKeyValuePair()
+		if err != nil {
+			continue
+		}
+		if _, ok := values[key]; ok && value != "" {
+			values[key] = value
+		}
+	}
+
+	for key, value := range values {
+		if value == "" {
+			continue
+		}
+		if limit, err := strconv.Atoi(value); err != nil || limit < 0 {
+			r.logger.Warnf("Ignoring invalid %s value %q: must be a non-negative integer", key, value)
+			continue
+		}
+		if err := os.Setenv(key, value); err != nil {
+			r.logger.Warnf("Failed to set %s: %s", key, err)
+		}
+	}
 }
 
 func processArgs(cmd *cobra.Command, args []string) (*RunConfig, error) {

--- a/cli/run.go
+++ b/cli/run.go
@@ -378,32 +378,39 @@ func (r WorkflowRunner) runWorkflows() (models.BuildRunResultsModel, error) {
 // runs while preparing that step's own environment, so a build already oversized
 // on its first step could never lift the limit from inside the run.
 //
-// Precedence is process env < secret < app env; an invalid value is skipped so
-// it falls back to whatever envman would otherwise use.
+// Precedence is process env < secret < app env; the highest-precedence valid
+// value wins. Invalid values are skipped as they are considered, so a malformed
+// higher-precedence value never discards a valid lower-precedence one.
 func (r WorkflowRunner) applyEnvVarLimitOverrides(environments []envmanModels.EnvironmentItemModel) {
-	values := map[string]string{
-		envman.EnvBytesLimitInKBEnvKey:     os.Getenv(envman.EnvBytesLimitInKBEnvKey),
-		envman.EnvListBytesLimitInKBEnvKey: os.Getenv(envman.EnvListBytesLimitInKBEnvKey),
+	targets := map[string]struct{}{
+		envman.EnvBytesLimitInKBEnvKey:     {},
+		envman.EnvListBytesLimitInKBEnvKey: {},
+	}
+	resolved := map[string]string{}
+
+	consider := func(key, value string) {
+		if _, ok := targets[key]; !ok || value == "" {
+			return
+		}
+		if limit, err := strconv.Atoi(value); err != nil || limit < 0 {
+			r.logger.Warnf("Ignoring invalid %s value %q: must be a non-negative integer", key, value)
+			return
+		}
+		resolved[key] = value
 	}
 
+	for key := range targets {
+		consider(key, os.Getenv(key))
+	}
 	for _, env := range environments {
 		key, value, err := env.GetKeyValuePair()
 		if err != nil {
 			continue
 		}
-		if _, ok := values[key]; ok && value != "" {
-			values[key] = value
-		}
+		consider(key, value)
 	}
 
-	for key, value := range values {
-		if value == "" {
-			continue
-		}
-		if limit, err := strconv.Atoi(value); err != nil || limit < 0 {
-			r.logger.Warnf("Ignoring invalid %s value %q: must be a non-negative integer", key, value)
-			continue
-		}
+	for key, value := range resolved {
 		if err := os.Setenv(key, value); err != nil {
 			r.logger.Warnf("Failed to set %s: %s", key, err)
 		}

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	al.essio.dev/pkg/shellescape v1.6.0
 	github.com/Masterminds/semver/v3 v3.4.0
 	github.com/bitrise-io/colorstring v0.0.0-20180614154802-a8cd70115192
-	github.com/bitrise-io/envman/v2 v2.6.2
+	github.com/bitrise-io/envman/v2 v2.6.3-0.20260805112420-14318fa14a78
 	github.com/bitrise-io/go-steputils/v2 v2.0.0-alpha.44
 	github.com/bitrise-io/go-utils v1.0.15
 	github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.36

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	al.essio.dev/pkg/shellescape v1.6.0
 	github.com/Masterminds/semver/v3 v3.4.0
 	github.com/bitrise-io/colorstring v0.0.0-20180614154802-a8cd70115192
-	github.com/bitrise-io/envman/v2 v2.6.3-0.20260805112420-14318fa14a78
+	github.com/bitrise-io/envman/v2 v2.7.0
 	github.com/bitrise-io/go-steputils/v2 v2.0.0-alpha.44
 	github.com/bitrise-io/go-utils v1.0.15
 	github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.36

--- a/go.sum
+++ b/go.sum
@@ -18,8 +18,8 @@ github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPd
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/bitrise-io/colorstring v0.0.0-20180614154802-a8cd70115192 h1:vSHYT6kCL/iOT9BVuUPm0tVcbW57r5zldLWg0aB7qbQ=
 github.com/bitrise-io/colorstring v0.0.0-20180614154802-a8cd70115192/go.mod h1:CIHVcxZUvsG99XUJV6JlR7okNsMMGY81jMvPC20W+O0=
-github.com/bitrise-io/envman/v2 v2.6.3-0.20260805112420-14318fa14a78 h1:pRJuAIDypnGnFIggsVUCwtt2sjl7ikKHaytM1yA4A4s=
-github.com/bitrise-io/envman/v2 v2.6.3-0.20260805112420-14318fa14a78/go.mod h1:FuWPjEk053wT3POPxj8IuyeVv7chbh20o3s2zcIXLvw=
+github.com/bitrise-io/envman/v2 v2.7.0 h1:6C/a6jXAJ0RRPQ3sdxbdm417W86Y/74xUQ3ifE0C/D4=
+github.com/bitrise-io/envman/v2 v2.7.0/go.mod h1:FuWPjEk053wT3POPxj8IuyeVv7chbh20o3s2zcIXLvw=
 github.com/bitrise-io/go-steputils/v2 v2.0.0-alpha.44 h1:EXclFI+XfxxcsRZlly3WsYJwph/6BwJdhF7JZ9bde2M=
 github.com/bitrise-io/go-steputils/v2 v2.0.0-alpha.44/go.mod h1:i72XgHIZPEZtPPQLWy2cP86MaImo37nlQRhX1HCKi7Q=
 github.com/bitrise-io/go-utils v1.0.15 h1:KRQjNiPrkxBRM6G5fQy05v0p0r8wycWfKVb+Ko+Vtg0=

--- a/go.sum
+++ b/go.sum
@@ -18,8 +18,8 @@ github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPd
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/bitrise-io/colorstring v0.0.0-20180614154802-a8cd70115192 h1:vSHYT6kCL/iOT9BVuUPm0tVcbW57r5zldLWg0aB7qbQ=
 github.com/bitrise-io/colorstring v0.0.0-20180614154802-a8cd70115192/go.mod h1:CIHVcxZUvsG99XUJV6JlR7okNsMMGY81jMvPC20W+O0=
-github.com/bitrise-io/envman/v2 v2.6.2 h1:51N8ujA4ies4m/4k2sm8DwF1TIbRz6h7CkpKz0UNMXc=
-github.com/bitrise-io/envman/v2 v2.6.2/go.mod h1:JJjnW87+zJj0Ft4QxuouiIJ40Ir8ZYQ8T3wVnAcpvW0=
+github.com/bitrise-io/envman/v2 v2.6.3-0.20260805112420-14318fa14a78 h1:pRJuAIDypnGnFIggsVUCwtt2sjl7ikKHaytM1yA4A4s=
+github.com/bitrise-io/envman/v2 v2.6.3-0.20260805112420-14318fa14a78/go.mod h1:FuWPjEk053wT3POPxj8IuyeVv7chbh20o3s2zcIXLvw=
 github.com/bitrise-io/go-steputils/v2 v2.0.0-alpha.44 h1:EXclFI+XfxxcsRZlly3WsYJwph/6BwJdhF7JZ9bde2M=
 github.com/bitrise-io/go-steputils/v2 v2.0.0-alpha.44/go.mod h1:i72XgHIZPEZtPPQLWy2cP86MaImo37nlQRhX1HCKi7Q=
 github.com/bitrise-io/go-utils v1.0.15 h1:KRQjNiPrkxBRM6G5fQy05v0p0r8wycWfKVb+Ko+Vtg0=

--- a/integrationtests/go.mod
+++ b/integrationtests/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/ProtonMail/go-crypto v1.1.6 // indirect
 	github.com/bitrise-io/colorstring v0.0.0-20180614154802-a8cd70115192 // indirect
-	github.com/bitrise-io/envman/v2 v2.6.2 // indirect
+	github.com/bitrise-io/envman/v2 v2.7.0 // indirect
 	github.com/bitrise-io/go-steputils/v2 v2.0.0-alpha.44 // indirect
 	github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.36 // indirect
 	github.com/bitrise-io/goinp v0.0.0-20240103152431-054ed78518ef // indirect

--- a/integrationtests/go.sum
+++ b/integrationtests/go.sum
@@ -18,8 +18,8 @@ github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPd
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/bitrise-io/colorstring v0.0.0-20180614154802-a8cd70115192 h1:vSHYT6kCL/iOT9BVuUPm0tVcbW57r5zldLWg0aB7qbQ=
 github.com/bitrise-io/colorstring v0.0.0-20180614154802-a8cd70115192/go.mod h1:CIHVcxZUvsG99XUJV6JlR7okNsMMGY81jMvPC20W+O0=
-github.com/bitrise-io/envman/v2 v2.6.2 h1:51N8ujA4ies4m/4k2sm8DwF1TIbRz6h7CkpKz0UNMXc=
-github.com/bitrise-io/envman/v2 v2.6.2/go.mod h1:JJjnW87+zJj0Ft4QxuouiIJ40Ir8ZYQ8T3wVnAcpvW0=
+github.com/bitrise-io/envman/v2 v2.7.0 h1:6C/a6jXAJ0RRPQ3sdxbdm417W86Y/74xUQ3ifE0C/D4=
+github.com/bitrise-io/envman/v2 v2.7.0/go.mod h1:FuWPjEk053wT3POPxj8IuyeVv7chbh20o3s2zcIXLvw=
 github.com/bitrise-io/go-steputils/v2 v2.0.0-alpha.44 h1:EXclFI+XfxxcsRZlly3WsYJwph/6BwJdhF7JZ9bde2M=
 github.com/bitrise-io/go-steputils/v2 v2.0.0-alpha.44/go.mod h1:i72XgHIZPEZtPPQLWy2cP86MaImo37nlQRhX1HCKi7Q=
 github.com/bitrise-io/go-utils v1.0.15 h1:KRQjNiPrkxBRM6G5fQy05v0p0r8wycWfKVb+Ko+Vtg0=

--- a/vendor/github.com/bitrise-io/envman/v2/envman/configs.go
+++ b/vendor/github.com/bitrise-io/envman/v2/envman/configs.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path"
+	"strconv"
 
 	"github.com/bitrise-io/go-utils/fileutil"
 	"github.com/bitrise-io/go-utils/pathutil"
@@ -13,6 +14,14 @@ const (
 	envmanConfigFileName         = "configs.json"
 	defaultEnvBytesLimitInKB     = 256
 	defaultEnvListBytesLimitInKB = 256
+
+	// EnvBytesLimitInKBEnvKey and EnvListBytesLimitInKBEnvKey override the
+	// per-value and list-size limits at the process level, taking precedence
+	// over configs.json. This lets the limit be raised before the first
+	// `envman add`, which a script step cannot do because the check runs while
+	// preparing that step's own environment.
+	EnvBytesLimitInKBEnvKey     = "ENVMAN_ENV_BYTES_LIMIT_IN_KB"
+	EnvListBytesLimitInKBEnvKey = "ENVMAN_ENV_LIST_BYTES_LIMIT_IN_KB"
 )
 
 // ConfigsModel ...
@@ -47,44 +56,70 @@ func createDefaultConfigsModel() ConfigsModel {
 	}
 }
 
-// GetConfigs ...
+// GetConfigs resolves the env var limits with default < configs.json < process
+// env var precedence. A malformed or negative env override is ignored so a bad
+// value never breaks a build; the caller setting it is expected to validate.
 func GetConfigs() (ConfigsModel, error) {
 	configPth := getEnvmanConfigsFilePath()
-	defaultConfigs := createDefaultConfigsModel()
+	configs := createDefaultConfigsModel()
 
-	if isExist, err := pathutil.IsPathExists(configPth); err != nil {
-		return ConfigsModel{}, err
-	} else if !isExist {
-		return defaultConfigs, nil
-	}
-
-	bytes, err := fileutil.ReadBytesFromFile(configPth)
+	isExist, err := pathutil.IsPathExists(configPth)
 	if err != nil {
 		return ConfigsModel{}, err
 	}
 
-	type ConfigsFileMode struct {
-		EnvBytesLimitInKB     *int `json:"env_bytes_limit_in_kb,omitempty"`
-		EnvListBytesLimitInKB *int `json:"env_list_bytes_limit_in_kb,omitempty"`
+	if isExist {
+		bytes, err := fileutil.ReadBytesFromFile(configPth)
+		if err != nil {
+			return ConfigsModel{}, err
+		}
+
+		type ConfigsFileMode struct {
+			EnvBytesLimitInKB     *int `json:"env_bytes_limit_in_kb,omitempty"`
+			EnvListBytesLimitInKB *int `json:"env_list_bytes_limit_in_kb,omitempty"`
+		}
+
+		var userConfigs ConfigsFileMode
+		if err := json.Unmarshal(bytes, &userConfigs); err != nil {
+			return ConfigsModel{}, err
+		}
+
+		if userConfigs.EnvBytesLimitInKB != nil {
+			configs.EnvBytesLimitInKB = *userConfigs.EnvBytesLimitInKB
+		}
+		if userConfigs.EnvListBytesLimitInKB != nil {
+			configs.EnvListBytesLimitInKB = *userConfigs.EnvListBytesLimitInKB
+		}
 	}
 
-	var userConfigs ConfigsFileMode
-	if err := json.Unmarshal(bytes, &userConfigs); err != nil {
-		return ConfigsModel{}, err
+	if limit, ok := envLimitOverride(EnvBytesLimitInKBEnvKey); ok {
+		configs.EnvBytesLimitInKB = limit
+	}
+	if limit, ok := envLimitOverride(EnvListBytesLimitInKBEnvKey); ok {
+		configs.EnvListBytesLimitInKB = limit
 	}
 
-	if userConfigs.EnvBytesLimitInKB != nil {
-		defaultConfigs.EnvBytesLimitInKB = *userConfigs.EnvBytesLimitInKB
-	}
-	if userConfigs.EnvListBytesLimitInKB != nil {
-		defaultConfigs.EnvListBytesLimitInKB = *userConfigs.EnvListBytesLimitInKB
-	}
+	return configs, nil
+}
 
-	return defaultConfigs, nil
+// envLimitOverride reads a limit from a process env var, treating a value of 0
+// as "no limit" (matching validateEnv). Empty, non-integer, or negative values
+// return ok=false so the file/default value stands.
+func envLimitOverride(key string) (int, bool) {
+	value := os.Getenv(key)
+	if value == "" {
+		return 0, false
+	}
+	limit, err := strconv.Atoi(value)
+	if err != nil || limit < 0 {
+		return 0, false
+	}
+	return limit, true
 }
 
 // saveConfigs ...
-//  only used for unit testing at the moment
+//
+//	only used for unit testing at the moment
 func saveConfigs(configModel ConfigsModel) error {
 	if err := ensureEnvmanConfigDirExists(); err != nil {
 		return err

--- a/vendor/github.com/bitrise-io/envman/v2/version/version.go
+++ b/vendor/github.com/bitrise-io/envman/v2/version/version.go
@@ -1,3 +1,3 @@
 package version
 
-var Version = "2.6.2"
+var Version = "2.7.0"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -41,8 +41,8 @@ github.com/ProtonMail/go-crypto/openpgp/x448
 # github.com/bitrise-io/colorstring v0.0.0-20180614154802-a8cd70115192
 ## explicit
 github.com/bitrise-io/colorstring
-# github.com/bitrise-io/envman/v2 v2.6.2
-## explicit; go 1.25.3
+# github.com/bitrise-io/envman/v2 v2.6.3-0.20260805112420-14318fa14a78
+## explicit; go 1.25
 github.com/bitrise-io/envman/v2/cli
 github.com/bitrise-io/envman/v2/env
 github.com/bitrise-io/envman/v2/envman

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -41,7 +41,7 @@ github.com/ProtonMail/go-crypto/openpgp/x448
 # github.com/bitrise-io/colorstring v0.0.0-20180614154802-a8cd70115192
 ## explicit
 github.com/bitrise-io/colorstring
-# github.com/bitrise-io/envman/v2 v2.6.3-0.20260805112420-14318fa14a78
+# github.com/bitrise-io/envman/v2 v2.7.0
 ## explicit; go 1.25
 github.com/bitrise-io/envman/v2/cli
 github.com/bitrise-io/envman/v2/env


### PR DESCRIPTION
## Why

Builds fail when the assembled env var list crosses envman's list-size limit (default 256 KB). The workflow-level mitigation, a script step that raises the limit, cannot help: the list-size check runs while envman prepares that very step's own environment, so a build that is already oversized on its first step has no way to lift the limit from inside the run.

The only value that can take effect from step 0 is one set before the CLI starts adding envs. envman v2.7.0 adds process env var overrides (`default < configs.json < process env`) for both limits. This PR is the CLI half: it lets a build supply that value through a secret or `app.envs` entry, and promotes it into the process environment before the first `envman add`.

## What

At the start of the envman setup in `runWorkflows`, `applyEnvVarLimitOverrides` scans the assembled app-level envs (secrets + `app.envs`) in a single pass for `ENVMAN_ENV_BYTES_LIMIT_IN_KB` and `ENVMAN_ENV_LIST_BYTES_LIMIT_IN_KB`, resolves each with `process env < secret < app env` precedence, and `os.Setenv`s the result so envman reads it from step 0.

DEN can set the same var at the process level directly; both paths funnel through the one env var envman reads.

Fail-soft: a malformed or negative value is warned about and skipped, so a bad value never breaks a build. A value of `0` disables the limit (unlimited), matching envman's existing `validateEnv` treatment of a `0` limit.

## Testing

- `TestApplyEnvVarLimitOverrides`: precedence and fail-soft cases.
- Manual, against a ~293 KB `app.envs` config: without an override the build fails with `env var list is too large (292.96875 KB)`; with the override via `app.envs`, via a process env (DEN-style), or set to `0`, the build succeeds; a garbage value warns and falls back to the default limit.
