### PR TITLE
v3 prep: add the `config` command

### DIFF
--- a/_docs/v3-breaking-changes.md
+++ b/_docs/v3-breaking-changes.md
@@ -139,6 +139,17 @@ scripts keep running: `trigger-check` was the only command removed outright, and
   one. *Migrate:* no action required. To have a value controlled by the new
   per-directory or global file instead, remove that value from
   `~/.bitrise/config.json`.
+- **`api_base_url` and `web_base_url` never come from the per-directory file.** These
+  two keys — new in v3, managed with `bitrise config get/set/unset/list` and stored in
+  the global `~/.config/bitrise/cli/config.yml` — are the one exception to the
+  precedence above: they are only ever read from the global file. Both carry
+  credentials (a bearer token, a login password) to whatever host they name, and
+  `.bitrise-cli.yml` is picked up from the working directory and its ancestors with no
+  confirmation, so a repo you merely clone and run `bitrise` inside of must not be able
+  to redirect them. `web_base_url` is additionally overridable via
+  `$BITRISE_WEB_BASE_URL`, which wins over the global file. *Migrate:* set these keys
+  with `bitrise config set` or the env var — either key in a `.bitrise-cli.yml` is
+  ignored.
 - **`setup`/CLI-update-check/plugin-update-check now also write `config.yml`.** If you
   already have `~/.bitrise/config.json`, it keeps being updated exactly as before (still
   authoritative for reads), and `~/.config/bitrise/cli/config.yml` is kept in sync

--- a/cli/auth/login.go
+++ b/cli/auth/login.go
@@ -58,6 +58,11 @@ Bitrise (OAuth) and stores a managed, auto-refreshing token. The modes:
          bitrise auth login --email alice@example.com
          printf '%s' "$PW" | bitrise auth login --email alice@example.com --password-stdin
 
