### PR TITLE
v3 prep: add yaml tags to structs printed via output.Print

### DIFF
--- a/cli/auth/status.go
+++ b/cli/auth/status.go
@@ -14,12 +14,12 @@ import (
 
 // authStatus is the JSON/YML shape of `bitrise auth status`.
 type authStatus struct {
-	HasToken  bool   `json:"has_token"`
-	TokenType string `json:"token_type,omitempty"`
-	Source    string `json:"source"`
+	HasToken  bool   `json:"has_token" yaml:"has_token"`
+	TokenType string `json:"token_type,omitempty" yaml:"token_type,omitempty"`
+	Source    string `json:"source" yaml:"source"`
 	// TokenExpiry is set (RFC 3339) only for OAuth-managed tokens.
-	TokenExpiry string `json:"token_expiry,omitempty"`
-	Path        string `json:"path"`
+	TokenExpiry string `json:"token_expiry,omitempty" yaml:"token_expiry,omitempty"`
+	Path        string `json:"path" yaml:"path"`
 }
 
 func NewStatusCommand() *cobra.Command {

--- a/cli/version.go
+++ b/cli/version.go
@@ -14,12 +14,12 @@ import (
 
 // VersionOutputModel ...
 type VersionOutputModel struct {
-	Version       string `json:"version"`
-	FormatVersion string `json:"format_version"`
-	OS            string `json:"os"`
-	GO            string `json:"go"`
-	BuildNumber   string `json:"build_number"`
-	Commit        string `json:"commit"`
+	Version       string `json:"version" yaml:"version"`
+	FormatVersion string `json:"format_version" yaml:"format_version"`
+	OS            string `json:"os" yaml:"os"`
+	GO            string `json:"go" yaml:"go"`
+	BuildNumber   string `json:"build_number" yaml:"build_number"`
+	Commit        string `json:"commit" yaml:"commit"`
 }
 
 var versionCommand = &cobra.Command{

--- a/internal/bitriseapi/steps.go
+++ b/internal/bitriseapi/steps.go
@@ -8,29 +8,29 @@ import (
 )
 
 type StepResponse struct {
-	ID                  string                    `json:"id"`
-	StepRef             string                    `json:"step_ref"`
-	Title               string                    `json:"title"`
-	Summary             string                    `json:"summary,omitempty"`
-	Description         string                    `json:"description,omitempty"`
-	Version             string                    `json:"version,omitempty"`
-	LatestVersionNumber string                    `json:"latest_version_number,omitempty"`
-	Maintainer          string                    `json:"maintainer,omitempty"`
-	IsDeprecated        bool                      `json:"is_deprecated,omitempty"`
-	IsLatest            bool                      `json:"is_latest,omitempty"`
-	Inputs              []StepInputOutputResponse `json:"inputs,omitempty"`
-	Outputs             []StepInputOutputResponse `json:"outputs,omitempty"`
+	ID                  string                    `json:"id" yaml:"id"`
+	StepRef             string                    `json:"step_ref" yaml:"step_ref"`
+	Title               string                    `json:"title" yaml:"title"`
+	Summary             string                    `json:"summary,omitempty" yaml:"summary,omitempty"`
+	Description         string                    `json:"description,omitempty" yaml:"description,omitempty"`
+	Version             string                    `json:"version,omitempty" yaml:"version,omitempty"`
+	LatestVersionNumber string                    `json:"latest_version_number,omitempty" yaml:"latest_version_number,omitempty"`
+	Maintainer          string                    `json:"maintainer,omitempty" yaml:"maintainer,omitempty"`
+	IsDeprecated        bool                      `json:"is_deprecated,omitempty" yaml:"is_deprecated,omitempty"`
+	IsLatest            bool                      `json:"is_latest,omitempty" yaml:"is_latest,omitempty"`
+	Inputs              []StepInputOutputResponse `json:"inputs,omitempty" yaml:"inputs,omitempty"`
+	Outputs             []StepInputOutputResponse `json:"outputs,omitempty" yaml:"outputs,omitempty"`
 }
 
 type StepInputOutputResponse struct {
-	Name         string   `json:"name,omitempty"`
-	Title        string   `json:"title,omitempty"`
-	Summary      string   `json:"summary,omitempty"`
-	Description  string   `json:"description,omitempty"`
-	DefaultValue string   `json:"default_value,omitempty"`
-	IsRequired   bool     `json:"is_required,omitempty"`
-	IsSensitive  bool     `json:"is_sensitive,omitempty"`
-	ValueOptions []string `json:"value_options,omitempty"`
+	Name         string   `json:"name,omitempty" yaml:"name,omitempty"`
+	Title        string   `json:"title,omitempty" yaml:"title,omitempty"`
+	Summary      string   `json:"summary,omitempty" yaml:"summary,omitempty"`
+	Description  string   `json:"description,omitempty" yaml:"description,omitempty"`
+	DefaultValue string   `json:"default_value,omitempty" yaml:"default_value,omitempty"`
+	IsRequired   bool     `json:"is_required,omitempty" yaml:"is_required,omitempty"`
+	IsSensitive  bool     `json:"is_sensitive,omitempty" yaml:"is_sensitive,omitempty"`
+	ValueOptions []string `json:"value_options,omitempty" yaml:"value_options,omitempty"`
 }
 
 type StepSearchOptions struct {

--- a/internal/stack/service.go
+++ b/internal/stack/service.go
@@ -11,19 +11,19 @@ import (
 // Stack is the CLI representation of a Bitrise stack. Field names are
 // normalized to snake_case from the wire format's hyphenated keys.
 type Stack struct {
-	ID          string `json:"id"`
-	Title       string `json:"title"`
-	OS          string `json:"os"`
-	OSVersion   int    `json:"os_version,omitempty"`
-	Status      string `json:"status"`
-	Description string `json:"description,omitempty"`
-	StackReport string `json:"stack_report,omitempty"`
-	RemovalDate string `json:"removal_date,omitempty"`
+	ID          string `json:"id" yaml:"id"`
+	Title       string `json:"title" yaml:"title"`
+	OS          string `json:"os" yaml:"os"`
+	OSVersion   int    `json:"os_version,omitempty" yaml:"os_version,omitempty"`
+	Status      string `json:"status" yaml:"status"`
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
+	StackReport string `json:"stack_report,omitempty" yaml:"stack_report,omitempty"`
+	RemovalDate string `json:"removal_date,omitempty" yaml:"removal_date,omitempty"`
 }
 
 // StacksResult holds all available stacks.
 type StacksResult struct {
-	Items []Stack `json:"items"`
+	Items []Stack `json:"items" yaml:"items"`
 }
 
 // Service exposes stack operations to the cmd layer.

--- a/internal/yml/service.go
+++ b/internal/yml/service.go
@@ -14,9 +14,9 @@ import (
 
 // GetResult holds the retrieved bitrise.yml content.
 type GetResult struct {
-	AppSlug   string `json:"app_id"`
-	BuildSlug string `json:"build_id,omitempty"`
-	Content   string `json:"content"`
+	AppSlug   string `json:"app_id" yaml:"app_id"`
+	BuildSlug string `json:"build_id,omitempty" yaml:"build_id,omitempty"`
+	Content   string `json:"content" yaml:"content"`
 }
 
 // ValidateResult holds the outcome of an online bitrise.yml validation.


### PR DESCRIPTION
output.Print marshals --format yml with gopkg.in/yaml.v2, which ignores json tags and falls back to the lowercased Go field name. Every struct reaching it with json-only tags therefore emitted different keys under --format yml than under --format json (formatversion/buildnumber for version, apibaseurl for config, avatarurl-style names for the API responses), and different keys than the raw human output names for the same fields.