### PR TITLE
v3 prep: extract the cross-process file lock into internal/filelock

### DIFF
--- a/internal/auth/lock.go
+++ b/internal/auth/lock.go
@@ -2,20 +2,16 @@ package auth
 
 import (
 	"context"
-	"crypto/rand"
-	"encoding/hex"
-	"errors"
-	"fmt"
-	"io/fs"
-	"os"
-	"path/filepath"
 	"time"
+
+	"github.com/bitrise-io/bitrise/v2/internal/filelock"
 )
 
-// lockStaleAfter bounds how long a lock file is honored after its holder last
-// renewed it. A live holder re-stamps the mtime every lockRefreshInterval (see
-// newLockLease), so exceeding this means the holder died — not that its refresh
-// is slow, which the OAuth ladder's network calls can legitimately be.
+// lockStaleAfter/lockRefreshInterval size the lease for the OAuth ladder's
+// read-refresh-write sequence, which can legitimately run across three
+// sequential token requests, each with its own timeout — much slower than
+// internal/config's lock, which is why this can't share a single fixed
+// Options value with it.
 //
 // Vars rather than consts so tests can compress both timings.
 var (
@@ -23,129 +19,13 @@ var (
 	lockRefreshInterval = 5 * time.Second
 )
 
-const lockRetryDelay = 50 * time.Millisecond
-
 // Lock acquires an exclusive, cross-process lock around a read-refresh-write
 // sequence on auth.yaml, so concurrent CLI invocations don't race the OAuth
 // refresh token. Call the returned unlock func to release it.
 func Lock(ctx context.Context) (unlock func(), err error) {
-	p, err := lockPath()
-	if err != nil {
-		return nil, err
-	}
-	if err := os.MkdirAll(filepath.Dir(p), 0o700); err != nil {
-		return nil, fmt.Errorf("create config dir: %w", err)
-	}
-	nonce, err := lockNonce()
-	if err != nil {
-		return nil, err
-	}
-	for {
-		f, err := os.OpenFile(p, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
-		if err == nil {
-			if err := writeLockNonce(f, nonce); err != nil {
-				_ = os.Remove(p)
-				return nil, fmt.Errorf("write lock %s: %w", p, err)
-			}
-			return newLockLease(p, nonce), nil
-		}
-		if !errors.Is(err, fs.ErrExist) {
-			return nil, fmt.Errorf("create lock %s: %w", p, err)
-		}
-		stale, statErr := lockIsStale(p)
-		if statErr != nil {
-			if errors.Is(statErr, fs.ErrNotExist) {
-				// The lock file vanished between our OpenFile and this stat
-				// (the holder released it) — retry immediately.
-				continue
-			}
-			return nil, fmt.Errorf("check lock %s: %w", p, statErr)
-		}
-		if stale {
-			_ = os.Remove(p)
-			continue
-		}
-		select {
-		case <-ctx.Done():
-			return nil, fmt.Errorf("timed out waiting for auth lock: %w", ctx.Err())
-		case <-time.After(lockRetryDelay):
-		}
-	}
-}
-
-func lockPath() (string, error) {
 	p, err := Path()
 	if err != nil {
-		return "", err
+		return nil, err
 	}
-	return p + ".lock", nil
-}
-
-// lockNonce identifies this process's hold on the lock, so a lock reclaimed as
-// stale is never mistaken for our own (see lockIsOwned).
-func lockNonce() (string, error) {
-	b := make([]byte, 16)
-	if _, err := rand.Read(b); err != nil {
-		return "", fmt.Errorf("generate lock nonce: %w", err)
-	}
-	return hex.EncodeToString(b), nil
-}
-
-func writeLockNonce(f *os.File, nonce string) error {
-	if _, err := f.WriteString(nonce); err != nil {
-		_ = f.Close()
-		return err
-	}
-	return f.Close()
-}
-
-// newLockLease keeps the held lock's mtime current until unlock, so a refresh
-// that is slow (three sequential token requests, each with its own timeout) is
-// never mistaken for a crashed process and stolen mid-flight. Both the renewal
-// and the release are gated on still owning the lock, so a hold that did lapse
-// and was reclaimed is neither kept alive nor deleted by its former holder.
-func newLockLease(path, nonce string) (unlock func()) {
-	interval := lockRefreshInterval
-	stop := make(chan struct{})
-	stopped := make(chan struct{})
-	go func() {
-		defer close(stopped)
-		t := time.NewTicker(interval)
-		defer t.Stop()
-		for {
-			select {
-			case <-stop:
-				return
-			case now := <-t.C:
-				if lockIsOwned(path, nonce) {
-					_ = os.Chtimes(path, now, now)
-				}
-			}
-		}
-	}()
-	return func() {
-		close(stop)
-		<-stopped
-		if lockIsOwned(path, nonce) {
-			_ = os.Remove(path)
-		}
-	}
-}
-
-func lockIsOwned(path, nonce string) bool {
-	b, err := os.ReadFile(path)
-	return err == nil && string(b) == nonce
-}
-
-// statLockFile is a var so tests can simulate stat failures other than
-// fs.ErrNotExist (e.g. permission denied) without depending on real,
-// platform-specific filesystem permission behavior.
-var statLockFile = os.Stat
-
-func lockIsStale(p string) (bool, error) {
-	info, err := statLockFile(p)
-	if err != nil {
-		return false, err
-	}
-	return time.Since(info.ModTime()) > lockStaleAfter, nil
+	return filelock.Lock(ctx, p, filelock.Options{StaleAfter: lockStaleAfter, RefreshInterval: lockRefreshInterval})
 }

--- a/internal/auth/lock_test.go
+++ b/internal/auth/lock_test.go
@@ -2,10 +2,6 @@ package auth
 
 import (
 	"context"
-	"errors"
-	"io/fs"
-	"os"
-	"path/filepath"
 	"testing"
 	"time"
 
@@ -31,66 +27,6 @@ func TestLock_ExcludesSecondAcquirer(t *testing.T) {
 	unlock2()
 }
 
-func TestLock_ReclaimsStaleLock(t *testing.T) {
-	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
-
-	p, err := lockPath()
-	require.NoError(t, err)
-	require.NoError(t, os.MkdirAll(filepath.Dir(p), 0o700))
-	require.NoError(t, os.WriteFile(p, nil, 0o600))
-	old := time.Now().Add(-lockStaleAfter - time.Second)
-	require.NoError(t, os.Chtimes(p, old, old))
-
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
-	unlock, err := Lock(ctx)
-	require.NoError(t, err, "a stale lock should be reclaimed rather than blocking forever")
-	unlock()
-}
-
-func TestLock_PropagatesStatErrorOtherThanNotExist(t *testing.T) {
-	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
-
-	p, err := lockPath()
-	require.NoError(t, err)
-	require.NoError(t, os.MkdirAll(filepath.Dir(p), 0o700))
-	require.NoError(t, os.WriteFile(p, nil, 0o600))
-
-	wantErr := errors.New("permission denied")
-	orig := statLockFile
-	statLockFile = func(name string) (os.FileInfo, error) { return nil, wantErr }
-	defer func() { statLockFile = orig }()
-
-	_, err = Lock(context.Background())
-	require.Error(t, err, "a real stat failure must not be silently retried forever")
-	assert.ErrorIs(t, err, wantErr)
-}
-
-func TestLock_RetriesImmediatelyWhenLockFileVanishes(t *testing.T) {
-	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
-
-	p, err := lockPath()
-	require.NoError(t, err)
-	require.NoError(t, os.MkdirAll(filepath.Dir(p), 0o700))
-	require.NoError(t, os.WriteFile(p, nil, 0o600))
-
-	// Simulate another process releasing the lock in the window between our
-	// OpenFile (which saw it exist) and this stat call: the file disappears
-	// out from under us, and lockIsStale surfaces that as fs.ErrNotExist.
-	orig := statLockFile
-	statLockFile = func(name string) (os.FileInfo, error) {
-		_ = os.Remove(p)
-		return nil, fs.ErrNotExist
-	}
-	defer func() { statLockFile = orig }()
-
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
-	unlock, err := Lock(ctx)
-	require.NoError(t, err, "should retry once the file is actually gone, not error out or hang")
-	unlock()
-}
-
 func TestLock_CtxTimeoutWhileWaiting(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 
@@ -102,13 +38,15 @@ func TestLock_CtxTimeoutWhileWaiting(t *testing.T) {
 	defer cancel()
 	_, err = Lock(ctx)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "timed out waiting for auth lock")
+	assert.Contains(t, err.Error(), "timed out waiting for lock")
 }
 
 // TestLock_HeldLockSurvivesTheStaleWindow covers the case a plain mtime check
 // gets wrong: the OAuth ladder can hold the lock across three sequential token
 // requests, longer than lockStaleAfter, and a waiter must not then reclaim the
-// lock and spend the same refresh token.
+// lock and spend the same refresh token. The general staleness/reclaim/nonce
+// mechanics live in internal/filelock's own tests; this just confirms auth
+// wires its (staleAfter, refreshInterval) pair correctly.
 func TestLock_HeldLockSurvivesTheStaleWindow(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	compressLockTimings(t, 100*time.Millisecond, 10*time.Millisecond)
@@ -123,25 +61,6 @@ func TestLock_HeldLockSurvivesTheStaleWindow(t *testing.T) {
 	defer cancel()
 	_, err = Lock(ctx)
 	assert.Error(t, err, "a still-held lock must not be reclaimed just because the hold outlived lockStaleAfter")
-}
-
-func TestLock_UnlockLeavesAReclaimedLockAlone(t *testing.T) {
-	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
-
-	unlock, err := Lock(context.Background())
-	require.NoError(t, err)
-
-	// Stand in for another process reclaiming the lock as stale and taking it:
-	// same path, different owner.
-	p, err := lockPath()
-	require.NoError(t, err)
-	require.NoError(t, os.WriteFile(p, []byte("another-process"), 0o600))
-
-	unlock()
-
-	got, err := os.ReadFile(p)
-	require.NoError(t, err, "unlock must not delete a lock held by someone else")
-	assert.Equal(t, "another-process", string(got))
 }
 
 func compressLockTimings(t *testing.T, staleAfter, refreshInterval time.Duration) {

--- a/internal/filelock/filelock.go
+++ b/internal/filelock/filelock.go
@@ -1,0 +1,163 @@
+// Package filelock provides a simple, cross-process exclusive lock backed by
+// a sentinel file, for serializing a read-modify-write sequence on some other
+// file across separate CLI invocations. Shared by internal/auth (guarding
+// auth.yaml against the OAuth refresh race) and internal/config (guarding
+// config.yml against concurrent `config set`/`unset`).
+package filelock
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// retryDelay paces re-checks while waiting for a held lock. Var rather than
+// const so tests can compress it.
+var retryDelay = 50 * time.Millisecond
+
+// Options configures Lock's staleness handling. Both durations should be
+// picked relative to how long the caller's critical section can actually
+// run.
+type Options struct {
+	// StaleAfter bounds how long a lock file is honored without being
+	// refreshed. Exceeding it means the holder crashed (or never
+	// refreshes, RefreshInterval == 0, and the write it was guarding
+	// already finished) — not that the holder is merely slow.
+	StaleAfter time.Duration
+	// RefreshInterval re-stamps the held lock's mtime this often, so a
+	// critical section slower than StaleAfter is never mistaken for a
+	// crashed holder. Zero disables refreshing, which is fine as long as
+	// StaleAfter comfortably exceeds the slowest realistic hold time.
+	RefreshInterval time.Duration
+}
+
+// Lock acquires an exclusive, cross-process lock on path+".lock" (creating
+// path's parent directory if needed), so a read-modify-write sequence on
+// path isn't raced by another process doing the same. Call the returned
+// unlock func to release it.
+func Lock(ctx context.Context, path string, opts Options) (unlock func(), err error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	lockPath := path + ".lock"
+	if err := os.MkdirAll(filepath.Dir(lockPath), 0o700); err != nil {
+		return nil, fmt.Errorf("create lock dir: %w", err)
+	}
+	nonce, err := lockNonce()
+	if err != nil {
+		return nil, err
+	}
+	for {
+		f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+		if err == nil {
+			if err := writeLockNonce(f, nonce); err != nil {
+				_ = os.Remove(lockPath)
+				return nil, fmt.Errorf("write lock %s: %w", lockPath, err)
+			}
+			return newLockLease(lockPath, nonce, opts.RefreshInterval), nil
+		}
+		if !errors.Is(err, fs.ErrExist) {
+			return nil, fmt.Errorf("create lock %s: %w", lockPath, err)
+		}
+		stale, statErr := lockIsStale(lockPath, opts.StaleAfter)
+		if statErr != nil {
+			if errors.Is(statErr, fs.ErrNotExist) {
+				// The lock file vanished between our OpenFile and this stat
+				// (the holder released it) — retry immediately.
+				continue
+			}
+			return nil, fmt.Errorf("check lock %s: %w", lockPath, statErr)
+		}
+		if stale {
+			_ = os.Remove(lockPath)
+			continue
+		}
+		select {
+		case <-ctx.Done():
+			return nil, fmt.Errorf("timed out waiting for lock %s: %w", lockPath, ctx.Err())
+		case <-time.After(retryDelay):
+		}
+	}
+}
+
+// lockNonce identifies this call's hold on the lock, so a lock reclaimed as
+// stale is never mistaken for our own (see lockIsOwned).
+func lockNonce() (string, error) {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("generate lock nonce: %w", err)
+	}
+	return hex.EncodeToString(b), nil
+}
+
+func writeLockNonce(f *os.File, nonce string) error {
+	if _, err := f.WriteString(nonce); err != nil {
+		_ = f.Close()
+		return err
+	}
+	return f.Close()
+}
+
+// newLockLease optionally keeps the held lock's mtime current until unlock
+// (refreshInterval > 0), so a critical section slower than StaleAfter is
+// never mistaken for a crashed process and stolen mid-flight. Both the
+// renewal and the release are gated on still owning the lock, so a hold that
+// did lapse and was reclaimed is neither kept alive nor deleted by its
+// former holder.
+func newLockLease(path, nonce string, refreshInterval time.Duration) (unlock func()) {
+	if refreshInterval <= 0 {
+		return func() {
+			if lockIsOwned(path, nonce) {
+				_ = os.Remove(path)
+			}
+		}
+	}
+	stop := make(chan struct{})
+	stopped := make(chan struct{})
+	go func() {
+		defer close(stopped)
+		t := time.NewTicker(refreshInterval)
+		defer t.Stop()
+		for {
+			select {
+			case <-stop:
+				return
+			case now := <-t.C:
+				if lockIsOwned(path, nonce) {
+					_ = os.Chtimes(path, now, now)
+				}
+			}
+		}
+	}()
+	return func() {
+		close(stop)
+		<-stopped
+		if lockIsOwned(path, nonce) {
+			_ = os.Remove(path)
+		}
+	}
+}
+
+func lockIsOwned(path, nonce string) bool {
+	b, err := os.ReadFile(path)
+	return err == nil && string(b) == nonce
+}
+
+// statFile is a var so tests can simulate stat failures other than
+// fs.ErrNotExist (e.g. permission denied) without depending on real,
+// platform-specific filesystem permission behavior.
+var statFile = os.Stat
+
+func lockIsStale(p string, staleAfter time.Duration) (bool, error) {
+	info, err := statFile(p)
+	if err != nil {
+		return false, err
+	}
+	return time.Since(info.ModTime()) > staleAfter, nil
+}

--- a/internal/filelock/filelock_test.go
+++ b/internal/filelock/filelock_test.go
@@ -1,0 +1,167 @@
+package filelock
+
+import (
+	"context"
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func testOptions() Options {
+	return Options{StaleAfter: 30 * time.Second, RefreshInterval: 5 * time.Second}
+}
+
+func TestLock_ExcludesSecondAcquirer(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "resource")
+
+	unlock, err := Lock(context.Background(), p, testOptions())
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	_, err = Lock(ctx, p, testOptions())
+	assert.Error(t, err, "a second acquirer should not get the lock while it's held")
+
+	unlock()
+
+	unlock2, err := Lock(context.Background(), p, testOptions())
+	require.NoError(t, err, "lock should be acquirable again after release")
+	unlock2()
+}
+
+func TestLock_ReclaimsStaleLock(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "resource")
+	opts := testOptions()
+
+	lockPath := p + ".lock"
+	require.NoError(t, os.WriteFile(lockPath, nil, 0o600))
+	old := time.Now().Add(-opts.StaleAfter - time.Second)
+	require.NoError(t, os.Chtimes(lockPath, old, old))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	unlock, err := Lock(ctx, p, opts)
+	require.NoError(t, err, "a stale lock should be reclaimed rather than blocking forever")
+	unlock()
+}
+
+func TestLock_PropagatesStatErrorOtherThanNotExist(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "resource")
+	lockPath := p + ".lock"
+	require.NoError(t, os.WriteFile(lockPath, nil, 0o600))
+
+	wantErr := errors.New("permission denied")
+	orig := statFile
+	statFile = func(name string) (os.FileInfo, error) { return nil, wantErr }
+	defer func() { statFile = orig }()
+
+	_, err := Lock(context.Background(), p, testOptions())
+	require.Error(t, err, "a real stat failure must not be silently retried forever")
+	assert.ErrorIs(t, err, wantErr)
+}
+
+func TestLock_RetriesImmediatelyWhenLockFileVanishes(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "resource")
+	lockPath := p + ".lock"
+	require.NoError(t, os.WriteFile(lockPath, nil, 0o600))
+
+	// Simulate another process releasing the lock in the window between our
+	// OpenFile (which saw it exist) and this stat call: the file disappears
+	// out from under us, and lockIsStale surfaces that as fs.ErrNotExist.
+	orig := statFile
+	statFile = func(name string) (os.FileInfo, error) {
+		_ = os.Remove(lockPath)
+		return nil, fs.ErrNotExist
+	}
+	defer func() { statFile = orig }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	unlock, err := Lock(ctx, p, testOptions())
+	require.NoError(t, err, "should retry once the file is actually gone, not error out or hang")
+	unlock()
+}
+
+func TestLock_CtxTimeoutWhileWaiting(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "resource")
+
+	unlock, err := Lock(context.Background(), p, testOptions())
+	require.NoError(t, err)
+	defer unlock()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	_, err = Lock(ctx, p, testOptions())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "timed out waiting for lock")
+}
+
+// TestLock_HeldLockSurvivesTheStaleWindow covers the case a plain mtime check
+// gets wrong: a holder can legitimately keep the lock across a critical
+// section longer than StaleAfter as long as RefreshInterval keeps re-stamping
+// it, and a waiter must not then reclaim the lock mid-hold.
+func TestLock_HeldLockSurvivesTheStaleWindow(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "resource")
+	opts := Options{StaleAfter: 100 * time.Millisecond, RefreshInterval: 10 * time.Millisecond}
+
+	unlock, err := Lock(context.Background(), p, opts)
+	require.NoError(t, err)
+	defer unlock()
+
+	time.Sleep(5 * opts.StaleAfter)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	_, err = Lock(ctx, p, opts)
+	assert.Error(t, err, "a still-held lock must not be reclaimed just because the hold outlived StaleAfter")
+}
+
+func TestLock_NoRefreshDoesNotSurviveTheStaleWindow(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "resource")
+	opts := Options{StaleAfter: 50 * time.Millisecond} // RefreshInterval: 0
+
+	unlock, err := Lock(context.Background(), p, opts)
+	require.NoError(t, err)
+	defer unlock()
+
+	time.Sleep(5 * opts.StaleAfter)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	unlock2, err := Lock(ctx, p, opts)
+	require.NoError(t, err, "with RefreshInterval 0 the lock is expected to go stale and be reclaimed once StaleAfter elapses")
+	unlock2()
+}
+
+func TestLock_UnlockLeavesAReclaimedLockAlone(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "resource")
+
+	unlock, err := Lock(context.Background(), p, testOptions())
+	require.NoError(t, err)
+
+	// Stand in for another process reclaiming the lock as stale and taking it:
+	// same path, different owner.
+	lockPath := p + ".lock"
+	require.NoError(t, os.WriteFile(lockPath, []byte("another-process"), 0o600))
+
+	unlock()
+
+	got, err := os.ReadFile(lockPath)
+	require.NoError(t, err, "unlock must not delete a lock held by someone else")
+	assert.Equal(t, "another-process", string(got))
+}
+
+func TestLock_NilContextDoesNotPanic(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "resource")
+
+	//nolint:staticcheck // SA1012: deliberately passing a nil context.Context — callers' cmd.Context() can be nil in tests that invoke RunE directly instead of Execute()
+	unlock, err := Lock(nil, p, testOptions())
+	require.NoError(t, err)
+	unlock()
+}


### PR DESCRIPTION
internal/auth.Lock guards auth.yaml against concurrent OAuth refreshes with a lock file, staleness detection and automated renewal. The global config file needs the same protection for its read-modify-write cycle, so move the mechanism somewhere both can use instead of copying it.

The two differ only in timing: auth holds the lock across several sequential token requests and needs the lease to keep re-stamping it, while a config write is local disk I/O that finishes well inside the staleness window. Those become Options fields, and the mechanism tests move with the code.