+     The target is web_base_url (default app.bitrise.io), overridable via
+     $BITRISE_WEB_BASE_URL or 'bitrise config set web_base_url' — never by a
+     per-directory .bitrise-cli.yml, so a repo you merely clone can't
+     silently redirect where your password is sent.
+
 The resulting token is written to $XDG_CONFIG_HOME/bitrise/cli/auth.yaml with
 0600 permissions and is never echoed (use 'auth status' to verify, 'auth
 logout' to clear).`,
@@ -137,7 +142,7 @@ func runEmailLogin(cmd *cobra.Command, email string, passwordStdin bool) error {
 	if pw == "" {
 		return fmt.Errorf("password is empty")
 	}
-	wc, err := webclient.New(cmdutil.ResolveWebBaseURL())
+	wc, err := webclient.New(cmdutil.ResolveWebBaseURL(cmd))
 	if err != nil {
 		return err
 	}

--- a/cli/cmdutil/webbase.go
+++ b/cli/cmdutil/webbase.go
@@ -4,6 +4,7 @@ import (
 	"os"
 
 	"github.com/bitrise-io/bitrise/v2/internal/config"
+	"github.com/spf13/cobra"
 )
 
 // EnvWebBaseURL overrides the web base URL — rarely changed, mostly for
@@ -11,10 +12,17 @@ import (
 // directly.
 const EnvWebBaseURL = "BITRISE_WEB_BASE_URL"
 
-const defaultWebBaseURL = "https://app.bitrise.io"
-
-// ResolveWebBaseURL returns the resolved web base URL, overridable via
-// BITRISE_WEB_BASE_URL.
-func ResolveWebBaseURL() string {
-	return config.FirstNonEmptyString(os.Getenv(EnvWebBaseURL), defaultWebBaseURL)
+// ResolveWebBaseURL returns the resolved web base URL: BITRISE_WEB_BASE_URL,
+// then the web_base_url set via `bitrise config set`/a per-dir
+// .bitrise-cli.yml, then the built-in default.
+func ResolveWebBaseURL(cmd *cobra.Command) string {
+	if v := os.Getenv(EnvWebBaseURL); v != "" {
+		return v
+	}
+	if ctx := cmd.Context(); ctx != nil {
+		if v := config.FromContext(ctx).WebBaseURL; v != "" {
+			return v
+		}
+	}
+	return config.DefaultWebBaseURL
 }

--- a/cli/cmdutil/webbase.go
+++ b/cli/cmdutil/webbase.go
@@ -13,8 +13,9 @@ import (
 const EnvWebBaseURL = "BITRISE_WEB_BASE_URL"
 
 // ResolveWebBaseURL returns the resolved web base URL: BITRISE_WEB_BASE_URL,
-// then the web_base_url set via `bitrise config set`/a per-dir
-// .bitrise-cli.yml, then the built-in default.
+// then the web_base_url set via `bitrise config set` (global config file only
+// — never a per-dir .bitrise-cli.yml, see internal/config.Resolve), then the
+// built-in default.
 func ResolveWebBaseURL(cmd *cobra.Command) string {
 	if v := os.Getenv(EnvWebBaseURL); v != "" {
 		return v

--- a/cli/cmdutil/webbase_test.go
+++ b/cli/cmdutil/webbase_test.go
@@ -1,0 +1,39 @@
+package cmdutil
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/bitrise-io/bitrise/v2/internal/config"
+)
+
+func TestResolveWebBaseURL_EnvWinsOverContext(t *testing.T) {
+	t.Setenv(EnvWebBaseURL, "https://env.example")
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(config.WithResolved(t.Context(), config.Resolved{Config: config.Config{WebBaseURL: "https://ctx.example"}}))
+
+	assert.Equal(t, "https://env.example", ResolveWebBaseURL(cmd))
+}
+
+func TestResolveWebBaseURL_ContextWinsOverDefault(t *testing.T) {
+	cmd := &cobra.Command{}
+	cmd.SetContext(config.WithResolved(t.Context(), config.Resolved{Config: config.Config{WebBaseURL: "https://ctx.example"}}))
+
+	assert.Equal(t, "https://ctx.example", ResolveWebBaseURL(cmd))
+}
+
+func TestResolveWebBaseURL_NilContextFallsBackToDefault(t *testing.T) {
+	cmd := &cobra.Command{}
+
+	assert.Equal(t, config.DefaultWebBaseURL, ResolveWebBaseURL(cmd))
+}
+
+func TestResolveWebBaseURL_EmptyResolvedContextFallsBackToDefault(t *testing.T) {
+	cmd := &cobra.Command{}
+	cmd.SetContext(t.Context())
+
+	assert.Equal(t, config.DefaultWebBaseURL, ResolveWebBaseURL(cmd))
+}

--- a/cli/config/cmd.go
+++ b/cli/config/cmd.go
@@ -1,0 +1,49 @@
+package config
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/bitrise-io/bitrise/v2/cli/cmdutil"
+	internalconfig "github.com/bitrise-io/bitrise/v2/internal/config"
+)
+
+// NewCmd returns the `config` parent command and its subcommands.
+func NewCmd() *cobra.Command {
+	c := &cobra.Command{
+		Use:   "config",
+		Short: "Manage CLI configuration (defaults persisted to a YAML file).",
+		Long: fmt.Sprintf(`Manage persistent CLI configuration.
+
+Storage:
+  Global file: ~/.config/bitrise/cli/config.yml
+               (honors $XDG_CONFIG_HOME instead of ~/.config)
+
+Precedence, highest to lowest: global file > built-in default.
+web_base_url is additionally overridable via $%s, which takes precedence
+over the global file.
+
+Recognized keys: %s
+
+These two keys deliberately ignore the per-directory .bitrise-cli.yml file
+(unlike every other setting) and the legacy ~/.bitrise/config.json — both
+carry credentials to whatever host they name, and a repo you merely clone
+and run 'bitrise' inside of must not be able to silently redirect them.
+'get'/'set'/'unset'/'list' only read and write the global file.
+
+To manage your access token, use 'bitrise auth login/logout/status'.`,
+			cmdutil.EnvWebBaseURL, strings.Join(internalconfig.Keys, ", "),
+		),
+		RunE: cmdutil.RequireKnownSubcommand,
+	}
+	c.AddCommand(
+		NewPathCommand(),
+		NewListCommand(),
+		NewGetCommand(),
+		NewSetCommand(),
+		NewUnsetCommand(),
+	)
+	return c
+}

--- a/cli/config/get.go
+++ b/cli/config/get.go
@@ -1,0 +1,40 @@
+package config
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/bitrise-io/bitrise/v2/cli/cmdutil"
+	internalconfig "github.com/bitrise-io/bitrise/v2/internal/config"
+)
+
+// NewGetCommand returns the `config get` subcommand.
+func NewGetCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:       "get KEY",
+		Short:     "Print the value of a single config key",
+		ValidArgs: internalconfig.Keys,
+		Long: fmt.Sprintf(`Print the value of one config key from the global config file.
+
+Valid keys: %s`,
+			strings.Join(internalconfig.Keys, ", "),
+		),
+		Args: cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cmdutil.LogCommandParameters(cmd)
+
+			cfg, err := internalconfig.Load()
+			if err != nil {
+				return err
+			}
+			v, err := cfg.Get(args[0])
+			if err != nil {
+				return err
+			}
+			_, err = fmt.Fprintln(cmd.OutOrStdout(), v)
+			return err
+		},
+	}
+}

--- a/cli/config/get_test.go
+++ b/cli/config/get_test.go
@@ -1,0 +1,65 @@
+package config
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	internalconfig "github.com/bitrise-io/bitrise/v2/internal/config"
+)
+
+func TestGetCmd_PrintsStoredValue(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	require.NoError(t, internalconfig.Save(internalconfig.Config{APIBaseURL: "https://api.example.com"}))
+
+	cmd, out := newTestCmd(t, NewGetCommand())
+	require.NoError(t, cmd.RunE(cmd, []string{internalconfig.KeyAPIBaseURL}))
+
+	assert.Equal(t, "https://api.example.com\n", out.String())
+}
+
+func TestGetCmd_UnsetKeyPrintsEmptyLine(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	cmd, out := newTestCmd(t, NewGetCommand())
+	require.NoError(t, cmd.RunE(cmd, []string{internalconfig.KeyWebBaseURL}))
+
+	assert.Equal(t, "\n", out.String())
+}
+
+func TestGetCmd_UnknownKeyErrors(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	cmd, _ := newTestCmd(t, NewGetCommand())
+	err := cmd.RunE(cmd, []string{"nope"})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown config key")
+}
+
+func TestGetCmd_RequiresExactlyOneArg(t *testing.T) {
+	cmd := NewGetCommand()
+	cmd.SetArgs([]string{})
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	assert.Error(t, cmd.Execute())
+
+	cmd = NewGetCommand()
+	cmd.SetArgs([]string{"a", "b"})
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	assert.Error(t, cmd.Execute())
+}
+
+func TestGetCmd_ExecuteRejectsUnknownKeyBeforeRunE(t *testing.T) {
+	cmd := NewGetCommand()
+	cmd.SetArgs([]string{"nope"})
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `invalid argument "nope"`)
+}

