### PR TITLE
v3 prep: api command

### DIFF
--- a/_docs/v3-breaking-changes.md
+++ b/_docs/v3-breaking-changes.md
@@ -70,7 +70,8 @@ default**. A non-bool env value is now an error.
 
 The commands were regrouped by use case under `local`, `yml`, and `step` parent
 commands. The old top-level names continue to work as hidden aliases, so existing
-scripts keep running — only `trigger-check` was removed outright.
+scripts keep running: `trigger-check` was the only command removed outright, and
+`validate` the only one whose behavior changed.
 
 ### `trigger-check` removed
 
@@ -106,36 +107,18 @@ scripts keep running — only `trigger-check` was removed outright.
   *Migrate:* no action required for existing scripts. New usage and documentation
   should prefer the grouped paths.
 
-## Cloud resource-management commands
+### `yml validate` updated
 
-New commands were added under `auth`, `stack`, `user`, and `yml`, plus new
-subcommands under `step`, to manage cloud-side resources without leaving the CLI.
-
-### `auth`
-
-- **`bitrise auth login`, `logout`, and `status` are new.** Authenticate with a
-  personal access token, OAuth (browser flow), or email/password. Credentials
-  are stored at `~/.config/bitrise/cli/auth.yaml`.
-
-### `stack`
-
-- **`bitrise stack list` is new.** Lists the build stacks available to your
-  account/workspace.
-
-### `yml`
-
-- **`bitrise yml get` and `update` are new.** Read/write the bitrise.yml stored
-  on Bitrise for a given app (`--app`, or set `BITRISE_APP_ID`).
 - **`validate` now validates online when you're authenticated, instead of locally.**
-  When an access token resolves (from `bitrise auth login` or `$BITRISE_TOKEN`), the
-  config is submitted to Bitrise and the local schema check is skipped entirely — the
-  API runs the same schema checks plus app-specific ones. With no token, or when the
-  online attempt can't be completed (network, 5xx, timeout), validation falls back to
-  the local check and reports the reason as a warning. Because the old top-level
-  `bitrise validate` is an alias of this command, existing invocations change behavior
-  as soon as a token is present — including picking up any difference between the
-  server's messages and the local ones. When validation happens online the command
-  says so on stderr and names the escape hatch, and the result gains a `source`
+  When an access token resolves (from the new `bitrise auth login` command or
+  `$BITRISE_TOKEN`), the config is submitted to Bitrise and the local schema check is
+  skipped entirely — the API runs the same schema checks plus app-specific ones. With
+  no token, or when the online attempt can't be completed (network, 5xx, timeout),
+  validation falls back to the local check and reports the reason as a warning. Because
+  the old top-level `bitrise validate` is an alias of this command, existing invocations
+  change behavior as soon as a token is present — including picking up any difference
+  between the server's messages and the local ones. When validation happens online the
+  command says so on stderr and names the escape hatch, and the result gains a `source`
   field under `--format json`; a local result carries no marker and its output on
   stdout is unchanged from v2. Two flags control it, and they cannot be combined:
   the new `--offline` forces the local-only check, and the optional `--app` (or
@@ -143,22 +126,6 @@ subcommands under `step`, to manage cloud-side resources without leaving the CLI
   pools).
   *Migrate:* pass `--offline` anywhere you depend on local validation or on its exact
   output — in particular scripts and tests that assert on validation messages.
-
-### `step`
-
-- **`bitrise step search` and `inputs` are new.** Search the steplib and
-  inspect a step's declared inputs.
-
-### `user`
-
-- **`bitrise user create` and `me` are new.** `create` registers a new Bitrise
-  account by email and password; `me` shows the profile of the currently
-  authenticated user.
-
-All of these require a Bitrise access token (`bitrise auth login`, or
-`$BITRISE_TOKEN`) — except `user create`, which registers the account you then log
-into. *Migrate:* no action required for the new commands, since they are additive.
-The one existing command whose behavior changed is `validate`, covered above.
 
 ## Config handling
 

--- a/analytics/analyticstest/tracker.go
+++ b/analytics/analyticstest/tracker.go
@@ -27,7 +27,7 @@ func (NoOpTracker) SendWorkflowFinished(extanalytics.Properties, bool)          
 func (NoOpTracker) SendCommandInfo(string, string, []string)                            {}
 func (NoOpTracker) SendToolSetupEvent(string, provider.ToolRequest, provider.ToolInstallResult, bool, time.Duration) {
 }
