### PR TITLE
v3 prep: require https for base URLs carrying credentials

### DIFF
--- a/cli/cmdutil/client.go
+++ b/cli/cmdutil/client.go
@@ -20,7 +20,7 @@ func NewAPIClient(cmd *cobra.Command) (*bitriseapi.Client, error) {
 		return nil, err
 	}
 	r := config.FromContext(cmd.Context())
-	return bitriseapi.New(r.APIBaseURL, tok), nil
+	return bitriseapi.New(r.APIBaseURL, tok)
 }
 
 // ResolveToken returns the configured token and whether it came from the

--- a/internal/api/service_test.go
+++ b/internal/api/service_test.go
@@ -22,7 +22,7 @@ func TestDo_GetFieldsBecomeQuery(t *testing.T) {
 		_, _ = w.Write([]byte(`{}`))
 	})
 
-	_, err := NewService(bitriseapi.New(srv.URL, "t")).Do(context.Background(), Request{
+	_, err := NewService(newAPIClient(t, srv.URL)).Do(context.Background(), Request{
 		Method: http.MethodGet,
 		Path:   "/apps",
 		Fields: []KeyValue{{Key: "sort_by", Value: "last_build_at"}},
@@ -40,7 +40,7 @@ func TestDo_NonGetFieldsBecomeJSONBodyWithDefaultContentType(t *testing.T) {
 		_, _ = w.Write([]byte(`{}`))
 	})
 
-	_, err := NewService(bitriseapi.New(srv.URL, "t")).Do(context.Background(), Request{
+	_, err := NewService(newAPIClient(t, srv.URL)).Do(context.Background(), Request{
 		Method: http.MethodPost,
 		Path:   "/apps",
 		Fields: []KeyValue{{Key: "title", Value: "My App"}},
@@ -57,7 +57,7 @@ func TestDo_CallerContentTypeWins(t *testing.T) {
 		_, _ = w.Write([]byte(`{}`))
 	})
 
-	_, err := NewService(bitriseapi.New(srv.URL, "t")).Do(context.Background(), Request{
+	_, err := NewService(newAPIClient(t, srv.URL)).Do(context.Background(), Request{
 		Method:  http.MethodPost,
 		Path:    "/apps",
 		Fields:  []KeyValue{{Key: "title", Value: "My App"}},
@@ -75,7 +75,7 @@ func TestDo_BodyPassthrough(t *testing.T) {
 		_, _ = w.Write([]byte(`{}`))
 	})
 
-	_, err := NewService(bitriseapi.New(srv.URL, "t")).Do(context.Background(), Request{
+	_, err := NewService(newAPIClient(t, srv.URL)).Do(context.Background(), Request{
 		Method: http.MethodPost,
 		Path:   "/apps",
 		Body:   strings.NewReader(`{"raw":"body"}`),
@@ -91,7 +91,7 @@ func TestDo_InputBodyGetsDefaultContentType(t *testing.T) {
 		_, _ = w.Write([]byte(`{}`))
 	})
 
-	_, err := NewService(bitriseapi.New(srv.URL, "t")).Do(context.Background(), Request{
+	_, err := NewService(newAPIClient(t, srv.URL)).Do(context.Background(), Request{
 		Method: http.MethodPost,
 		Path:   "/apps",
 		Body:   strings.NewReader(`{"nested":{"a":1}}`),
@@ -101,7 +101,7 @@ func TestDo_InputBodyGetsDefaultContentType(t *testing.T) {
 }
 
 func TestDo_PaginateRejectedOnNonGet(t *testing.T) {
-	_, err := NewService(bitriseapi.New("http://unused.invalid", "t")).Do(context.Background(), Request{
+	_, err := NewService(newAPIClient(t, "https://unused.invalid")).Do(context.Background(), Request{
 		Method:   http.MethodPost,
 		Path:     "/apps",
 		Paginate: true,
@@ -111,7 +111,7 @@ func TestDo_PaginateRejectedOnNonGet(t *testing.T) {
 }
 
 func TestDo_PaginateRejectedWithInputBody(t *testing.T) {
-	_, err := NewService(bitriseapi.New("http://unused.invalid", "t")).Do(context.Background(), Request{
+	_, err := NewService(newAPIClient(t, "https://unused.invalid")).Do(context.Background(), Request{
 		Method:   http.MethodGet,
 		Path:     "/apps",
 		Body:     strings.NewReader(`{"raw":"body"}`),
@@ -132,7 +132,7 @@ func TestDo_PaginateMergesPages(t *testing.T) {
 		_, _ = w.Write([]byte(`{"data":[1,2],"paging":{"next":"cursor2"}}`))
 	})
 
-	resp, err := NewService(bitriseapi.New(srv.URL, "t")).Do(context.Background(), Request{
+	resp, err := NewService(newAPIClient(t, srv.URL)).Do(context.Background(), Request{
 		Method:   http.MethodGet,
 		Path:     "/apps",
 		Paginate: true,
@@ -148,7 +148,7 @@ func TestDo_PaginateNoOpOnNonListResponse(t *testing.T) {
 		_, _ = w.Write([]byte(`{"foo":"bar"}`))
 	})
 
-	resp, err := NewService(bitriseapi.New(srv.URL, "t")).Do(context.Background(), Request{
+	resp, err := NewService(newAPIClient(t, srv.URL)).Do(context.Background(), Request{
 		Method:   http.MethodGet,
 		Path:     "/me",
 		Paginate: true,
@@ -170,7 +170,7 @@ func TestDo_PaginateStopsOnErrorPage(t *testing.T) {
 		_, _ = w.Write([]byte(`{"message":"boom"}`))
 	})
 
-	resp, err := NewService(bitriseapi.New(srv.URL, "t")).Do(context.Background(), Request{
+	resp, err := NewService(newAPIClient(t, srv.URL)).Do(context.Background(), Request{
 		Method:   http.MethodGet,
 		Path:     "/apps",
 		Paginate: true,
@@ -186,7 +186,7 @@ func TestDo_PaginateEmptyListStaysAnArray(t *testing.T) {
 		_, _ = w.Write([]byte(`{"data":[],"paging":{"next":""}}`))
 	})
 
-	resp, err := NewService(bitriseapi.New(srv.URL, "t")).Do(context.Background(), Request{
+	resp, err := NewService(newAPIClient(t, srv.URL)).Do(context.Background(), Request{
 		Method:   http.MethodGet,
 		Path:     "/apps",
 		Paginate: true,
@@ -206,7 +206,7 @@ func TestDo_PaginateKeepsFieldsAcrossPages(t *testing.T) {
 		_, _ = w.Write([]byte(`{"data":[1],"paging":{"next":"cursor2"}}`))
 	})
 
-	_, err := NewService(bitriseapi.New(srv.URL, "t")).Do(context.Background(), Request{
+	_, err := NewService(newAPIClient(t, srv.URL)).Do(context.Background(), Request{
 		Method:   http.MethodGet,
 		Path:     "/apps",
 		Fields:   []KeyValue{{Key: "sort_by", Value: "last_build_at"}},
@@ -230,7 +230,7 @@ func TestDo_PaginateReportsLastPageHeaders(t *testing.T) {
 		_, _ = w.Write([]byte(`{"data":[1],"paging":{"next":"cursor2"}}`))
 	})
 
-	resp, err := NewService(bitriseapi.New(srv.URL, "t")).Do(context.Background(), Request{
+	resp, err := NewService(newAPIClient(t, srv.URL)).Do(context.Background(), Request{
 		Method:   http.MethodGet,
 		Path:     "/apps",
 		Paginate: true,
@@ -249,7 +249,7 @@ func TestDo_PaginateStopsOnRepeatedCursor(t *testing.T) {
 		_, _ = w.Write([]byte(`{"data":[1],"paging":{"next":"stuck"}}`))
 	})
 
-	_, err := NewService(bitriseapi.New(srv.URL, "t")).Do(context.Background(), Request{
+	_, err := NewService(newAPIClient(t, srv.URL)).Do(context.Background(), Request{
 		Method:   http.MethodGet,
 		Path:     "/apps",
 		Paginate: true,
@@ -264,4 +264,11 @@ func newFakeServer(t *testing.T, handler http.HandlerFunc) *httptest.Server {
 	srv := httptest.NewServer(handler)
 	t.Cleanup(srv.Close)
 	return srv
+}
+
+func newAPIClient(t *testing.T, baseURL string) *bitriseapi.Client {
+	t.Helper()
+	c, err := bitriseapi.New(baseURL, "t")
+	require.NoError(t, err)
+	return c
 }

--- a/internal/baseurl/baseurl.go
+++ b/internal/baseurl/baseurl.go
@@ -1,0 +1,34 @@
+// Package baseurl validates URLs that will carry credentials (a bearer
+// token, a login password) to whatever host they name. Shared by
+// internal/webclient, internal/bitriseapi, and internal/config, all of
+// which need the same rule: https, except against a local test server.
+package baseurl
+
+import (
+	"fmt"
+	"net"
+	"net/url"
+)
+
+// Validate checks that raw is an absolute URL using https — or plain http
+// against a loopback host, so tests can point at an httptest server. label
+// identifies raw in the returned error (e.g. "base URL", or a config key
+// name like "api_base_url").
+func Validate(label, raw string) (*url.URL, error) {
+	u, err := url.Parse(raw)
+	if err != nil || !u.IsAbs() || u.Host == "" {
+		return nil, fmt.Errorf("%s %q must be an absolute URL", label, raw)
+	}
+	if u.Scheme != "https" && !isLoopbackHost(u.Hostname()) {
+		return nil, fmt.Errorf("%s %q must use https (got %q)", label, raw, u.Scheme)
+	}
+	return u, nil
+}
+
+func isLoopbackHost(host string) bool {
+	if host == "localhost" {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
+}

--- a/internal/baseurl/baseurl_test.go
+++ b/internal/baseurl/baseurl_test.go
@@ -1,0 +1,36 @@
+package baseurl
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidate_AcceptsHTTPS(t *testing.T) {
+	u, err := Validate("base URL", "https://api.example.com")
+	require.NoError(t, err)
+	assert.Equal(t, "https://api.example.com", u.String())
+}
+
+func TestValidate_RejectsRelative(t *testing.T) {
+	_, err := Validate("base URL", "not-a-url")
+	assert.ErrorContains(t, err, `base URL "not-a-url" must be an absolute URL`)
+}
+
+func TestValidate_RejectsUnparsable(t *testing.T) {
+	_, err := Validate("base URL", "://bad")
+	assert.Error(t, err)
+}
+
+func TestValidate_RejectsPlainHTTP(t *testing.T) {
+	_, err := Validate("web_base_url", "http://app.example.com")
+	assert.ErrorContains(t, err, `web_base_url "http://app.example.com" must use https (got "http")`)
+}
+
+func TestValidate_AllowsPlainHTTPForLoopback(t *testing.T) {
+	for _, raw := range []string{"http://localhost:1234", "http://127.0.0.1:1234", "http://[::1]:1234"} {
+		_, err := Validate("base URL", raw)
+		require.NoError(t, err, raw)
+	}
+}

--- a/internal/bitriseapi/client.go
+++ b/internal/bitriseapi/client.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/bitrise-io/bitrise/v2/internal/baseurl"
 	"github.com/bitrise-io/bitrise/v2/internal/stringutil"
 )
 
@@ -32,16 +33,23 @@ func WithHTTPClient(hc *http.Client) Option {
 	return func(c *Client) { c.httpClient = hc }
 }
 
-func New(baseURL, token string, opts ...Option) *Client {
+// New validates baseURL (via internal/baseurl: https, loopback exempted —
+// this client sends a bearer token on every request) before constructing a
+// Client against it.
+func New(rawBaseURL, token string, opts ...Option) (*Client, error) {
+	u, err := baseurl.Validate("API base URL", rawBaseURL)
+	if err != nil {
+		return nil, err
+	}
 	c := &Client{
-		baseURL:    baseURL,
+		baseURL:    u.String(),
 		token:      token,
 		httpClient: &http.Client{Timeout: defaultTimeout},
 	}
 	for _, opt := range opts {
 		opt(c)
 	}
-	return c
+	return c, nil
 }
 
 // APIError represents an error response from the Bitrise API. Body is only

--- a/internal/bitriseapi/client_test.go
+++ b/internal/bitriseapi/client_test.go
@@ -11,14 +11,19 @@ import (
 )
 
 func TestNew_DefaultHTTPClientTimeout(t *testing.T) {
-	c := New("http://example.invalid", "t")
+	c := newAPIClient(t, "https://example.invalid", "t")
 	assert.Equal(t, defaultTimeout, c.httpClient.Timeout)
 }
 
 func TestWithHTTPClient_Overrides(t *testing.T) {
 	custom := &http.Client{}
-	c := New("http://example.invalid", "t", WithHTTPClient(custom))
+	c := newAPIClient(t, "https://example.invalid", "t", WithHTTPClient(custom))
 	assert.Same(t, custom, c.httpClient)
+}
+
+func TestNew_RejectsPlainHTTP(t *testing.T) {
+	_, err := New("http://example.invalid", "t")
+	assert.ErrorContains(t, err, "must use https")
 }
 
 func TestAPIError_NonJSONBody(t *testing.T) {
@@ -27,7 +32,7 @@ func TestAPIError_NonJSONBody(t *testing.T) {
 		_, _ = w.Write([]byte("upstream exploded"))
 	})
 
-	_, err := New(srv.URL, "t").SearchSteps(context.Background(), StepSearchOptions{})
+	_, err := newAPIClient(t, srv.URL, "t").SearchSteps(context.Background(), StepSearchOptions{})
 	require.Error(t, err)
 	apiErr, ok := err.(*APIError)
 	require.True(t, ok, "expected *APIError, got %T", err)
@@ -50,7 +55,7 @@ func TestAPIError_AlternativeJSONFields(t *testing.T) {
 				w.WriteHeader(http.StatusUnprocessableEntity)
 				_, _ = w.Write([]byte(tc.body))
 			})
-			_, err := New(srv.URL, "t").SearchSteps(context.Background(), StepSearchOptions{})
+			_, err := newAPIClient(t, srv.URL, "t").SearchSteps(context.Background(), StepSearchOptions{})
 			apiErr, ok := err.(*APIError)
 			require.True(t, ok)
 			assert.Equal(t, tc.want, apiErr.Message)
@@ -64,7 +69,7 @@ func TestAPIError_RequestInfo(t *testing.T) {
 		_, _ = w.Write([]byte(`{"message":"Unauthorized"}`))
 	})
 
-	_, err := New(srv.URL, "bad-token").SearchSteps(context.Background(), StepSearchOptions{Query: "clone"})
+	_, err := newAPIClient(t, srv.URL, "bad-token").SearchSteps(context.Background(), StepSearchOptions{Query: "clone"})
 	require.Error(t, err)
 	apiErr, ok := err.(*APIError)
 	require.True(t, ok)
@@ -78,4 +83,14 @@ func newFakeServer(t *testing.T, handler http.HandlerFunc) *httptest.Server {
 	srv := httptest.NewServer(handler)
 	t.Cleanup(srv.Close)
 	return srv
+}
+
+// newAPIClient builds a Client and fails the test immediately on a validation
+// error — every other test here is about behavior past construction, not
+// New's own validation (covered by TestNew_RejectsPlainHTTP).
+func newAPIClient(t *testing.T, baseURL, token string, opts ...Option) *Client {
+	t.Helper()
+	c, err := New(baseURL, token, opts...)
+	require.NoError(t, err)
+	return c
 }

--- a/internal/bitriseapi/raw_test.go
+++ b/internal/bitriseapi/raw_test.go
@@ -22,7 +22,7 @@ func TestRawRequest_MethodAndBodyPassthrough(t *testing.T) {
 		_, _ = w.Write([]byte(`{"ok":true}`))
 	})
 
-	resp, err := New(srv.URL, "t").RawRequest(context.Background(), http.MethodPost, "/things", nil, nil, strings.NewReader(`{"a":1}`))
+	resp, err := newAPIClient(t, srv.URL, "t").RawRequest(context.Background(), http.MethodPost, "/things", nil, nil, strings.NewReader(`{"a":1}`))
 	require.NoError(t, err)
 	assert.Equal(t, http.MethodPost, gotMethod)
 	assert.Equal(t, `{"a":1}`, gotBody)
@@ -39,7 +39,7 @@ func TestRawRequest_DefaultHeadersAndUserOverride(t *testing.T) {
 	})
 
 	header := http.Header{"Accept": []string{"text/plain"}}
-	_, err := New(srv.URL, "t").RawRequest(context.Background(), http.MethodGet, "/x", nil, header, nil)
+	_, err := newAPIClient(t, srv.URL, "t").RawRequest(context.Background(), http.MethodGet, "/x", nil, header, nil)
 	require.NoError(t, err)
 	assert.Equal(t, "token t", gotAuth)
 	assert.Equal(t, "text/plain", gotAccept, "user header should override the default Accept")
@@ -66,7 +66,7 @@ func TestRawRequest_PathJoiningAndQueryMerging(t *testing.T) {
 				_, _ = w.Write([]byte(`{}`))
 			})
 
-			_, err := New(srv.URL, "t").RawRequest(context.Background(), http.MethodGet, tc.path, tc.query, nil, nil)
+			_, err := newAPIClient(t, srv.URL, "t").RawRequest(context.Background(), http.MethodGet, tc.path, tc.query, nil, nil)
 			require.NoError(t, err)
 			assert.Equal(t, tc.wantPath, gotPath)
 			assert.Equal(t, tc.wantQuery, gotQuery)
@@ -82,7 +82,7 @@ func TestRawRequest_AbsoluteURLIgnoresConfiguredBaseButKeepsAuth(t *testing.T) {
 		_, _ = w.Write([]byte(`{}`))
 	})
 
-	client := New("http://unused.invalid", "t")
+	client := newAPIClient(t, "https://unused.invalid", "t")
 	_, err := client.RawRequest(context.Background(), http.MethodGet, srv.URL+"/absolute", nil, nil, nil)
 	require.NoError(t, err)
 	assert.Equal(t, "/absolute", gotPath)
@@ -95,7 +95,7 @@ func TestRawRequest_NonSuccessStatusIsNotAnError(t *testing.T) {
 		_, _ = w.Write([]byte(`{"message":"not found"}`))
 	})
 
-	resp, err := New(srv.URL, "t").RawRequest(context.Background(), http.MethodGet, "/missing", nil, nil, nil)
+	resp, err := newAPIClient(t, srv.URL, "t").RawRequest(context.Background(), http.MethodGet, "/missing", nil, nil, nil)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
 	assert.Equal(t, `{"message":"not found"}`, string(resp.Body))

--- a/internal/bitriseapi/stacks_test.go
+++ b/internal/bitriseapi/stacks_test.go
@@ -17,7 +17,7 @@ func TestAvailableStacks_GlobalPath(t *testing.T) {
 		_, _ = w.Write([]byte(`{}`))
 	})
 
-	_, err := New(srv.URL, "my-token").AvailableStacks(context.Background(), "")
+	_, err := newAPIClient(t, srv.URL, "my-token").AvailableStacks(context.Background(), "")
 	require.NoError(t, err)
 	assert.Equal(t, "/available-stacks", gotPath)
 	assert.Equal(t, "token my-token", gotAuth)
@@ -30,7 +30,7 @@ func TestAvailableStacks_OrgScopedPath(t *testing.T) {
 		_, _ = w.Write([]byte(`{}`))
 	})
 
-	_, err := New(srv.URL, "t").AvailableStacks(context.Background(), "my-workspace")
+	_, err := newAPIClient(t, srv.URL, "t").AvailableStacks(context.Background(), "my-workspace")
 	require.NoError(t, err)
 	assert.Equal(t, "/organizations/my-workspace/available-stacks", gotPath)
 }
@@ -52,7 +52,7 @@ func TestAvailableStacks_EscapesOrgSlug(t *testing.T) {
 				_, _ = w.Write([]byte(`{}`))
 			})
 
-			_, err := New(srv.URL, "t").AvailableStacks(context.Background(), slug)
+			_, err := newAPIClient(t, srv.URL, "t").AvailableStacks(context.Background(), slug)
 			require.NoError(t, err)
 			assert.Equal(t, wantURI, gotURI)
 		})
@@ -66,7 +66,7 @@ func TestAvailableStacks_ParsesResponse(t *testing.T) {
 		}`))
 	})
 
-	stacks, err := New(srv.URL, "t").AvailableStacks(context.Background(), "")
+	stacks, err := newAPIClient(t, srv.URL, "t").AvailableStacks(context.Background(), "")
 	require.NoError(t, err)
 	require.Len(t, stacks, 1)
 	got := stacks["linux-docker-android"]
@@ -83,7 +83,7 @@ func TestAvailableStacks_PropagatesAPIError(t *testing.T) {
 		_, _ = w.Write([]byte(`{"message":"forbidden"}`))
 	})
 
-	_, err := New(srv.URL, "t").AvailableStacks(context.Background(), "")
+	_, err := newAPIClient(t, srv.URL, "t").AvailableStacks(context.Background(), "")
 	require.Error(t, err)
 	apiErr, ok := err.(*APIError)
 	require.True(t, ok, "expected *APIError, got %T", err)

--- a/internal/bitriseapi/steps_test.go
+++ b/internal/bitriseapi/steps_test.go
@@ -19,7 +19,7 @@ func TestSearchSteps_PassesAuthHeaderAndQuery(t *testing.T) {
 		_, _ = w.Write([]byte(`[]`))
 	})
 
-	_, err := New(srv.URL, "my-token").SearchSteps(context.Background(), StepSearchOptions{
+	_, err := newAPIClient(t, srv.URL, "my-token").SearchSteps(context.Background(), StepSearchOptions{
 		Query:       "clone",
 		Categories:  []string{"utility"},
 		Maintainers: []string{"bitrise"},
@@ -37,7 +37,7 @@ func TestSearchSteps_ParsesResponse(t *testing.T) {
 		_, _ = w.Write([]byte(`[{"id":"1","step_ref":"git-clone@8.3.1","title":"Git Clone","maintainer":"bitrise","is_deprecated":false}]`))
 	})
 
-	steps, err := New(srv.URL, "t").SearchSteps(context.Background(), StepSearchOptions{Query: "clone"})
+	steps, err := newAPIClient(t, srv.URL, "t").SearchSteps(context.Background(), StepSearchOptions{Query: "clone"})
 	require.NoError(t, err)
 	require.Len(t, steps, 1)
 	assert.Equal(t, "git-clone@8.3.1", steps[0].StepRef)
@@ -51,7 +51,7 @@ func TestSearchSteps_PropagatesAPIError(t *testing.T) {
 		_, _ = w.Write([]byte(`{"message":"Unauthorized"}`))
 	})
 
-	_, err := New(srv.URL, "bad-token").SearchSteps(context.Background(), StepSearchOptions{})
+	_, err := newAPIClient(t, srv.URL, "bad-token").SearchSteps(context.Background(), StepSearchOptions{})
 	require.Error(t, err)
 	apiErr, ok := err.(*APIError)
 	require.True(t, ok, "expected *APIError, got %T", err)
@@ -67,7 +67,7 @@ func TestStepInputs_PassesStepRef(t *testing.T) {
 		_, _ = w.Write([]byte(`[]`))
 	})
 
-	_, err := New(srv.URL, "t").StepInputs(context.Background(), "git-clone@8.3.1")
+	_, err := newAPIClient(t, srv.URL, "t").StepInputs(context.Background(), "git-clone@8.3.1")
 	require.NoError(t, err)
 	assert.Equal(t, "/step-inputs", gotPath)
 	assert.Equal(t, "git-clone@8.3.1", gotStepRef)
@@ -78,7 +78,7 @@ func TestStepInputs_ParsesResponse(t *testing.T) {
 		_, _ = w.Write([]byte(`[{"name":"branch","default_value":"main","is_required":true}]`))
 	})
 
-	inputs, err := New(srv.URL, "t").StepInputs(context.Background(), "git-clone@8.3.1")
+	inputs, err := newAPIClient(t, srv.URL, "t").StepInputs(context.Background(), "git-clone@8.3.1")
 	require.NoError(t, err)
 	require.Len(t, inputs, 1)
 	assert.Equal(t, "branch", inputs[0].Name)
@@ -92,7 +92,7 @@ func TestStepInputs_PropagatesAPIError(t *testing.T) {
 		_, _ = w.Write([]byte(`{"error":"step not found"}`))
 	})
 
-	_, err := New(srv.URL, "t").StepInputs(context.Background(), "does-not-exist@1.0.0")
+	_, err := newAPIClient(t, srv.URL, "t").StepInputs(context.Background(), "does-not-exist@1.0.0")
 	require.Error(t, err)
 	apiErr, ok := err.(*APIError)
 	require.True(t, ok)

--- a/internal/bitriseapi/user_test.go
+++ b/internal/bitriseapi/user_test.go
@@ -17,7 +17,7 @@ func TestMe(t *testing.T) {
 		_, _ = w.Write([]byte(`{"data":{"username":"alice","email":"alice@example.com","avatar_url":"https://example.com/a.png"}}`))
 	})
 
-	user, err := New(srv.URL, "my-token").Me(context.Background())
+	user, err := newAPIClient(t, srv.URL, "my-token").Me(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, "/me", gotPath)
 	assert.Equal(t, "token my-token", gotAuth)
@@ -30,7 +30,7 @@ func TestMe_APIError(t *testing.T) {
 		_, _ = w.Write([]byte(`{"message":"Unauthorized"}`))
 	})
 
-	_, err := New(srv.URL, "bad-token").Me(context.Background())
+	_, err := newAPIClient(t, srv.URL, "bad-token").Me(context.Background())
 	require.Error(t, err)
 	apiErr, ok := err.(*APIError)
 	require.True(t, ok)

--- a/internal/bitriseapi/yml_test.go
+++ b/internal/bitriseapi/yml_test.go
@@ -19,7 +19,7 @@ func TestAppBitriseYML(t *testing.T) {
 		_, _ = w.Write([]byte("format_version: \"13\"\n"))
 	})
 
-	content, err := New(srv.URL, "my-token").AppBitriseYML(context.Background(), "app-slug")
+	content, err := newAPIClient(t, srv.URL, "my-token").AppBitriseYML(context.Background(), "app-slug")
 	require.NoError(t, err)
 	assert.Equal(t, "/apps/app-slug/bitrise.yml", gotPath)
 	assert.Equal(t, "token my-token", gotAuth)
@@ -34,7 +34,7 @@ func TestBuildBitriseYML(t *testing.T) {
 		_, _ = w.Write([]byte("format_version: \"13\"\n"))
 	})
 
-	_, err := New(srv.URL, "t").BuildBitriseYML(context.Background(), "app-slug", "build-slug")
+	_, err := newAPIClient(t, srv.URL, "t").BuildBitriseYML(context.Background(), "app-slug", "build-slug")
 	require.NoError(t, err)
 	assert.Equal(t, "/apps/app-slug/builds/build-slug/bitrise.yml", gotPath)
 }
@@ -50,7 +50,7 @@ func TestUpdateAppBitriseYML(t *testing.T) {
 		_, _ = w.Write([]byte(`{}`))
 	})
 
-	err := New(srv.URL, "t").UpdateAppBitriseYML(context.Background(), "app-slug", map[string]any{"format_version": "13"})
+	err := newAPIClient(t, srv.URL, "t").UpdateAppBitriseYML(context.Background(), "app-slug", map[string]any{"format_version": "13"})
 	require.NoError(t, err)
 	assert.Equal(t, "/apps/app-slug/bitrise.yml", gotPath)
 	assert.Equal(t, http.MethodPost, gotMethod)
@@ -64,7 +64,7 @@ func TestUpdateAppBitriseYML_PropagatesAPIError(t *testing.T) {
 		_, _ = w.Write([]byte(`{"message":"app not found"}`))
 	})
 
-	err := New(srv.URL, "t").UpdateAppBitriseYML(context.Background(), "app-slug", map[string]any{})
+	err := newAPIClient(t, srv.URL, "t").UpdateAppBitriseYML(context.Background(), "app-slug", map[string]any{})
 	require.Error(t, err)
 	apiErr, ok := err.(*APIError)
 	require.True(t, ok, "expected *APIError, got %T", err)
@@ -78,7 +78,7 @@ func TestValidateBitriseYML_NoAppSlug(t *testing.T) {
 		_, _ = w.Write([]byte(`{"errors":[],"warnings":[]}`))
 	})
 
-	resp, err := New(srv.URL, "t").ValidateBitriseYML(context.Background(), "format_version: \"13\"\n", "")
+	resp, err := newAPIClient(t, srv.URL, "t").ValidateBitriseYML(context.Background(), "format_version: \"13\"\n", "")
 	require.NoError(t, err)
 	assert.Empty(t, gotQuery)
 	assert.Empty(t, resp.Errors)
@@ -94,7 +94,7 @@ func TestValidateBitriseYML_WithAppSlug(t *testing.T) {
 		_, _ = w.Write([]byte(`{"errors":["missing format_version"],"warnings":["deprecated step used"]}`))
 	})
 
-	resp, err := New(srv.URL, "t").ValidateBitriseYML(context.Background(), "workflows: {}\n", "app-slug")
+	resp, err := newAPIClient(t, srv.URL, "t").ValidateBitriseYML(context.Background(), "workflows: {}\n", "app-slug")
 	require.NoError(t, err)
 	assert.Equal(t, "app_slug=app-slug", gotQuery)
 	assert.JSONEq(t, `{"bitrise_yml":"workflows: {}\n"}`, gotBody)
@@ -108,7 +108,7 @@ func TestValidateBitriseYML_PropagatesAPIError(t *testing.T) {
 		_, _ = w.Write([]byte(`{"message":"could not parse YAML"}`))
 	})
 
-	_, err := New(srv.URL, "t").ValidateBitriseYML(context.Background(), "not: valid: yaml:", "")
+	_, err := newAPIClient(t, srv.URL, "t").ValidateBitriseYML(context.Background(), "not: valid: yaml:", "")
 	require.Error(t, err)
 	apiErr, ok := err.(*APIError)
 	require.True(t, ok, "expected *APIError, got %T", err)

--- a/internal/stack/service_test.go
+++ b/internal/stack/service_test.go
@@ -20,7 +20,7 @@ func TestList_SortsByIDAndNormalizesFields(t *testing.T) {
 			"a-stack": {"id":"a-stack","title":"A","os":"osx","status":"edge"}
 		}`))
 	})
-	client := bitriseapi.New(srv.URL, "t")
+	client := newAPIClient(t, srv.URL)
 
 	result, err := NewService(client).List(context.Background(), "")
 	require.NoError(t, err)
@@ -35,7 +35,7 @@ func TestList_FallsBackToMapKeyWhenInfoIDEmpty(t *testing.T) {
 	srv := newFakeServer(t, func(w http.ResponseWriter, _ *http.Request) {
 		_, _ = w.Write([]byte(`{"linux-docker-android": {"title":"Linux Android","os":"linux","status":"stable"}}`))
 	})
-	client := bitriseapi.New(srv.URL, "t")
+	client := newAPIClient(t, srv.URL)
 
 	result, err := NewService(client).List(context.Background(), "")
 	require.NoError(t, err)
@@ -49,7 +49,7 @@ func TestList_PassesWorkspaceSlugAsOrgScopedPath(t *testing.T) {
 		gotPath = r.URL.Path
 		_, _ = w.Write([]byte(`{}`))
 	})
-	client := bitriseapi.New(srv.URL, "t")
+	client := newAPIClient(t, srv.URL)
 
 	_, err := NewService(client).List(context.Background(), "my-workspace")
 	require.NoError(t, err)
@@ -86,7 +86,7 @@ func TestList_PropagatesAPIError(t *testing.T) {
 		w.WriteHeader(http.StatusUnauthorized)
 		_, _ = w.Write([]byte(`{"message":"Unauthorized"}`))
 	})
-	client := bitriseapi.New(srv.URL, "t")
+	client := newAPIClient(t, srv.URL)
 
 	_, err := NewService(client).List(context.Background(), "")
 	require.Error(t, err)
@@ -100,4 +100,11 @@ func newFakeServer(t *testing.T, handler http.HandlerFunc) *httptest.Server {
 	srv := httptest.NewServer(handler)
 	t.Cleanup(srv.Close)
 	return srv
+}
+
+func newAPIClient(t *testing.T, baseURL string) *bitriseapi.Client {
+	t.Helper()
+	c, err := bitriseapi.New(baseURL, "t")
+	require.NoError(t, err)
+	return c
 }

--- a/internal/user/profile_test.go
+++ b/internal/user/profile_test.go
@@ -20,7 +20,7 @@ func TestProfileService_Me(t *testing.T) {
 		}
 		_, _ = w.Write([]byte(`{"data":{"username":"alice","email":"alice@example.com","avatar_url":"https://example.com/a.png"}}`))
 	})
-	client := bitriseapi.New(srv.URL, "t")
+	client := newAPIClient(t, srv.URL)
 
 	profile, err := NewProfileService(client).Me(context.Background())
 	require.NoError(t, err)
@@ -45,4 +45,11 @@ func newFakeServer(t *testing.T, handler http.HandlerFunc) *httptest.Server {
 	srv := httptest.NewServer(handler)
 	t.Cleanup(srv.Close)
 	return srv
+}
+
+func newAPIClient(t *testing.T, baseURL string) *bitriseapi.Client {
+	t.Helper()
+	c, err := bitriseapi.New(baseURL, "t")
+	require.NoError(t, err)
+	return c
 }

--- a/internal/webclient/client.go
+++ b/internal/webclient/client.go
@@ -12,7 +12,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"net"
 	"net/http"
 	"net/http/cookiejar"
 	"net/url"
@@ -20,6 +19,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/bitrise-io/bitrise/v2/internal/baseurl"
 	"github.com/bitrise-io/bitrise/v2/version"
 )
 
@@ -161,28 +161,14 @@ func (c *Client) url(path string) (string, error) {
 }
 
 // normalizeBaseURL rejects a relative URL or a plaintext http:// URL against
-// a non-loopback host (this flow sends a password), and trims a trailing
-// slash so concatenating a leading-slash path in url() can't produce "//".
-// Loopback is allowed over http so tests can point at an httptest server.
+// a non-loopback host (this flow sends a password — see internal/baseurl),
+// and trims a trailing slash so concatenating a leading-slash path in url()
+// can't produce "//".
 func normalizeBaseURL(raw string) (string, error) {
-	u, err := url.Parse(raw)
+	u, err := baseurl.Validate("base URL", raw)
 	if err != nil {
-		return "", fmt.Errorf("parse base URL %q: %w", raw, err)
-	}
-	if !u.IsAbs() || u.Host == "" {
-		return "", fmt.Errorf("base URL %q must be an absolute URL", raw)
-	}
-	if u.Scheme != "https" && !isLoopbackHost(u.Hostname()) {
-		return "", fmt.Errorf("base URL %q must use https (got %q)", raw, u.Scheme)
+		return "", err
 	}
 	u.Path = strings.TrimSuffix(u.Path, "/")
 	return u.String(), nil
-}
-
-func isLoopbackHost(host string) bool {
-	if host == "localhost" {
-		return true
-	}
-	ip := net.ParseIP(host)
-	return ip != nil && ip.IsLoopback()
 }

--- a/internal/yml/service_test.go
+++ b/internal/yml/service_test.go
@@ -19,7 +19,7 @@ func TestGet_App(t *testing.T) {
 		_, _ = w.Write([]byte("format_version: \"13\"\n"))
 	})
 
-	result, err := NewService(bitriseapi.New(srv.URL, "t")).Get(context.Background(), "app-slug", "")
+	result, err := NewService(newAPIClient(t, srv.URL)).Get(context.Background(), "app-slug", "")
 	require.NoError(t, err)
 	assert.Equal(t, "app-slug", result.AppSlug)
 	assert.Empty(t, result.BuildSlug)
@@ -32,7 +32,7 @@ func TestGet_Build(t *testing.T) {
 		_, _ = w.Write([]byte("format_version: \"13\"\n"))
 	})
 
-	result, err := NewService(bitriseapi.New(srv.URL, "t")).Get(context.Background(), "app-slug", "build-slug")
+	result, err := NewService(newAPIClient(t, srv.URL)).Get(context.Background(), "app-slug", "build-slug")
 	require.NoError(t, err)
 	assert.Equal(t, "build-slug", result.BuildSlug)
 }
@@ -43,7 +43,7 @@ func TestGet_AppNotFound(t *testing.T) {
 		_, _ = w.Write([]byte(`{"message":"not found"}`))
 	})
 
-	_, err := NewService(bitriseapi.New(srv.URL, "t")).Get(context.Background(), "app-slug", "")
+	_, err := NewService(newAPIClient(t, srv.URL)).Get(context.Background(), "app-slug", "")
 	require.EqualError(t, err, `app "app-slug" not found`)
 }
 
@@ -53,7 +53,7 @@ func TestGet_BuildNotFound(t *testing.T) {
 		_, _ = w.Write([]byte(`{"message":"not found"}`))
 	})
 
-	_, err := NewService(bitriseapi.New(srv.URL, "t")).Get(context.Background(), "app-slug", "build-slug")
+	_, err := NewService(newAPIClient(t, srv.URL)).Get(context.Background(), "app-slug", "build-slug")
 	require.EqualError(t, err, `build "build-slug" not found`)
 }
 
@@ -63,7 +63,7 @@ func TestGet_PropagatesOtherErrors(t *testing.T) {
 		_, _ = w.Write([]byte(`{"message":"unauthorized"}`))
 	})
 
-	_, err := NewService(bitriseapi.New(srv.URL, "t")).Get(context.Background(), "app-slug", "")
+	_, err := NewService(newAPIClient(t, srv.URL)).Get(context.Background(), "app-slug", "")
 	require.Error(t, err)
 	apiErr, ok := err.(*bitriseapi.APIError)
 	require.True(t, ok, "expected *bitriseapi.APIError, got %T", err)
@@ -79,13 +79,13 @@ func TestUpdate_ParsesAndSendsYAML(t *testing.T) {
 		_, _ = w.Write([]byte(`{}`))
 	})
 
-	err := NewService(bitriseapi.New(srv.URL, "t")).Update(context.Background(), "app-slug", "format_version: \"13\"\n")
+	err := NewService(newAPIClient(t, srv.URL)).Update(context.Background(), "app-slug", "format_version: \"13\"\n")
 	require.NoError(t, err)
 	assert.JSONEq(t, `{"app_config_datastore_yaml":{"format_version":"13"}}`, gotBody)
 }
 
 func TestUpdate_InvalidYAML(t *testing.T) {
-	err := NewService(bitriseapi.New("http://unused.test", "t")).Update(context.Background(), "app-slug", "not: valid: yaml:")
+	err := NewService(newAPIClient(t, "https://unused.test")).Update(context.Background(), "app-slug", "not: valid: yaml:")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "parse bitrise.yml")
 }
@@ -96,7 +96,7 @@ func TestUpdate_AppNotFound(t *testing.T) {
 		_, _ = w.Write([]byte(`{"message":"not found"}`))
 	})
 
-	err := NewService(bitriseapi.New(srv.URL, "t")).Update(context.Background(), "app-slug", "format_version: \"13\"\n")
+	err := NewService(newAPIClient(t, srv.URL)).Update(context.Background(), "app-slug", "format_version: \"13\"\n")
 	require.EqualError(t, err, `app "app-slug" not found`)
 }
 
@@ -105,7 +105,7 @@ func TestValidate_Valid(t *testing.T) {
 		_, _ = w.Write([]byte(`{"errors":[],"warnings":[]}`))
 	})
 
-	result, err := NewService(bitriseapi.New(srv.URL, "t")).Validate(context.Background(), "format_version: \"13\"\n", "")
+	result, err := NewService(newAPIClient(t, srv.URL)).Validate(context.Background(), "format_version: \"13\"\n", "")
 	require.NoError(t, err)
 	assert.True(t, result.Valid)
 	assert.Equal(t, []string{}, result.Errors)
@@ -117,7 +117,7 @@ func TestValidate_OmittedSlicesAreNormalized(t *testing.T) {
 		_, _ = w.Write([]byte(`{}`))
 	})
 
-	result, err := NewService(bitriseapi.New(srv.URL, "t")).Validate(context.Background(), "format_version: \"13\"\n", "")
+	result, err := NewService(newAPIClient(t, srv.URL)).Validate(context.Background(), "format_version: \"13\"\n", "")
 	require.NoError(t, err)
 	assert.True(t, result.Valid)
 	assert.Equal(t, []string{}, result.Errors)
@@ -129,7 +129,7 @@ func TestValidate_WithWarnings(t *testing.T) {
 		_, _ = w.Write([]byte(`{"errors":[],"warnings":["deprecated step used"]}`))
 	})
 
-	result, err := NewService(bitriseapi.New(srv.URL, "t")).Validate(context.Background(), "format_version: \"13\"\n", "app-slug")
+	result, err := NewService(newAPIClient(t, srv.URL)).Validate(context.Background(), "format_version: \"13\"\n", "app-slug")
 	require.NoError(t, err)
 	assert.True(t, result.Valid)
 	assert.Equal(t, []string{"deprecated step used"}, result.Warnings)
@@ -141,7 +141,7 @@ func TestValidate_422TreatedAsInvalid(t *testing.T) {
 		_, _ = w.Write([]byte(`{"message":"could not parse YAML"}`))
 	})
 
-	result, err := NewService(bitriseapi.New(srv.URL, "t")).Validate(context.Background(), "not: valid: yaml:", "")
+	result, err := NewService(newAPIClient(t, srv.URL)).Validate(context.Background(), "not: valid: yaml:", "")
 	require.NoError(t, err)
 	assert.False(t, result.Valid)
 	assert.Equal(t, []string{"could not parse YAML"}, result.Errors)
@@ -157,7 +157,7 @@ func TestValidate_422WithUnrecognizedBodyStillExplainsWhy(t *testing.T) {
 		_, _ = w.Write([]byte(`<html>Bad Request</html>`))
 	})
 
-	result, err := NewService(bitriseapi.New(srv.URL, "t")).Validate(context.Background(), "not: valid: yaml:", "")
+	result, err := NewService(newAPIClient(t, srv.URL)).Validate(context.Background(), "not: valid: yaml:", "")
 	require.NoError(t, err)
 	assert.False(t, result.Valid)
 	require.Len(t, result.Errors, 1)
@@ -174,7 +174,7 @@ func TestValidate_PropagatesOtherErrors(t *testing.T) {
 		_, _ = w.Write([]byte(`{"message":"upstream exploded"}`))
 	})
 
-	_, err := NewService(bitriseapi.New(srv.URL, "t")).Validate(context.Background(), "format_version: \"13\"\n", "")
+	_, err := NewService(newAPIClient(t, srv.URL)).Validate(context.Background(), "format_version: \"13\"\n", "")
 	require.Error(t, err)
 	apiErr, ok := err.(*bitriseapi.APIError)
 	require.True(t, ok, "expected *bitriseapi.APIError, got %T", err)
@@ -186,4 +186,11 @@ func newFakeServer(t *testing.T, handler http.HandlerFunc) *httptest.Server {
 	srv := httptest.NewServer(handler)
 	t.Cleanup(srv.Close)
 	return srv
+}
+
+func newAPIClient(t *testing.T, baseURL string) *bitriseapi.Client {
+	t.Helper()
+	c, err := bitriseapi.New(baseURL, "t")
+	require.NoError(t, err)
+	return c
 }


### PR DESCRIPTION
internal/bitriseapi.New validated nothing, so an api_base_url of http://... silently sent the bearer token over plaintext HTTP on every cloud command. internal/webclient.New already required https (except loopback, so tests can point at an httptest server) because its flow posts a password; the same rule belongs on the API client, which sends a token just as sensitive.

Extracted that shared rule into internal/baseurl rather than duplicating it a second time. New now returns an error, which is what updates the call sites here; the httptest URLs those tests pass are loopback and still valid.