--- a/cli/config/list.go
+++ b/cli/config/list.go
@@ -1,0 +1,77 @@
+package config
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/bitrise-io/bitrise/v2/cli/cmdutil"
+	internalconfig "github.com/bitrise-io/bitrise/v2/internal/config"
+	"github.com/bitrise-io/bitrise/v2/output"
+)
+
+// configList is the JSON/YAML shape of `config list`. Neither URL field is
+// omitempty: this command's job is to enumerate every recognized key's
+// state, so an unset key must still appear (as "") rather than vanish from
+// the JSON/YAML output while still showing as "(unset)" in raw mode.
+type configList struct {
+	APIBaseURL string `json:"api_base_url" yaml:"api_base_url"`
+	WebBaseURL string `json:"web_base_url" yaml:"web_base_url"`
+	Path       string `json:"path" yaml:"path"`
+}
+
+// NewListCommand returns the `config list` subcommand.
+func NewListCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List the values currently saved in the global config file",
+		Long: `List the values currently saved in the global config file.
+
+This does not show the BITRISE_WEB_BASE_URL environment override, which
+takes precedence over it at runtime.`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cmdutil.LogCommandParameters(cmd)
+
+			format, _ := cmd.Flags().GetString(cmdutil.FormatKey)
+			if err := output.ConfigureOutputFormat(format); err != nil {
+				return fmt.Errorf("failed to configure output format: %w", err)
+			}
+
+			cfg, err := internalconfig.Load()
+			if err != nil {
+				return err
+			}
+			p, err := internalconfig.Path()
+			if err != nil {
+				return err
+			}
+			v := configList{APIBaseURL: cfg.APIBaseURL, WebBaseURL: cfg.WebBaseURL, Path: p}
+
+			if output.Format == output.FormatRaw {
+				return printListHuman(cmd.OutOrStdout(), v)
+			}
+			return output.Print(v, output.Format)
+		},
+	}
+
+	cmd.Flags().StringP(cmdutil.FormatKey, "f", "", "Output format. Accepted: raw (default), json, yml")
+	return cmd
+}
+
+func printListHuman(w io.Writer, v configList) error {
+	_, err := fmt.Fprintf(w, "Path: %s\n\n%s: %s\n%s: %s\n",
+		v.Path,
+		internalconfig.KeyAPIBaseURL, unsetLabel(v.APIBaseURL),
+		internalconfig.KeyWebBaseURL, unsetLabel(v.WebBaseURL),
+	)
+	return err
+}
+
+func unsetLabel(v string) string {
+	if v == "" {
+		return "(unset)"
+	}
+	return v
+}

--- a/cli/config/list_test.go
+++ b/cli/config/list_test.go
@@ -1,0 +1,77 @@
+package config
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	internalconfig "github.com/bitrise-io/bitrise/v2/internal/config"
+	"github.com/bitrise-io/bitrise/v2/log"
+)
+
+func TestListCmd_Empty(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	cmd, out := newTestCmd(t, NewListCommand())
+	require.NoError(t, cmd.RunE(cmd, nil))
+
+	got := out.String()
+	assert.Contains(t, got, "Path: ")
+	assert.Contains(t, got, "api_base_url: (unset)")
+	assert.Contains(t, got, "web_base_url: (unset)")
+}
+
+func TestListCmd_ShowsSavedValues(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	require.NoError(t, internalconfig.Save(internalconfig.Config{APIBaseURL: "https://api.example.com"}))
+
+	cmd, out := newTestCmd(t, NewListCommand())
+	require.NoError(t, cmd.RunE(cmd, nil))
+
+	assert.Contains(t, out.String(), "api_base_url: https://api.example.com")
+	assert.Contains(t, out.String(), "web_base_url: (unset)")
+}
+
+func TestListCmd_JSONFormat(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	require.NoError(t, internalconfig.Save(internalconfig.Config{APIBaseURL: "https://api.example.com"}))
+
+	var logBuf strings.Builder
+	log.InitGlobalLogger(log.LoggerOpts{LoggerType: log.ConsoleLogger, Producer: log.BitriseCLI, Writer: &logBuf})
+
+	cmd, _ := newTestCmd(t, NewListCommand())
+	require.NoError(t, cmd.Flags().Set("format", "json"))
+	require.NoError(t, cmd.RunE(cmd, nil))
+
+	out := logBuf.String()
+	assert.Contains(t, out, `"api_base_url":"https://api.example.com"`)
+	assert.Contains(t, out, `"web_base_url":""`, "unset keys must still be enumerated, not omitted")
+}
+
+func TestListCmd_YMLFormat(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	require.NoError(t, internalconfig.Save(internalconfig.Config{APIBaseURL: "https://api.example.com"}))
+
+	var logBuf strings.Builder
+	log.InitGlobalLogger(log.LoggerOpts{LoggerType: log.ConsoleLogger, Producer: log.BitriseCLI, Writer: &logBuf})
+
+	cmd, _ := newTestCmd(t, NewListCommand())
+	require.NoError(t, cmd.Flags().Set("format", "yml"))
+	require.NoError(t, cmd.RunE(cmd, nil))
+
+	out := logBuf.String()
+	assert.Contains(t, out, "api_base_url: https://api.example.com", "yaml.v2 ignores json tags; this key name regresses to \"apibaseurl\" without a yaml tag")
+	assert.Contains(t, out, `web_base_url: ""`)
+}
+
+func TestListCmd_RejectsPositionalArgs(t *testing.T) {
+	cmd := NewListCommand()
+	cmd.SetArgs([]string{"unexpected"})
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+
+	assert.Error(t, cmd.Execute(), "positional args should be rejected before the command runs")
+}