-func (NoOpTracker) SendStepActivationEvent(activator.ActivationType, string, bool, time.Duration, bool) {
+func (NoOpTracker) SendStepActivationEvent(string, activator.ActivationType, activator.ActivationInventorySource, string, bool, time.Duration, bool) {
 }
 func (NoOpTracker) SendToolkitPrepareEvent(string, string, string, string, toolkits.PrepareForStepRunResult, error) {
 }

--- a/cli/api/cmd.go
+++ b/cli/api/cmd.go
@@ -1,0 +1,199 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/bitrise-io/bitrise/v2/cli/cmdutil"
+	internalapi "github.com/bitrise-io/bitrise/v2/internal/api"
+)
+
+// NewCmd returns the `api` command: a generic, curl-like authenticated
+// passthrough to the Bitrise API. Unlike every other cloud command, it
+// deliberately does not support --format — the response body is always
+// printed as-is, so -f is free to mean --field here instead.
+func NewCmd() *cobra.Command {
+	var method string
+	var fields []string
+	var headers []string
+	var inputPath string
+	var all bool
+	var include bool
+
+	cmd := &cobra.Command{
+		Use:   "api PATH",
+		Short: "Make an authenticated request to the Bitrise API",
+		Long: `Make an authenticated HTTP request to the Bitrise API and print the response.
+
+PATH is resolved relative to the configured API base URL, or used verbatim
+if it's an absolute http(s):// URL. The response body goes to stdout, so it
+composes with tools like jq.
+
+--field pairs are sent as strings; use --input for bodies that need nesting
+or non-string values.`,
+		Example: `  bitrise api /me
+  bitrise api /apps -f sort_by=last_build_at --all | jq '.data[].title'
+  bitrise api "/apps/APP_ID/builds?limit=10"
+  bitrise api /apps/APP_ID/builds -X POST --input body.json
+  bitrise api -X DELETE /apps/APP_ID/builds/BUILD_ID -i`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cmdutil.LogCommandParameters(cmd)
+
+			kvFields, err := parseFields(fields)
+			if err != nil {
+				return err
+			}
+			header, err := parseHeaders(headers)
+			if err != nil {
+				return err
+			}
+
+			var body io.Reader
+			if inputPath != "" {
+				data, err := openInput(cmd.InOrStdin(), inputPath)
+				if err != nil {
+					return fmt.Errorf("read input: %w", err)
+				}
+				body = bytes.NewReader(data)
+			}
+
+			resolvedMethod := strings.ToUpper(method)
+			if resolvedMethod == "" {
+				resolvedMethod = http.MethodGet
+				if len(kvFields) > 0 || body != nil {
+					resolvedMethod = http.MethodPost
+				}
+			}
+
+			client, err := cmdutil.NewAPIClient(cmd)
+			if err != nil {
+				return err
+			}
+
+			resp, err := internalapi.NewService(client).Do(cmd.Context(), internalapi.Request{
+				Method:   resolvedMethod,
+				Path:     args[0],
+				Fields:   kvFields,
+				Headers:  header,
+				Body:     body,
+				Paginate: all,
+			})
+			if err != nil {
+				return err
+			}
+
+			if err := writeResponse(cmd.OutOrStdout(), resp, include); err != nil {
+				return err
+			}
+
+			if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+				return fmt.Errorf("bitrise API responded with HTTP %d", resp.StatusCode)
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVarP(&method, "method", "X", "", "HTTP method (default GET, or POST when a body is present)")
+	cmd.Flags().StringArrayVarP(&fields, "field", "f", nil, "key=value; query parameter for GET, JSON body field otherwise (may be repeated)")
+	cmd.Flags().StringArrayVarP(&headers, "header", "H", nil, `"Name: value"; adds or overrides a request header (may be repeated)`)
+	cmd.Flags().StringVar(&inputPath, "input", "", "path to a file for the request body, or - for stdin")
+	cmd.Flags().BoolVar(&all, "all", false, "follow cursor pagination and merge every page's data array (GET only)")
+	cmd.Flags().BoolVarP(&include, "include", "i", false, "print the response status and headers before the body")
+	cmd.MarkFlagsMutuallyExclusive("field", "input")
+
+	return cmd
+}
+
+// parseFields parses "key=value" flag values into KeyValue pairs.
+func parseFields(raw []string) ([]internalapi.KeyValue, error) {
+	fields := make([]internalapi.KeyValue, 0, len(raw))
+	for _, f := range raw {
+		key, value, ok := strings.Cut(f, "=")
+		if !ok || key == "" {
+			return nil, fmt.Errorf(`invalid --field %q: expected "key=value"`, f)
+		}
+		fields = append(fields, internalapi.KeyValue{Key: key, Value: value})
+	}
+	return fields, nil
+}
+
+// parseHeaders parses "Name: value" flag values into an http.Header.
+func parseHeaders(raw []string) (http.Header, error) {
+	header := http.Header{}
+	for _, h := range raw {
+		name, value, ok := strings.Cut(h, ":")
+		name = strings.TrimSpace(name)
+		if !ok || name == "" {
+			return nil, fmt.Errorf(`invalid --header %q: expected "Name: value"`, h)
+		}
+		header.Add(name, strings.TrimSpace(value))
+	}
+	return header, nil
+}
+
+// openInput reads the request body for --input: stdin when path is "-",
+// otherwise the file at path.
+func openInput(stdin io.Reader, path string) ([]byte, error) {
+	if path == "-" {
+		return io.ReadAll(stdin)
+	}
+	return os.ReadFile(path)
+}
+
+// writeResponse prints resp to w: optionally the status line and headers
+// (--include), then the body. A JSON body is indented only when w is a real
+// terminal; piped or redirected output keeps the API's own formatting so it
+// composes with tools like jq. A missing trailing newline is appended either
+// way, so a terminal prompt isn't left mid-line.
+func writeResponse(w io.Writer, resp internalapi.Response, include bool) error {
+	if include {
+		statusLine := fmt.Sprintf("HTTP %d", resp.StatusCode)
+		if text := http.StatusText(resp.StatusCode); text != "" {
+			statusLine += " " + text
+		}
+		if _, err := fmt.Fprintln(w, statusLine); err != nil {
+			return err
+		}
+		names := make([]string, 0, len(resp.Header))
+		for name := range resp.Header {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+		for _, name := range names {
+			for _, value := range resp.Header[name] {
+				if _, err := fmt.Fprintf(w, "%s: %s\n", name, value); err != nil {
+					return err
+				}
+			}
+		}
+		if _, err := fmt.Fprintln(w); err != nil {
+			return err
+		}
+	}
+
+	body := resp.Body
+	if strings.Contains(resp.Header.Get("Content-Type"), "json") && cmdutil.IsTerminalWriter(w) {
+		var pretty bytes.Buffer
+		if err := json.Indent(&pretty, body, "", "  "); err == nil {
+			body = pretty.Bytes()
+		}
+	}
+
+	if _, err := w.Write(body); err != nil {
+		return err
+	}
+	if len(body) > 0 && !bytes.HasSuffix(body, []byte("\n")) {
+		_, err := fmt.Fprintln(w)
+		return err
+	}
+	return nil
+}

--- a/cli/api/cmd_test.go
+++ b/cli/api/cmd_test.go
@@ -1,0 +1,206 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/bitrise-io/bitrise/v2/internal/auth"
+	"github.com/bitrise-io/bitrise/v2/internal/config"
+)
+
+func TestCmd_GetRawBodyPassthrough(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/me", r.URL.Path)
+		assert.Equal(t, "token test-token", r.Header.Get("Authorization"))
+		_, _ = w.Write([]byte(`{"data":{"username":"marton"}}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	cmd, out := newTestCmd(t, srv.URL)
+	require.NoError(t, cmd.RunE(cmd, []string{"/me"}))
+	assert.Equal(t, `{"data":{"username":"marton"}}`+"\n", out.String())
+}
+
+func TestCmd_IncludePrintsStatusAndHeaders(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("X-Test", "yes")
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	cmd, out := newTestCmd(t, srv.URL)
+	require.NoError(t, cmd.Flags().Set("include", "true"))
+	require.NoError(t, cmd.RunE(cmd, []string{"/me"}))
+
+	got := out.String()
+	assert.Contains(t, got, "HTTP 200 OK")
+	assert.Contains(t, got, "X-Test: yes")
+	assert.Contains(t, got, "{}")
+}
+
+func TestCmd_NonSuccessPrintsBodyAndErrors(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"message":"not found"}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	cmd, out := newTestCmd(t, srv.URL)
+	err := cmd.RunE(cmd, []string{"/missing"})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "404")
+	assert.Contains(t, out.String(), "not found")
+}
+
+func TestCmd_MethodDefaultsToPostWhenFieldsPresent(t *testing.T) {
+	var gotMethod string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	cmd, _ := newTestCmd(t, srv.URL)
+	require.NoError(t, cmd.Flags().Set("field", "title=My App"))
+	require.NoError(t, cmd.RunE(cmd, []string{"/apps"}))
+	assert.Equal(t, http.MethodPost, gotMethod)
+}
+
+func TestCmd_ExplicitMethodIsUpcased(t *testing.T) {
+	var gotMethod string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	cmd, _ := newTestCmd(t, srv.URL)
+	require.NoError(t, cmd.Flags().Set("method", "delete"))
+	require.NoError(t, cmd.RunE(cmd, []string{"/apps/APP_ID/builds/BUILD_ID"}))
+	assert.Equal(t, http.MethodDelete, gotMethod)
+}
+
+func TestCmd_InputFromFile(t *testing.T) {
+	var gotBody, gotContentType string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotContentType = r.Header.Get("Content-Type")
+		body, _ := io.ReadAll(r.Body)
+		gotBody = string(body)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	path := filepath.Join(t.TempDir(), "body.json")
+	require.NoError(t, os.WriteFile(path, []byte(`{"hook_info":{"type":"bitrise"}}`), 0600))
+
+	cmd, _ := newTestCmd(t, srv.URL)
+	require.NoError(t, cmd.Flags().Set("input", path))
+	require.NoError(t, cmd.RunE(cmd, []string{"/apps/APP_ID/builds"}))
+
+	assert.Equal(t, `{"hook_info":{"type":"bitrise"}}`, gotBody)
+	assert.Equal(t, "application/json", gotContentType)
+}
+
+func TestCmd_InputFromStdin(t *testing.T) {
+	var gotBody string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		gotBody = string(body)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	cmd, _ := newTestCmd(t, srv.URL)
+	cmd.SetIn(strings.NewReader(`{"from":"stdin"}`))
+	require.NoError(t, cmd.Flags().Set("input", "-"))
+	require.NoError(t, cmd.RunE(cmd, []string{"/apps"}))
+	assert.Equal(t, `{"from":"stdin"}`, gotBody)
+}
+
+func TestCmd_AllMergesPages(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("next") == "cursor2" {
+			_, _ = w.Write([]byte(`{"data":[2],"paging":{"next":""}}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"data":[1],"paging":{"next":"cursor2"}}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	cmd, out := newTestCmd(t, srv.URL)
+	require.NoError(t, cmd.Flags().Set("all", "true"))
+	require.NoError(t, cmd.RunE(cmd, []string{"/apps"}))
+
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(out.Bytes(), &got))
+	assert.Equal(t, []any{float64(1), float64(2)}, got["data"])
+}
+
+func TestCmd_FieldAndInputMutuallyExclusive(t *testing.T) {
+	cmd := NewCmd()
+	cmd.SetArgs([]string{"/apps", "--field", "a=b", "--input", "-"})
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "field")
+	assert.Contains(t, err.Error(), "input")
+}
+
+func TestCmd_RejectsMalformedFieldsAndHeaders(t *testing.T) {
+	cases := map[string]struct{ flag, value string }{
+		"field without separator": {flag: "field", value: "title"},
+		"field with empty key":    {flag: "field", value: "=value"},
+		"header without colon":    {flag: "header", value: "X-Test"},
+		"header with empty name":  {flag: "header", value: " : value"},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			cmd, _ := newTestCmd(t, "http://unused.invalid")
+			require.NoError(t, cmd.Flags().Set(tc.flag, tc.value))
+
+			err := cmd.RunE(cmd, []string{"/apps"})
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "--"+tc.flag)
+		})
+	}
+}
+
+func TestCmd_RequiresPathArg(t *testing.T) {
+	cmd := NewCmd()
+	cmd.SetArgs([]string{})
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+
+	assert.Error(t, cmd.Execute(), "PATH argument should be required")
+}
+
+// newTestCmd builds a NewCmd() wired to apiBaseURL, with its output captured
+// in the returned buffer.
+func newTestCmd(t *testing.T, apiBaseURL string) (*cobra.Command, *bytes.Buffer) {
+	t.Helper()
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	// An ambient BITRISE_TOKEN outranks the saved one in cmdutil.ResolveToken.
+	t.Setenv(auth.EnvToken, "")
+	require.NoError(t, auth.Save(auth.Auth{Token: "test-token"}))
+
+	cmd := NewCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	resolved := config.Resolve(config.Config{}, config.Config{}, config.Config{APIBaseURL: apiBaseURL})
+	cmd.SetContext(config.WithResolved(t.Context(), resolved))
+	return cmd, &out
+}