--- a/cli/config/path.go
+++ b/cli/config/path.go
@@ -1,0 +1,29 @@
+package config
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/bitrise-io/bitrise/v2/cli/cmdutil"
+	internalconfig "github.com/bitrise-io/bitrise/v2/internal/config"
+)
+
+// NewPathCommand returns the `config path` subcommand.
+func NewPathCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "path",
+		Short: "Print the absolute path of the global config file",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cmdutil.LogCommandParameters(cmd)
+
+			p, err := internalconfig.Path()
+			if err != nil {
+				return err
+			}
+			_, err = fmt.Fprintln(cmd.OutOrStdout(), p)
+			return err
+		},
+	}
+}

--- a/cli/config/path_test.go
+++ b/cli/config/path_test.go
@@ -1,0 +1,40 @@
+package config
+
+import (
+	"bytes"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPathCmd_PrintsGlobalConfigPath(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+
+	cmd, out := newTestCmd(t, NewPathCommand())
+	require.NoError(t, cmd.RunE(cmd, nil))
+
+	assert.Equal(t, filepath.Join(dir, "bitrise", "cli", "config.yml")+"\n", out.String())
+}
+
+func TestPathCmd_RejectsPositionalArgs(t *testing.T) {
+	cmd := NewPathCommand()
+	cmd.SetArgs([]string{"unexpected"})
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+
+	assert.Error(t, cmd.Execute(), "positional args should be rejected before the command runs")
+}
+
+// newTestCmd wires cmd's output into a buffer for assertions. Every cli/config
+// subcommand only touches the global config file, isolated via XDG_CONFIG_HOME
+// in each test — no auth/API-client wiring is needed here, unlike cli/stack.
+func newTestCmd(t *testing.T, cmd *cobra.Command) (*cobra.Command, *bytes.Buffer) {
+	t.Helper()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	return cmd, &out
+}

--- a/cli/config/set.go
+++ b/cli/config/set.go
@@ -1,0 +1,61 @@
+package config
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/bitrise-io/bitrise/v2/cli/cmdutil"
+	internalconfig "github.com/bitrise-io/bitrise/v2/internal/config"
+)
+
+// NewSetCommand returns the `config set` subcommand.
+func NewSetCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:       "set KEY VALUE",
+		Short:     "Set a config key and save the global config file",
+		ValidArgs: internalconfig.Keys,
+		Long: fmt.Sprintf(`Set a config key in the global config file.
+
+Valid keys: %s`,
+			strings.Join(internalconfig.Keys, ", "),
+		),
+		Example: `  bitrise config set api_base_url https://staging-api.bitrise.io/v0.1`,
+		Args:    cobra.MatchAll(cobra.ExactArgs(2), validKeyArg),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cmdutil.LogCommandParameters(cmd)
+
+			key, value := args[0], args[1]
+
+			unlock, err := internalconfig.Lock(cmd.Context())
+			if err != nil {
+				return err
+			}
+			defer unlock()
+
+			cfg, err := internalconfig.Load()
+			if err != nil {
+				return err
+			}
+			if err := cfg.Set(key, value); err != nil {
+				return err
+			}
+			if err := internalconfig.Save(cfg); err != nil {
+				return err
+			}
+			_, err = fmt.Fprintf(cmd.OutOrStdout(), "Saved %s\n", key)
+			return err
+		},
+	}
+}
+
+// validKeyArg checks only the first positional (KEY) against ValidArgs —
+// cobra.OnlyValidArgs alone would also require the free-form VALUE argument
+// to be one of the recognized keys.
+func validKeyArg(cmd *cobra.Command, args []string) error {
+	if len(args) == 0 {
+		return nil
+	}
+	return cobra.OnlyValidArgs(cmd, args[:1])
+}

--- a/cli/config/set_test.go
+++ b/cli/config/set_test.go
@@ -1,0 +1,97 @@
+package config
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	internalconfig "github.com/bitrise-io/bitrise/v2/internal/config"
+)
+
+func TestSetCmd_SavesValue(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	cmd, out := newTestCmd(t, NewSetCommand())
+	require.NoError(t, cmd.RunE(cmd, []string{internalconfig.KeyAPIBaseURL, "https://api.example.com"}))
+
+	assert.Equal(t, "Saved api_base_url\n", out.String())
+
+	cfg, err := internalconfig.Load()
+	require.NoError(t, err)
+	assert.Equal(t, "https://api.example.com", cfg.APIBaseURL)
+}
+
+func TestSetCmd_InvalidURLErrorsWithoutSaving(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	cmd, _ := newTestCmd(t, NewSetCommand())
+	cmd.SetErr(&bytes.Buffer{})
+	err := cmd.RunE(cmd, []string{internalconfig.KeyAPIBaseURL, "not-a-url"})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must be an absolute URL")
+
+	cfg, loadErr := internalconfig.Load()
+	require.NoError(t, loadErr)
+	assert.Equal(t, "", cfg.APIBaseURL)
+}
+
+func TestSetCmd_UnknownKeyErrors(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	cmd, _ := newTestCmd(t, NewSetCommand())
+	cmd.SetErr(&bytes.Buffer{})
+	err := cmd.RunE(cmd, []string{"nope", "value"})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown config key")
+}
+
+func TestSetCmd_PreservesOtherKeys(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	require.NoError(t, internalconfig.Save(internalconfig.Config{WebBaseURL: "https://app.example.com"}))
+
+	cmd, _ := newTestCmd(t, NewSetCommand())
+	cmd.SetErr(&bytes.Buffer{})
+	require.NoError(t, cmd.RunE(cmd, []string{internalconfig.KeyAPIBaseURL, "https://api.example.com"}))
+
+	cfg, err := internalconfig.Load()
+	require.NoError(t, err)
+	assert.Equal(t, "https://api.example.com", cfg.APIBaseURL)
+	assert.Equal(t, "https://app.example.com", cfg.WebBaseURL)
+}
+
+func TestSetCmd_RequiresExactlyTwoArgs(t *testing.T) {
+	cmd := NewSetCommand()
+	cmd.SetArgs([]string{internalconfig.KeyAPIBaseURL})
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	assert.Error(t, cmd.Execute())
+}
+
+func TestSetCmd_ExecuteRejectsUnknownKeyBeforeRunE(t *testing.T) {
+	cmd := NewSetCommand()
+	cmd.SetArgs([]string{"nope", "value"})
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `invalid argument "nope"`)
+}
+
+func TestSetCmd_ExecuteAllowsArbitraryValueArg(t *testing.T) {
+	// The VALUE positional must NOT be checked against ValidArgs (only KEY
+	// is) — cobra.OnlyValidArgs alone would wrongly reject any value that
+	// isn't itself a recognized key.
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	cmd := NewSetCommand()
+	cmd.SetArgs([]string{internalconfig.KeyAPIBaseURL, "https://api.example.com"})
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+
+	require.NoError(t, cmd.Execute())
+}

--- a/cli/config/unset.go
+++ b/cli/config/unset.go
@@ -1,0 +1,48 @@
+package config
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/bitrise-io/bitrise/v2/cli/cmdutil"
+	internalconfig "github.com/bitrise-io/bitrise/v2/internal/config"
+)
+
+// NewUnsetCommand returns the `config unset` subcommand.
+func NewUnsetCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:       "unset KEY",
+		Short:     "Remove a config key and save the global config file",
+		ValidArgs: internalconfig.Keys,
+		Long: fmt.Sprintf(`Remove a config key from the global config file.
+
+Valid keys: %s`, strings.Join(internalconfig.Keys, ", ")),
+		Args: cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cmdutil.LogCommandParameters(cmd)
+
+			key := args[0]
+
+			unlock, err := internalconfig.Lock(cmd.Context())
+			if err != nil {
+				return err
+			}
+			defer unlock()
+
+			cfg, err := internalconfig.Load()
+			if err != nil {
+				return err
+			}
+			if err := cfg.Unset(key); err != nil {
+				return err
+			}
+			if err := internalconfig.Save(cfg); err != nil {
+				return err
+			}
+			_, err = fmt.Fprintf(cmd.OutOrStdout(), "Cleared %s\n", key)
+			return err
+		},
+	}
+}

--- a/cli/config/unset_test.go
+++ b/cli/config/unset_test.go
@@ -1,0 +1,55 @@
+package config
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	internalconfig "github.com/bitrise-io/bitrise/v2/internal/config"
+)
+
+func TestUnsetCmd_ClearsValue(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	require.NoError(t, internalconfig.Save(internalconfig.Config{APIBaseURL: "https://api.example.com"}))
+
+	cmd, out := newTestCmd(t, NewUnsetCommand())
+	require.NoError(t, cmd.RunE(cmd, []string{internalconfig.KeyAPIBaseURL}))
+
+	assert.Equal(t, "Cleared api_base_url\n", out.String())
+
+	cfg, err := internalconfig.Load()
+	require.NoError(t, err)
+	assert.Equal(t, "", cfg.APIBaseURL)
+}
+
+func TestUnsetCmd_UnknownKeyErrors(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	cmd, _ := newTestCmd(t, NewUnsetCommand())
+	cmd.SetErr(&bytes.Buffer{})
+	err := cmd.RunE(cmd, []string{"nope"})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown config key")
+}
+
+func TestUnsetCmd_RequiresExactlyOneArg(t *testing.T) {
+	cmd := NewUnsetCommand()
+	cmd.SetArgs([]string{})
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	assert.Error(t, cmd.Execute())
+}
+
+func TestUnsetCmd_ExecuteRejectsUnknownKeyBeforeRunE(t *testing.T) {
+	cmd := NewUnsetCommand()
+	cmd.SetArgs([]string{"nope"})
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `invalid argument "nope"`)
+}