--- a/cli/cmdutil/secret.go
+++ b/cli/cmdutil/secret.go
@@ -4,30 +4,10 @@ import (
 	"bufio"
 	"fmt"
 	"io"
-	"os"
 	"strings"
 
 	"golang.org/x/term"
 )
-
-// terminalFd reports whether stream is an *os.File backed by a TTY. fd is
-// only meaningful when isTerminal is true.
-func terminalFd(stream any) (fd int, isTerminal bool) {
-	f, ok := stream.(*os.File)
-	if !ok {
-		return 0, false
-	}
-	fd = int(f.Fd()) // file descriptors are small ints, no overflow risk
-	return fd, term.IsTerminal(fd)
-}
-
-// IsTerminal reports whether r is an interactive terminal. Pipes and buffers
-// never are, so callers can pick an interactive default (e.g. browser login)
-// while keeping non-interactive stdin (CI, pipes) working.
-func IsTerminal(r io.Reader) bool {
-	_, ok := terminalFd(r)
-	return ok
-}
 
 // ReadTokenInput reads a token from in, trimming all surrounding whitespace
 // (tokens are forgiving of shell copy/paste artifacts). When fromStdin is

--- a/cli/cmdutil/secret_test.go
+++ b/cli/cmdutil/secret_test.go
@@ -2,29 +2,9 @@ package cmdutil
 
 import (
 	"bytes"
-	"os"
 	"strings"
 	"testing"
 )