--- a/cli/root.go
+++ b/cli/root.go
@@ -8,6 +8,7 @@ import (
 	"github.com/bitrise-io/bitrise/v2/cli/api"
 	"github.com/bitrise-io/bitrise/v2/cli/auth"
 	"github.com/bitrise-io/bitrise/v2/cli/cmdutil"
+	"github.com/bitrise-io/bitrise/v2/cli/config"
 	"github.com/bitrise-io/bitrise/v2/cli/local"
 	"github.com/bitrise-io/bitrise/v2/cli/plugin"
 	"github.com/bitrise-io/bitrise/v2/cli/stack"
@@ -55,6 +56,7 @@ func newRootCommand() *cobra.Command {
 		stack.NewCmd(),
 		user.NewCmd(),
 		api.NewCmd(),
+		config.NewCmd(),
 
 		versionCommand,
 		updateCommand,

--- a/cli/user/create.go
+++ b/cli/user/create.go
@@ -62,7 +62,13 @@ Password input:
 Email verification:
   After signup the server emails a verification link. Click it before running
   'bitrise auth login --email <addr>' — sign-in is blocked on unverified
-  accounts.`,
+  accounts.
+
+Target host:
+  The signup request goes to web_base_url (default app.bitrise.io),
+  overridable via $BITRISE_WEB_BASE_URL or 'bitrise config set web_base_url'
+  — never by a per-directory .bitrise-cli.yml, so a repo you merely clone
+  can't silently redirect where your password is sent.`,
 		Example: `  bitrise user create --email alice@example.com --username alice --first-name Alice --last-name L
   printf '%s' "$NEW_PASSWORD" | bitrise user create \
       --email alice@example.com --username alice --first-name Alice --last-name L --password-stdin --format json`,
@@ -92,7 +98,7 @@ Email verification:
 				return fmt.Errorf("password is empty")
 			}
 
-			wc, err := webclient.New(cmdutil.ResolveWebBaseURL())
+			wc, err := webclient.New(cmdutil.ResolveWebBaseURL(cmd))
 			if err != nil {
 				return err
 			}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -21,8 +21,9 @@ import (
 // Config is the on-disk shape. SetupVersion, LastCLIUpdateCheck, and
 // LastPluginUpdateChecks mirror configs.ConfigModel exactly, so the legacy
 // ~/.bitrise/config.json can act as a layer in Resolve (see resolve.go) with
-// the same fields to compare against. Newer fields like APIBaseURL have no
-// legacy counterpart — the legacy layer simply leaves them zero.
+// the same fields to compare against. Newer fields like APIBaseURL and
+// WebBaseURL have no legacy counterpart — the legacy layer simply leaves
+// them zero.
 //
 // LastCLIUpdateCheck and LastPluginUpdateChecks are timestamps the CLI
 // itself writes during normal operation, not user preferences — unusual
@@ -33,6 +34,7 @@ type Config struct {
 	LastCLIUpdateCheck     time.Time            `yaml:"last_cli_update_check,omitempty"`
 	LastPluginUpdateChecks map[string]time.Time `yaml:"last_plugin_update_checks,omitempty"`
 	APIBaseURL             string               `yaml:"api_base_url,omitempty"`
+	WebBaseURL             string               `yaml:"web_base_url,omitempty"`
 }
 
 // DirFileName is the file looked up in the working directory and its

--- a/internal/config/keys.go
+++ b/internal/config/keys.go
@@ -1,0 +1,75 @@
+package config
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/bitrise-io/bitrise/v2/internal/baseurl"
+)
+
+const (
+	KeyAPIBaseURL = "api_base_url"
+	KeyWebBaseURL = "web_base_url"
+)
+
+// Keys is the subset of Config's fields exposed to `bitrise config
+// get/set/unset` — SetupVersion/LastCLIUpdateCheck/LastPluginUpdateChecks are
+// deliberately excluded: the CLI writes those itself, they aren't user
+// settings.
+var Keys = []string{KeyAPIBaseURL, KeyWebBaseURL}
+
+// Get returns the stored value of a known key.
+func (c *Config) Get(key string) (string, error) {
+	switch key {
+	case KeyAPIBaseURL:
+		return c.APIBaseURL, nil
+	case KeyWebBaseURL:
+		return c.WebBaseURL, nil
+	default:
+		return "", unknownKeyErr(key)
+	}
+}
+
+// Set assigns value to key. If validation fails, c is left untouched —
+// callers can rely on Set being all-or-nothing.
+func (c *Config) Set(key, value string) error {
+	next := *c
+	switch key {
+	case KeyAPIBaseURL:
+		if value != "" {
+			if err := validateURL(KeyAPIBaseURL, value); err != nil {
+				return err
+			}
+		}
+		next.APIBaseURL = value
+	case KeyWebBaseURL:
+		if value != "" {
+			if err := validateURL(KeyWebBaseURL, value); err != nil {
+				return err
+			}
+		}
+		next.WebBaseURL = value
+	default:
+		return unknownKeyErr(key)
+	}
+	*c = next
+	return nil
+}
+
+// Unset clears the value of key (equivalent to Set with an empty string).
+func (c *Config) Unset(key string) error {
+	return c.Set(key, "")
+}
+
+func unknownKeyErr(key string) error {
+	return fmt.Errorf("unknown config key %q (valid keys: %s)", key, strings.Join(Keys, ", "))
+}
+
+// validateURL rejects a value that the actual consumer
+// (webclient.New/bitriseapi.New, both backed by internal/baseurl) would
+// reject or, worse for api_base_url, silently send the bearer token over
+// plaintext http.
+func validateURL(key, value string) error {
+	_, err := baseurl.Validate(key, value)
+	return err
+}

--- a/internal/config/keys_test.go
+++ b/internal/config/keys_test.go
@@ -1,0 +1,68 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfig_GetSetUnset_RoundTrip(t *testing.T) {
+	var c Config
+
+	require.NoError(t, c.Set(KeyAPIBaseURL, "https://api.example.com"))
+	v, err := c.Get(KeyAPIBaseURL)
+	require.NoError(t, err)
+	assert.Equal(t, "https://api.example.com", v)
+
+	require.NoError(t, c.Unset(KeyAPIBaseURL))
+	v, err = c.Get(KeyAPIBaseURL)
+	require.NoError(t, err)
+	assert.Equal(t, "", v)
+}
+
+func TestConfig_Get_UnknownKey(t *testing.T) {
+	var c Config
+	_, err := c.Get("nope")
+	assert.ErrorContains(t, err, `unknown config key "nope"`)
+}
+
+func TestConfig_Set_UnknownKey(t *testing.T) {
+	var c Config
+	err := c.Set("nope", "value")
+	assert.ErrorContains(t, err, `unknown config key "nope"`)
+}
+
+func TestConfig_Set_InvalidURLLeavesConfigUntouched(t *testing.T) {
+	c := Config{APIBaseURL: "https://original.example"}
+
+	err := c.Set(KeyAPIBaseURL, "not-a-url")
+	assert.ErrorContains(t, err, `api_base_url "not-a-url" must be an absolute URL`)
+	assert.Equal(t, "https://original.example", c.APIBaseURL)
+}
+
+func TestConfig_Set_WebBaseURL(t *testing.T) {
+	var c Config
+	require.NoError(t, c.Set(KeyWebBaseURL, "https://app.example.com"))
+	assert.Equal(t, "https://app.example.com", c.WebBaseURL)
+
+	err := c.Set(KeyWebBaseURL, "://bad")
+	assert.Error(t, err)
+	assert.Equal(t, "https://app.example.com", c.WebBaseURL, "invalid Set must not mutate c")
+}
+
+func TestConfig_Set_RejectsPlainHTTP(t *testing.T) {
+	for _, key := range Keys {
+		var c Config
+		err := c.Set(key, "http://api.example.com")
+		require.Error(t, err, key)
+		assert.ErrorContains(t, err, `must use https (got "http")`)
+	}
+}
+
+func TestConfig_Set_AllowsPlainHTTPForLoopback(t *testing.T) {
+	for _, host := range []string{"http://localhost:1234", "http://127.0.0.1:1234", "http://[::1]:1234"} {
+		var c Config
+		require.NoError(t, c.Set(KeyAPIBaseURL, host), host)
+	}
+}

--- a/internal/config/lock.go
+++ b/internal/config/lock.go
@@ -1,0 +1,26 @@
+package config
+
+import (
+	"context"
+	"time"
+
+	"github.com/bitrise-io/bitrise/v2/internal/filelock"
+)
+
+// lockOptions sizes the lease for config.yml's read-modify-write sequence,
+// which is always local disk I/O with no network calls — much faster than
+// internal/auth's OAuth ladder, so no refresh is needed to survive a
+// legitimately slow hold.
+var lockOptions = filelock.Options{StaleAfter: 5 * time.Second}
+
+// Lock acquires an exclusive, cross-process lock around a read-modify-write
+// sequence on the global config file, so concurrent `bitrise config
+// set`/`unset` invocations don't silently drop one of the two writes. Call
+// the returned unlock func to release it.
+func Lock(ctx context.Context) (unlock func(), err error) {
+	p, err := Path()
+	if err != nil {
+		return nil, err
+	}
+	return filelock.Lock(ctx, p, lockOptions)
+}

--- a/internal/config/lock_test.go
+++ b/internal/config/lock_test.go
@@ -1,0 +1,45 @@
+package config
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLock_AcquireRelease(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	unlock, err := Lock(t.Context())
+	require.NoError(t, err)
+	unlock()
+
+	unlock2, err := Lock(t.Context())
+	require.NoError(t, err)
+	unlock2()
+}
+
+func TestLock_BlocksConcurrentHolder(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	unlock, err := Lock(t.Context())
+	require.NoError(t, err)
+	defer unlock()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
+	defer cancel()
+	_, err = Lock(ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "timed out waiting for lock")
+}
+
+func TestLock_NilContextDoesNotPanic(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	//nolint:staticcheck // SA1012: deliberately passing a nil context.Context — RunE's cmd.Context() is nil in every test that calls RunE directly instead of Execute(), which Lock must tolerate
+	unlock, err := Lock(nil)
+	require.NoError(t, err)
+	unlock()
+}

--- a/internal/config/resolve.go
+++ b/internal/config/resolve.go
@@ -12,6 +12,9 @@ import (
 //  3. Global config file (~/.config/bitrise/cli/config.yml)
 //  4. Zero value
 //
+// APIBaseURL/WebBaseURL are the exception: they skip the per-directory layer
+// (see below) — everything else follows the order above.
+//
 // Resolved embeds Config (rather than being an identical, separately-typed
 // copy of its fields) so a new field only needs adding once — but it stays a
 // distinct type on purpose: Save takes a Config, and a Resolved carries
@@ -26,19 +29,33 @@ type Resolved struct {
 // layer sets api_base_url.
 const DefaultAPIBaseURL = "https://api.bitrise.io/v0.1"
 
+// DefaultWebBaseURL is the production Bitrise website base URL, used when no
+// layer sets web_base_url.
+const DefaultWebBaseURL = "https://app.bitrise.io"
+
 // Resolve merges the legacy, per-directory, and global config layers. The
 // caller converts configs.ConfigModel into a Config for legacyCfg, keeping
 // this package independent of configs. dirCfg / legacyCfg are zero values
 // when their respective files were not found.
+//
+// APIBaseURL/WebBaseURL deliberately never consult dirCfg: both carry
+// credentials (a bearer token, a login password) to whatever host they name,
+// and .bitrise-cli.yml is read from the current directory and every
+// ancestor with no confirmation — a repo a user merely clones and runs
+// `bitrise` inside of could otherwise silently redirect either one to an
+// attacker-controlled host. The global file and the legacy file are both
+// user-owned (home directory), not repo-owned, so they don't have this
+// problem.
 func Resolve(legacyCfg, dirCfg, globalCfg Config) Resolved {
 	return Resolved{Config: Config{
 		SetupVersion:           FirstNonEmptyString(legacyCfg.SetupVersion, dirCfg.SetupVersion, globalCfg.SetupVersion),
 		LastCLIUpdateCheck:     firstNonZeroTime(legacyCfg.LastCLIUpdateCheck, dirCfg.LastCLIUpdateCheck, globalCfg.LastCLIUpdateCheck),
 		LastPluginUpdateChecks: firstNonEmptyMap(legacyCfg.LastPluginUpdateChecks, dirCfg.LastPluginUpdateChecks, globalCfg.LastPluginUpdateChecks),
-		// legacyCfg.APIBaseURL is always empty (configs.ConfigModel predates
+		// legacy is always empty for these two (configs.ConfigModel predates
 		// the cloud API and has no such field), so this is effectively
-		// dir > global > default.
-		APIBaseURL: FirstNonEmptyString(legacyCfg.APIBaseURL, dirCfg.APIBaseURL, globalCfg.APIBaseURL, DefaultAPIBaseURL),
+		// global > default — no dirCfg, see the doc comment above.
+		APIBaseURL: FirstNonEmptyString(legacyCfg.APIBaseURL, globalCfg.APIBaseURL, DefaultAPIBaseURL),
+		WebBaseURL: FirstNonEmptyString(legacyCfg.WebBaseURL, globalCfg.WebBaseURL, DefaultWebBaseURL),
 	}}
 }
 

--- a/internal/config/resolve_test.go
+++ b/internal/config/resolve_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestResolve_DefaultsWhenNothingSet(t *testing.T) {
 	r := Resolve(Config{}, Config{}, Config{})
-	assert.Equal(t, Resolved{Config: Config{APIBaseURL: DefaultAPIBaseURL}}, r)
+	assert.Equal(t, Resolved{Config: Config{APIBaseURL: DefaultAPIBaseURL, WebBaseURL: DefaultWebBaseURL}}, r)
 }
 
 func TestResolve_APIBaseURLPrecedence(t *testing.T) {
@@ -24,9 +24,38 @@ func TestResolve_APIBaseURLPrecedence(t *testing.T) {
 	r = Resolve(Config{}, Config{}, global)
 	assert.Equal(t, "https://global.example", r.APIBaseURL)
 
-	// dir overrides global (legacy has no concept of this field)
+	// dir is ignored, even when set and global isn't: this field carries a
+	// bearer token, and a repo's own .bitrise-cli.yml must not be able to
+	// redirect it (see Resolve's doc comment)
+	r = Resolve(Config{}, dir, Config{})
+	assert.Equal(t, DefaultAPIBaseURL, r.APIBaseURL, "dirCfg must never win for APIBaseURL")
+
+	// dir also doesn't override global
 	r = Resolve(Config{}, dir, global)
-	assert.Equal(t, "https://dir.example", r.APIBaseURL)
+	assert.Equal(t, "https://global.example", r.APIBaseURL)
+}
+
+func TestResolve_WebBaseURLPrecedence(t *testing.T) {
+	dir := Config{WebBaseURL: "https://dir.example"}
+	global := Config{WebBaseURL: "https://global.example"}
+
+	// no layer set: falls back to the default
+	r := Resolve(Config{}, Config{}, Config{})
+	assert.Equal(t, DefaultWebBaseURL, r.WebBaseURL)
+
+	// global only
+	r = Resolve(Config{}, Config{}, global)
+	assert.Equal(t, "https://global.example", r.WebBaseURL)
+
+	// dir is ignored, even when set and global isn't: this field carries a
+	// login password, and a repo's own .bitrise-cli.yml must not be able to
+	// redirect it (see Resolve's doc comment)
+	r = Resolve(Config{}, dir, Config{})
+	assert.Equal(t, DefaultWebBaseURL, r.WebBaseURL, "dirCfg must never win for WebBaseURL")
+
+	// dir also doesn't override global
+	r = Resolve(Config{}, dir, global)
+	assert.Equal(t, "https://global.example", r.WebBaseURL)
 }
 
 // TestResolve_LayerPrecedence covers the three fields sharing the generic


### PR DESCRIPTION
`bitrise config path/list/get/set/unset `manage the global config file (`~/.config/bitrise/cli/config.yml`), exposing the two user-facing settings: the pre-existing `api_base_url` and a new `web_base_url`, which replaces the hardcoded `app.bitrise.io `in the email-login and signup flows.

Two things about how these keys resolve are deliberate:

- Both skip the per-directory `.bitrise-cli.yml `layer that every other setting honors. That file is read from the working directory and every ancestor with no confirmation, and both keys name a host that receives credentials — a password for `web_base_url`, a bearer token for `api_base_url`. A repository you only clone and run `bitrise` inside of must not be able to redirect either. Only the user-owned global file and `$BITRISE_WEB_BASE_URL` can set them.

- `set/unset` take the `internal/filelock` lock around load-modify-save, so two concurrent invocations cannot drop one of the two writes, and validate the value through `internal/baseurl` so a bad URL is rejected at write time rather than surfacing later from whichever client consumes it.