-
-func TestIsTerminal_NonTerminalInputs(t *testing.T) {
-	if IsTerminal(nil) {
-		t.Error("IsTerminal(nil) should be false")
-	}
-	if IsTerminal(&bytes.Buffer{}) {
-		t.Error("IsTerminal(*bytes.Buffer) should be false")
-	}
-	// A regular file (not a TTY) is an *os.File, but term.IsTerminal is
-	// false → IsTerminal should still return false.
-	tmp, err := os.CreateTemp(t.TempDir(), "tty-test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() { _ = tmp.Close() })
-	if IsTerminal(tmp) {
-		t.Error("IsTerminal(regular *os.File) should be false")
-	}
-}
 
 func TestReadTokenInput_NonTerminalReadsLine(t *testing.T) {
 	in := strings.NewReader("  a-token-value  \nrest\n")

--- a/cli/cmdutil/terminal.go
+++ b/cli/cmdutil/terminal.go
@@ -1,0 +1,34 @@
+package cmdutil
+
+import (
+	"io"
+	"os"
+
+	"golang.org/x/term"
+)
+
+// terminalFd reports whether stream is an *os.File backed by a TTY. fd is
+// only meaningful when isTerminal is true.
+func terminalFd(stream any) (fd int, isTerminal bool) {
+	f, ok := stream.(*os.File)
+	if !ok {
+		return 0, false
+	}
+	fd = int(f.Fd()) // file descriptors are small ints, no overflow risk
+	return fd, term.IsTerminal(fd)
+}
+
+// IsTerminal reports whether r is an interactive terminal. Pipes and buffers
+// never are, so callers can pick an interactive default (e.g. browser login)
+// while keeping non-interactive stdin (CI, pipes) working.
+func IsTerminal(r io.Reader) bool {
+	_, ok := terminalFd(r)
+	return ok
+}
+
+// IsTerminalWriter reports whether w is an interactive terminal, e.g. for
+// gating pretty-printing so piped or redirected output isn't reformatted.
+func IsTerminalWriter(w io.Writer) bool {
+	_, ok := terminalFd(w)
+	return ok
+}

--- a/cli/cmdutil/terminal_test.go
+++ b/cli/cmdutil/terminal_test.go
@@ -1,0 +1,44 @@
+package cmdutil
+
+import (
+	"bytes"
+	"os"
+	"testing"
+)
+
+func TestIsTerminal_NonTerminalInputs(t *testing.T) {
+	if IsTerminal(nil) {
+		t.Error("IsTerminal(nil) should be false")
+	}
+	if IsTerminal(&bytes.Buffer{}) {
+		t.Error("IsTerminal(*bytes.Buffer) should be false")
+	}
+	// A regular file (not a TTY) is an *os.File, but term.IsTerminal is
+	// false → IsTerminal should still return false.
+	tmp := tempFile(t)
+	if IsTerminal(tmp) {
+		t.Error("IsTerminal(regular *os.File) should be false")
+	}
+}
+
+func TestIsTerminalWriter_NonTerminalOutputs(t *testing.T) {
+	if IsTerminalWriter(nil) {
+		t.Error("IsTerminalWriter(nil) should be false")
+	}
+	if IsTerminalWriter(&bytes.Buffer{}) {
+		t.Error("IsTerminalWriter(*bytes.Buffer) should be false")
+	}
+	if IsTerminalWriter(tempFile(t)) {
+		t.Error("IsTerminalWriter(regular *os.File) should be false")
+	}
+}
+
+func tempFile(t *testing.T) *os.File {
+	t.Helper()
+	f, err := os.CreateTemp(t.TempDir(), "tty-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = f.Close() })
+	return f
+}

--- a/cli/root.go
+++ b/cli/root.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/bitrise-io/bitrise/v2/cli/api"
 	"github.com/bitrise-io/bitrise/v2/cli/auth"
 	"github.com/bitrise-io/bitrise/v2/cli/cmdutil"
 	"github.com/bitrise-io/bitrise/v2/cli/local"
@@ -53,6 +54,7 @@ func newRootCommand() *cobra.Command {
 		auth.NewCmd(),
 		stack.NewCmd(),
 		user.NewCmd(),
+		api.NewCmd(),
 
 		versionCommand,
 		updateCommand,

--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -1,0 +1,205 @@
+// Package api holds the business-logic layer for the generic, curl-like
+// passthrough to the Bitrise API exposed by the `api` command.
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+
+	"github.com/bitrise-io/bitrise/v2/internal/bitriseapi"
+)
+
+// KeyValue is one --field key=value pair.
+type KeyValue struct {
+	Key   string
+	Value string
+}
+
+// Request describes one `api` command invocation.
+type Request struct {
+	Method   string
+	Path     string
+	Fields   []KeyValue
+	Headers  http.Header
+	Body     io.Reader
+	Paginate bool
+}
+
+// Response is the result of a Request, ready for the cmd layer to print.
+type Response struct {
+	StatusCode int
+	Header     http.Header
+	Body       []byte
+}
+
+// Service exposes the raw API passthrough to the cmd layer.
+type Service struct {
+	client *bitriseapi.Client
+}
+
+// NewService returns a Service backed by the given API client.
+func NewService(client *bitriseapi.Client) *Service {
+	return &Service{client: client}
+}
+
+// Do executes req. Fields become a query string for GET requests, or a JSON
+// body for anything else. Every non-GET body — whether built from Fields or
+// passed through from --input — gets a JSON Content-Type unless the caller set
+// one, since the API won't parse a body sent without it. When Paginate is set,
+// the request must be a GET; pages are followed via the "paging.next" cursor
+// and their "data" arrays merged into one response.
+func (s *Service) Do(ctx context.Context, req Request) (Response, error) {
+	header := cloneHeader(req.Headers)
+	isGet := req.Method == http.MethodGet
+
+	var query url.Values
+	body := req.Body
+
+	if len(req.Fields) > 0 {
+		if isGet {
+			query = fieldsToQuery(req.Fields)
+		} else {
+			data, err := json.Marshal(fieldsToMap(req.Fields))
+			if err != nil {
+				return Response{}, fmt.Errorf("encode fields: %w", err)
+			}
+			body = bytes.NewReader(data)
+		}
+	}
+	if body != nil && !isGet && header.Get("Content-Type") == "" {
+		header.Set("Content-Type", "application/json")
+	}
+
+	if req.Paginate {
+		if !isGet {
+			return Response{}, fmt.Errorf("--all is only supported for GET requests")
+		}
+		if body != nil {
+			return Response{}, fmt.Errorf("--all cannot be combined with --input")
+		}
+		return s.paginate(ctx, req.Method, req.Path, query, header)
+	}
+
+	raw, err := s.client.RawRequest(ctx, req.Method, req.Path, query, header, body)
+	if err != nil {
+		return Response{}, err
+	}
+	return asResponse(raw), nil
+}
+
+// pagedBody is the minimal shape of a Bitrise cursor-paginated list response.
+type pagedBody struct {
+	Data   json.RawMessage `json:"data"`
+	Paging struct {
+		Next string `json:"next"`
+	} `json:"paging"`
+}
+
+// paginate follows the "paging.next" cursor, merging every page's "data"
+// array into one {"data": [...]} envelope. A page that isn't a paginated
+// list (no "data" array) or is non-2xx stops the walk, and that page's raw
+// response is returned unchanged rather than the merge — the caller can't
+// tell the difference between "no more data" and "this wasn't a list" from
+// a merged envelope alone.
+//
+// A cursor that repeats means the walk isn't advancing, so it stops with an
+// error instead of looping forever: the API may be echoing the cursor back, or
+// PATH already carried a "next" query parameter, which is merged alongside the
+// one set here and takes precedence server-side.
+//
+// The merged response carries the last page's status and headers, so --include
+// reports what the API actually sent (rate limits, request IDs) rather than a
+// synthesized status line — minus the headers that describe that one page's
+// body, which the merged body would contradict.
+func (s *Service) paginate(ctx context.Context, method, path string, query url.Values, header http.Header) (Response, error) {
+	merged := []json.RawMessage{}
+	seen := map[string]bool{}
+	nextQuery := cloneValues(query)
+	var lastPage *bitriseapi.RawResponse
+
+	for {
+		raw, err := s.client.RawRequest(ctx, method, path, nextQuery, header, nil)
+		if err != nil {
+			return Response{}, err
+		}
+		lastPage = raw
+
+		if raw.StatusCode < 200 || raw.StatusCode >= 300 {
+			return asResponse(raw), nil
+		}
+
+		var page pagedBody
+		if err := json.Unmarshal(raw.Body, &page); err != nil || page.Data == nil {
+			return asResponse(raw), nil
+		}
+		var items []json.RawMessage
+		if err := json.Unmarshal(page.Data, &items); err != nil {
+			return asResponse(raw), nil
+		}
+		merged = append(merged, items...)
+
+		if page.Paging.Next == "" {
+			break
+		}
+		if seen[page.Paging.Next] {
+			return Response{}, fmt.Errorf("pagination stalled: the API returned the cursor %q twice", page.Paging.Next)
+		}
+		seen[page.Paging.Next] = true
+
+		nextQuery = cloneValues(query)
+		nextQuery.Set("next", page.Paging.Next)
+	}
+
+	body, err := json.Marshal(map[string]any{"data": merged})
+	if err != nil {
+		return Response{}, fmt.Errorf("encode paginated response: %w", err)
+	}
+	mergedHeader := cloneHeader(lastPage.Header)
+	for _, name := range []string{"Content-Length", "Content-Encoding", "Etag"} {
+		mergedHeader.Del(name)
+	}
+	return Response{StatusCode: lastPage.StatusCode, Header: mergedHeader, Body: body}, nil
+}
+
+func fieldsToQuery(fields []KeyValue) url.Values {
+	q := url.Values{}
+	for _, kv := range fields {
+		q.Add(kv.Key, kv.Value)
+	}
+	return q
+}
+
+func fieldsToMap(fields []KeyValue) map[string]string {
+	m := make(map[string]string, len(fields))
+	for _, kv := range fields {
+		m[kv.Key] = kv.Value
+	}
+	return m
+}
+
+func cloneHeader(h http.Header) http.Header {
+	if h == nil {
+		return http.Header{}
+	}
+	return h.Clone()
+}
+
+func cloneValues(v url.Values) url.Values {
+	if v == nil {
+		return url.Values{}
+	}
+	out := url.Values{}
+	for k, vs := range v {
+		out[k] = append([]string(nil), vs...)
+	}
+	return out
+}
+
+func asResponse(raw *bitriseapi.RawResponse) Response {
+	return Response{StatusCode: raw.StatusCode, Header: raw.Header, Body: raw.Body}
+}

--- a/internal/api/service_test.go
+++ b/internal/api/service_test.go
@@ -1,0 +1,267 @@
+package api
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/bitrise-io/bitrise/v2/internal/bitriseapi"
+)
+
+func TestDo_GetFieldsBecomeQuery(t *testing.T) {
+	var gotQuery string
+	srv := newFakeServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.RawQuery
+		_, _ = w.Write([]byte(`{}`))
+	})
+
+	_, err := NewService(bitriseapi.New(srv.URL, "t")).Do(context.Background(), Request{
+		Method: http.MethodGet,
+		Path:   "/apps",
+		Fields: []KeyValue{{Key: "sort_by", Value: "last_build_at"}},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "sort_by=last_build_at", gotQuery)
+}
+
+func TestDo_NonGetFieldsBecomeJSONBodyWithDefaultContentType(t *testing.T) {
+	var gotBody, gotContentType string
+	srv := newFakeServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotContentType = r.Header.Get("Content-Type")
+		body, _ := io.ReadAll(r.Body)
+		gotBody = string(body)
+		_, _ = w.Write([]byte(`{}`))
+	})
+
+	_, err := NewService(bitriseapi.New(srv.URL, "t")).Do(context.Background(), Request{
+		Method: http.MethodPost,
+		Path:   "/apps",
+		Fields: []KeyValue{{Key: "title", Value: "My App"}},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "application/json", gotContentType)
+	assert.JSONEq(t, `{"title":"My App"}`, gotBody)
+}
+
+func TestDo_CallerContentTypeWins(t *testing.T) {
+	var gotContentType string
+	srv := newFakeServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotContentType = r.Header.Get("Content-Type")
+		_, _ = w.Write([]byte(`{}`))
+	})
+
+	_, err := NewService(bitriseapi.New(srv.URL, "t")).Do(context.Background(), Request{
+		Method:  http.MethodPost,
+		Path:    "/apps",
+		Fields:  []KeyValue{{Key: "title", Value: "My App"}},
+		Headers: http.Header{"Content-Type": []string{"application/vnd.custom+json"}},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "application/vnd.custom+json", gotContentType)
+}
+
+func TestDo_BodyPassthrough(t *testing.T) {
+	var gotBody string
+	srv := newFakeServer(t, func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		gotBody = string(body)
+		_, _ = w.Write([]byte(`{}`))
+	})
+
+	_, err := NewService(bitriseapi.New(srv.URL, "t")).Do(context.Background(), Request{
+		Method: http.MethodPost,
+		Path:   "/apps",
+		Body:   strings.NewReader(`{"raw":"body"}`),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, `{"raw":"body"}`, gotBody)
+}
+
+func TestDo_InputBodyGetsDefaultContentType(t *testing.T) {
+	var gotContentType string
+	srv := newFakeServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotContentType = r.Header.Get("Content-Type")
+		_, _ = w.Write([]byte(`{}`))
+	})
+
+	_, err := NewService(bitriseapi.New(srv.URL, "t")).Do(context.Background(), Request{
+		Method: http.MethodPost,
+		Path:   "/apps",
+		Body:   strings.NewReader(`{"nested":{"a":1}}`),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "application/json", gotContentType)
+}
+
+func TestDo_PaginateRejectedOnNonGet(t *testing.T) {
+	_, err := NewService(bitriseapi.New("http://unused.invalid", "t")).Do(context.Background(), Request{
+		Method:   http.MethodPost,
+		Path:     "/apps",
+		Paginate: true,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--all is only supported for GET requests")
+}
+
+func TestDo_PaginateRejectedWithInputBody(t *testing.T) {
+	_, err := NewService(bitriseapi.New("http://unused.invalid", "t")).Do(context.Background(), Request{
+		Method:   http.MethodGet,
+		Path:     "/apps",
+		Body:     strings.NewReader(`{"raw":"body"}`),
+		Paginate: true,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--all cannot be combined with --input")
+}
+
+func TestDo_PaginateMergesPages(t *testing.T) {
+	var requests []string
+	srv := newFakeServer(t, func(w http.ResponseWriter, r *http.Request) {
+		requests = append(requests, r.URL.RawQuery)
+		if r.URL.Query().Get("next") == "cursor2" {
+			_, _ = w.Write([]byte(`{"data":[3],"paging":{"next":""}}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"data":[1,2],"paging":{"next":"cursor2"}}`))
+	})
+
+	resp, err := NewService(bitriseapi.New(srv.URL, "t")).Do(context.Background(), Request{
+		Method:   http.MethodGet,
+		Path:     "/apps",
+		Paginate: true,
+	})
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"data":[1,2,3]}`, string(resp.Body))
+	require.Len(t, requests, 2)
+	assert.Equal(t, "next=cursor2", requests[1])
+}
+
+func TestDo_PaginateNoOpOnNonListResponse(t *testing.T) {
+	srv := newFakeServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"foo":"bar"}`))
+	})
+
+	resp, err := NewService(bitriseapi.New(srv.URL, "t")).Do(context.Background(), Request{
+		Method:   http.MethodGet,
+		Path:     "/me",
+		Paginate: true,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, `{"foo":"bar"}`, string(resp.Body))
+}
+
+func TestDo_PaginateStopsOnErrorPage(t *testing.T) {
+	var calls int
+	srv := newFakeServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		calls++
+		if calls == 1 {
+			_, _ = w.Write([]byte(`{"data":[1],"paging":{"next":"cursor2"}}`))
+			return
+		}
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"message":"boom"}`))
+	})
+
+	resp, err := NewService(bitriseapi.New(srv.URL, "t")).Do(context.Background(), Request{
+		Method:   http.MethodGet,
+		Path:     "/apps",
+		Paginate: true,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+	assert.Equal(t, `{"message":"boom"}`, string(resp.Body))
+	assert.Equal(t, 2, calls)
+}
+
+func TestDo_PaginateEmptyListStaysAnArray(t *testing.T) {
+	srv := newFakeServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"data":[],"paging":{"next":""}}`))
+	})
+
+	resp, err := NewService(bitriseapi.New(srv.URL, "t")).Do(context.Background(), Request{
+		Method:   http.MethodGet,
+		Path:     "/apps",
+		Paginate: true,
+	})
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"data":[]}`, string(resp.Body), "an empty list must not collapse to a null data field")
+}
+
+func TestDo_PaginateKeepsFieldsAcrossPages(t *testing.T) {
+	var requests []url.Values
+	srv := newFakeServer(t, func(w http.ResponseWriter, r *http.Request) {
+		requests = append(requests, r.URL.Query())
+		if r.URL.Query().Get("next") == "cursor2" {
+			_, _ = w.Write([]byte(`{"data":[2],"paging":{"next":""}}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"data":[1],"paging":{"next":"cursor2"}}`))
+	})
+
+	_, err := NewService(bitriseapi.New(srv.URL, "t")).Do(context.Background(), Request{
+		Method:   http.MethodGet,
+		Path:     "/apps",
+		Fields:   []KeyValue{{Key: "sort_by", Value: "last_build_at"}},
+		Paginate: true,
+	})
+	require.NoError(t, err)
+	require.Len(t, requests, 2)
+	assert.Equal(t, "last_build_at", requests[1].Get("sort_by"))
+	assert.Equal(t, "cursor2", requests[1].Get("next"))
+}
+
+func TestDo_PaginateReportsLastPageHeaders(t *testing.T) {
+	srv := newFakeServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("next") == "cursor2" {
+			w.Header().Set("X-Ratelimit-Remaining", "41")
+			w.Header().Set("Etag", `W/"page-2"`)
+			_, _ = w.Write([]byte(`{"data":[2],"paging":{"next":""}}`))
+			return
+		}
+		w.Header().Set("X-Ratelimit-Remaining", "42")
+		_, _ = w.Write([]byte(`{"data":[1],"paging":{"next":"cursor2"}}`))
+	})
+
+	resp, err := NewService(bitriseapi.New(srv.URL, "t")).Do(context.Background(), Request{
+		Method:   http.MethodGet,
+		Path:     "/apps",
+		Paginate: true,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "41", resp.Header.Get("X-Ratelimit-Remaining"))
+	assert.Empty(t, resp.Header.Get("Content-Length"), "the last page's length must not describe the merged body")
+	assert.Empty(t, resp.Header.Get("Etag"), "the last page's validator must not describe the merged body")
+}
+
+func TestDo_PaginateStopsOnRepeatedCursor(t *testing.T) {
+	var calls int
+	srv := newFakeServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		calls++
+		_, _ = w.Write([]byte(`{"data":[1],"paging":{"next":"stuck"}}`))
+	})
+
+	_, err := NewService(bitriseapi.New(srv.URL, "t")).Do(context.Background(), Request{
+		Method:   http.MethodGet,
+		Path:     "/apps",
+		Paginate: true,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "pagination stalled")
+	assert.Equal(t, 2, calls)
+}
+
+func newFakeServer(t *testing.T, handler http.HandlerFunc) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	return srv
+}

--- a/internal/bitriseapi/raw.go
+++ b/internal/bitriseapi/raw.go
@@ -1,0 +1,88 @@
+package bitriseapi
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// RawResponse is the unprocessed result of a RawRequest call. Unlike the
+// client's typed methods, a non-2xx StatusCode is not an error here — the
+// caller (the `api` command) decides how to present it.
+type RawResponse struct {
+	StatusCode int
+	Header     http.Header
+	Body       []byte
+}
+
+// RawRequest performs an arbitrary authenticated request against the Bitrise
+// API, for callers that need direct control over method, path, query,
+// headers, and body rather than one of the typed endpoints.
+//
+// path is resolved relative to the client's configured base URL, unless it
+// is itself an absolute http(s):// URL, which is used verbatim (still with
+// the same Authorization/Accept headers). query is merged with any query
+// string already present in path.
+func (c *Client) RawRequest(ctx context.Context, method, path string, query url.Values, header http.Header, body io.Reader) (*RawResponse, error) {
+	reqURL, err := c.resolveURL(path, query)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, reqURL, body)
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Authorization", "token "+c.token)
+	req.Header.Set("Accept", "application/json")
+	for k, values := range header {
+		req.Header.Del(k)
+		for _, v := range values {
+			req.Header.Add(k, v)
+		}
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read response: %w", err)
+	}
+
+	return &RawResponse{StatusCode: resp.StatusCode, Header: resp.Header, Body: respBody}, nil
+}
+
+func (c *Client) resolveURL(path string, query url.Values) (string, error) {
+	if strings.HasPrefix(path, "http://") || strings.HasPrefix(path, "https://") {
+		return mergeQuery(path, query)
+	}
+	p := path
+	if !strings.HasPrefix(p, "/") {
+		p = "/" + p
+	}
+	return mergeQuery(strings.TrimSuffix(c.baseURL, "/")+p, query)
+}
+
+func mergeQuery(rawURL string, extra url.Values) (string, error) {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return "", fmt.Errorf("parse URL: %w", err)
+	}
+	if len(extra) > 0 {
+		q := u.Query()
+		for k, values := range extra {
+			for _, v := range values {
+				q.Add(k, v)
+			}
+		}
+		u.RawQuery = q.Encode()
+	}
+	return u.String(), nil
+}

--- a/internal/bitriseapi/raw_test.go
+++ b/internal/bitriseapi/raw_test.go
@@ -1,0 +1,102 @@
+package bitriseapi
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRawRequest_MethodAndBodyPassthrough(t *testing.T) {
+	var gotMethod, gotBody string
+	srv := newFakeServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		buf := make([]byte, 64)
+		n, _ := r.Body.Read(buf)
+		gotBody = string(buf[:n])
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	})
+
+	resp, err := New(srv.URL, "t").RawRequest(context.Background(), http.MethodPost, "/things", nil, nil, strings.NewReader(`{"a":1}`))
+	require.NoError(t, err)
+	assert.Equal(t, http.MethodPost, gotMethod)
+	assert.Equal(t, `{"a":1}`, gotBody)
+	assert.Equal(t, http.StatusCreated, resp.StatusCode)
+	assert.Equal(t, `{"ok":true}`, string(resp.Body))
+}
+
+func TestRawRequest_DefaultHeadersAndUserOverride(t *testing.T) {
+	var gotAuth, gotAccept string
+	srv := newFakeServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		gotAccept = r.Header.Get("Accept")
+		_, _ = w.Write([]byte(`{}`))
+	})
+
+	header := http.Header{"Accept": []string{"text/plain"}}
+	_, err := New(srv.URL, "t").RawRequest(context.Background(), http.MethodGet, "/x", nil, header, nil)
+	require.NoError(t, err)
+	assert.Equal(t, "token t", gotAuth)
+	assert.Equal(t, "text/plain", gotAccept, "user header should override the default Accept")
+}
+
+func TestRawRequest_PathJoiningAndQueryMerging(t *testing.T) {
+	cases := map[string]struct {
+		path      string
+		query     url.Values
+		wantPath  string
+		wantQuery string
+	}{
+		"leading slash":        {path: "/apps", wantPath: "/apps"},
+		"no leading slash":     {path: "apps", wantPath: "/apps"},
+		"query in path merged": {path: "/apps?limit=10", query: url.Values{"sort": {"name"}}, wantPath: "/apps", wantQuery: "limit=10&sort=name"},
+		"explicit query only":  {path: "/apps", query: url.Values{"sort": {"name"}}, wantPath: "/apps", wantQuery: "sort=name"},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			var gotPath, gotQuery string
+			srv := newFakeServer(t, func(w http.ResponseWriter, r *http.Request) {
+				gotPath = r.URL.Path
+				gotQuery = r.URL.RawQuery
+				_, _ = w.Write([]byte(`{}`))
+			})
+
+			_, err := New(srv.URL, "t").RawRequest(context.Background(), http.MethodGet, tc.path, tc.query, nil, nil)
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantPath, gotPath)
+			assert.Equal(t, tc.wantQuery, gotQuery)
+		})
+	}
+}
+
+func TestRawRequest_AbsoluteURLIgnoresConfiguredBaseButKeepsAuth(t *testing.T) {
+	var gotAuth, gotPath string
+	srv := newFakeServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		gotPath = r.URL.Path
+		_, _ = w.Write([]byte(`{}`))
+	})
+
+	client := New("http://unused.invalid", "t")
+	_, err := client.RawRequest(context.Background(), http.MethodGet, srv.URL+"/absolute", nil, nil, nil)
+	require.NoError(t, err)
+	assert.Equal(t, "/absolute", gotPath)
+	assert.Equal(t, "token t", gotAuth)
+}
+
+func TestRawRequest_NonSuccessStatusIsNotAnError(t *testing.T) {
+	srv := newFakeServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"message":"not found"}`))
+	})
+
+	resp, err := New(srv.URL, "t").RawRequest(context.Background(), http.MethodGet, "/missing", nil, nil, nil)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+	assert.Equal(t, `{"message":"not found"}`, string(resp.Body))
+}


### PR DESCRIPTION
Added the `api` command (all layers).  Moved terminal helpers from secrets to shared utility.
Removed new command descriptions from the breaking changes doc.