### PR TITLE
v3 prep: API and service layer for `app` commands

### DIFF
--- a/internal/app/create.go
+++ b/internal/app/create.go
@@ -1,0 +1,302 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+	"os/exec"
+	"path"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/bitrise-io/bitrise/v2/internal/bitriseapi"
+)
+
+// DefaultStackID is the stack used by Create when opts.StackID is empty. Any
+// valid stack ID for the org will do — this one is broadly available — and
+// callers can override it via --stack.
+const DefaultStackID = "linux-docker-android-22.04"
+
+// DefaultProjectType is the project_type sent to /finish when opts.ProjectType
+// is empty. "other" is a safe minimal preset.
+const DefaultProjectType = "other"
+
+// DefaultProvider is the provider sent to /apps/register when opts.Provider is
+// "" or "auto". The website's "Add new app" flow sends "custom" regardless of
+// host, and we mirror that so app creation doesn't trip over GitHub-App
+// ownership checks; override with --provider github (etc.) when the repo is
+// linked to Bitrise via that provider's app integration.
+const DefaultProvider = "custom"
+
+// FlowTypeCLI is the analytics attribution sent on register/finish so the
+// server can distinguish CLI-driven app creation from website-driven flows.
+const FlowTypeCLI = "cli"
+
+// DefaultBranchFallback is the branch name sent to /apps/register when none
+// can be detected from the local git checkout.
+const DefaultBranchFallback = "master"
+
+// CreateOptions are the inputs for Service.Create. Empty fields trigger
+// auto-detection (git, single-workspace pick) where applicable; RepoURL
+// produces an error if it can't be filled in.
+type CreateOptions struct {
+	RepoURL     string
+	Branch      string
+	Title       string
+	Provider    string // "auto" or one of the API's accepted values
+	OrgSlug     string // empty → fall back to single-workspace auto-detect
+	StackID     string
+	ProjectType string
+	Public      bool
+
+	// BitriseYML is the YAML to upload after Finish. Empty means skip the
+	// upload and let the server preset chosen by ProjectType take effect.
+	BitriseYML string
+}
+
+// CreateResult is what Service.Create returns once the app is registered and
+// finished. BitriseYMLUploaded is true when the upload step ran.
+type CreateResult struct {
+	Slug              string `json:"id" yaml:"id"`
+	Title             string `json:"title" yaml:"title"`
+	RepoURL           string `json:"repo_url" yaml:"repo_url"`
+	DefaultBranch     string `json:"default_branch" yaml:"default_branch"`
+	BuildTriggerToken string `json:"build_trigger_token" yaml:"build_trigger_token"`
+
+	OrgSlug            string `json:"workspace_id" yaml:"workspace_id"`
+	StackID            string `json:"stack_id" yaml:"stack_id"`
+	ProjectType        string `json:"project_type" yaml:"project_type"`
+	BitriseYMLUploaded bool   `json:"bitrise_yml_uploaded" yaml:"bitrise_yml_uploaded"`
+}
+
+// Create runs the register → finish → (optional) upload sequence on the
+// Bitrise API and returns the new app's identifying details.
+//
+// Required: opts.RepoURL (or a detectable git remote) and a workspace (via
+// opts.OrgSlug or single-workspace detection). Defaults are applied for
+// Branch, Provider, StackID, ProjectType.
+func (s *Service) Create(ctx context.Context, opts CreateOptions) (CreateResult, error) {
+	if opts.RepoURL == "" {
+		return CreateResult{}, errors.New("repo URL is required (pass --repo-url or run inside a git repo with an 'origin' remote)")
+	}
+	provider, err := resolveProvider(opts.Provider)
+	if err != nil {
+		return CreateResult{}, err
+	}
+
+	branch := opts.Branch
+	if branch == "" {
+		branch = DefaultBranchFallback
+	}
+	title := opts.Title
+	if title == "" {
+		title = deriveTitle(opts.RepoURL)
+	}
+	stackID := opts.StackID
+	if stackID == "" {
+		stackID = DefaultStackID
+	}
+	projectType := opts.ProjectType
+	if projectType == "" {
+		projectType = DefaultProjectType
+	}
+
+	orgSlug := opts.OrgSlug
+	if orgSlug == "" {
+		orgSlug, err = s.autoDetectOrg(ctx)
+		if err != nil {
+			return CreateResult{}, err
+		}
+	}
+
+	reg, err := s.client.RegisterApp(ctx, bitriseapi.RegisterAppRequest{
+		RepoURL:           opts.RepoURL,
+		OrganizationSlug:  orgSlug,
+		Provider:          provider,
+		IsPublic:          opts.Public,
+		Title:             title,
+		DefaultBranchName: branch,
+		FlowType:          FlowTypeCLI,
+	})
+	if err != nil {
+		return CreateResult{}, fmt.Errorf("register app: %w", err)
+	}
+
+	fin, err := s.client.FinishApp(ctx, reg.Slug, bitriseapi.FinishAppRequest{
+		StackID:     stackID,
+		Mode:        "manual",
+		ProjectType: projectType,
+		Config:      configIDForProjectType(projectType),
+		FlowType:    FlowTypeCLI,
+	})
+	if err != nil {
+		return CreateResult{}, fmt.Errorf("finish app %s: %w", reg.Slug, err)
+	}
+
+	res := CreateResult{
+		Slug:              reg.Slug,
+		Title:             title,
+		RepoURL:           opts.RepoURL,
+		DefaultBranch:     fin.BranchName,
+		BuildTriggerToken: fin.BuildTriggerToken,
+		OrgSlug:           orgSlug,
+		StackID:           stackID,
+		ProjectType:       projectType,
+	}
+	if res.DefaultBranch == "" {
+		res.DefaultBranch = branch
+	}
+
+	if opts.BitriseYML != "" {
+		// UpdateAppBitriseYML expects the YAML already parsed into a Go
+		// value, matching internal/yml.Service.Update's own handling of the
+		// same endpoint — reused here rather than adding a second client
+		// method for the same POST /apps/{slug}/bitrise.yml call.
+		var parsed any
+		if err := yaml.Unmarshal([]byte(opts.BitriseYML), &parsed); err != nil {
+			return res, fmt.Errorf("parse bitrise.yml: %w", err)
+		}
+		if err := s.client.UpdateAppBitriseYML(ctx, reg.Slug, parsed); err != nil {
+			return res, fmt.Errorf("upload bitrise.yml: %w", err)
+		}
+		res.BitriseYMLUploaded = true
+	}
+
+	return res, nil
+}
+
+// autoDetectOrg fetches the user's workspaces and returns the slug when
+// there's exactly one. 0 or 2+ workspaces produce a friendly error.
+func (s *Service) autoDetectOrg(ctx context.Context) (string, error) {
+	orgs, err := s.client.Organizations(ctx)
+	if err != nil {
+		return "", fmt.Errorf("list workspaces: %w", err)
+	}
+	switch len(orgs) {
+	case 0:
+		return "", errors.New("no workspaces found for this account — create one in the Bitrise dashboard, or pass --workspace")
+	case 1:
+		return orgs[0].Slug, nil
+	default:
+		names := make([]string, 0, len(orgs))
+		for _, o := range orgs {
+			names = append(names, fmt.Sprintf("  %s (%s)", o.Slug, o.Name))
+		}
+		return "", fmt.Errorf("multiple workspaces available — pass --workspace. Available:\n%s", strings.Join(names, "\n"))
+	}
+}
+
+// resolveProvider validates an explicit --provider value, or returns
+// DefaultProvider when "auto" or "" is given.
+func resolveProvider(explicit string) (string, error) {
+	switch explicit {
+	case "", "auto":
+		return DefaultProvider, nil
+	case "github", "gitlab", "bitbucket", "custom":
+		return explicit, nil
+	default:
+		return "", fmt.Errorf("unknown provider %q (valid: auto, github, gitlab, bitbucket, custom)", explicit)
+	}
+}
+
+// configIDForProjectType returns the preset config_id the server expects for
+// a given project_type. The values mirror the server's own preset list, so
+// they must stay in sync with it. Unknown project_types fall through to
+// "other-config", the same fallback the server applies when the field is
+// omitted.
+func configIDForProjectType(projectType string) string {
+	switch projectType {
+	case "android":
+		return "default-android-config"
+	case "cordova":
+		return "default-cordova-config"
+	case "fastlane":
+		return "default-fastlane-ios-config"
+	case "flutter":
+		return "flutter-config-test-ios-android-web-0"
+	case "ionic":
+		return "default-ionic-config"
+	case "ios":
+		return "default-ios-config"
+	case "java":
+		return "default-java-gradle-config"
+	case "kotlin-multiplatform":
+		return "default-kotlin-multiplatform-config"
+	case "macos":
+		return "default-macos-config"
+	case "node-js":
+		return "default-node-js-npm-config"
+	case "python":
+		return "default-python-pip-config"
+	case "react-native":
+		return "default-react-native-config"
+	case "ruby":
+		return "default-ruby-config"
+	default:
+		return "other-config"
+	}
+}
+
+// deriveTitle pulls a human-readable title from a repo URL: the last path
+// segment with any ".git" suffix removed. Returns "" when nothing parseable
+// remains.
+func deriveTitle(repoURL string) string {
+	clean := repoURL
+	// Strip any query/fragment before the ".git" suffix, so a URL like
+	// "https://host/repo.git?ref=x" still yields "repo".
+	if i := strings.IndexAny(clean, "?#"); i >= 0 {
+		clean = clean[:i]
+	}
+	clean = strings.TrimSuffix(clean, ".git")
+	if u, err := url.Parse(clean); err == nil && u.Path != "" {
+		base := path.Base(u.Path)
+		if base != "." && base != "/" {
+			return base
+		}
+	}
+	if i := strings.LastIndexAny(clean, ":/"); i >= 0 && i+1 < len(clean) {
+		return clean[i+1:]
+	}
+	return ""
+}
+
+// GitDetector detects the cwd's git remote URL and current branch. The
+// default implementation shells out to `git`. Tests inject a stub.
+type GitDetector interface {
+	RemoteURL(ctx context.Context) (string, error)
+	CurrentBranch(ctx context.Context) (string, error)
+}
+
+// ExecGitDetector is the default GitDetector. It runs the `git` CLI in the
+// current working directory.
+type ExecGitDetector struct{}
+
+// RemoteURL returns the URL of the "origin" remote, or "" if not in a git
+// repo / no origin is set. Errors from git itself are returned as-is.
+func (ExecGitDetector) RemoteURL(ctx context.Context) (string, error) {
+	out, err := exec.CommandContext(ctx, "git", "remote", "get-url", "origin").Output()
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			return "", nil
+		}
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+// CurrentBranch returns the name of the currently checked-out branch, or ""
+// when detached or not in a git repo.
+func (ExecGitDetector) CurrentBranch(ctx context.Context) (string, error) {
+	out, err := exec.CommandContext(ctx, "git", "symbolic-ref", "--short", "HEAD").Output()
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			return "", nil
+		}
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}

--- a/internal/app/create_test.go
+++ b/internal/app/create_test.go
@@ -1,0 +1,233 @@
+package app
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/bitrise-io/bitrise/v2/internal/bitriseapi"
+)
+
+func TestCreate_RegisterFinishUpload_WithExplicitOrg(t *testing.T) {
+	api := newStubAPI(t)
+	api.handle("/apps/register", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `{"slug":"new-app"}`)
+	})
+	api.handle("/apps/new-app/finish", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `{"build_trigger_token":"btt","branch_name":"main"}`)
+	})
+	api.handle("/apps/new-app/bitrise.yml", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `{}`)
+	})
+
+	svc := NewService(api.client())
+	got, err := svc.Create(context.Background(), CreateOptions{
+		RepoURL:    "https://github.com/acme/widget.git",
+		Branch:     "main",
+		Title:      "Widget",
+		Provider:   "auto",
+		OrgSlug:    "acme",
+		BitriseYML: "format_version: \"11\"\n",
+	})
+	require.NoError(t, err)
+
+	want := CreateResult{
+		Slug: "new-app", Title: "Widget", RepoURL: "https://github.com/acme/widget.git",
+		DefaultBranch: "main", BuildTriggerToken: "btt",
+		OrgSlug: "acme", StackID: DefaultStackID, ProjectType: DefaultProjectType,
+		BitriseYMLUploaded: true,
+	}
+	assert.Equal(t, want, got)
+
+	// Provider defaults to "custom" — matches the website's add-new-app flow.
+	var reg bitriseapi.RegisterAppRequest
+	require.NoError(t, json.Unmarshal(api.bodies["/apps/register"], &reg))
+	assert.Equal(t, DefaultProvider, reg.Provider)
+	assert.Equal(t, "acme", reg.OrganizationSlug)
+	assert.Equal(t, "main", reg.DefaultBranchName)
+	assert.Equal(t, FlowTypeCLI, reg.FlowType)
+
+	// Finish defaults applied; config maps to project_type.
+	var fin bitriseapi.FinishAppRequest
+	require.NoError(t, json.Unmarshal(api.bodies["/apps/new-app/finish"], &fin))
+	assert.Equal(t, DefaultStackID, fin.StackID)
+	assert.Equal(t, "manual", fin.Mode)
+	assert.Equal(t, DefaultProjectType, fin.ProjectType)
+	assert.Equal(t, "other-config", fin.Config)
+	assert.Equal(t, FlowTypeCLI, fin.FlowType)
+
+	// Upload happened with the parsed YAML payload.
+	assert.JSONEq(t, `{"app_config_datastore_yaml":{"format_version":"11"}}`, string(api.bodies["/apps/new-app/bitrise.yml"]))
+}
+
+func TestCreate_SkipsUpload_WhenNoYML(t *testing.T) {
+	api := newStubAPI(t)
+	api.handle("/apps/register", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `{"slug":"x"}`)
+	})
+	api.handle("/apps/x/finish", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `{"build_trigger_token":"t","branch_name":"main"}`)
+	})
+
+	svc := NewService(api.client())
+	got, err := svc.Create(context.Background(), CreateOptions{RepoURL: "https://github.com/a/b.git", OrgSlug: "acme"})
+	require.NoError(t, err)
+	assert.False(t, got.BitriseYMLUploaded)
+}
+
+func TestCreate_InvalidYAML(t *testing.T) {
+	api := newStubAPI(t)
+	api.handle("/apps/register", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `{"slug":"x"}`)
+	})
+	api.handle("/apps/x/finish", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `{"build_trigger_token":"t","branch_name":"main"}`)
+	})
+
+	svc := NewService(api.client())
+	_, err := svc.Create(context.Background(), CreateOptions{RepoURL: "https://github.com/a/b.git", OrgSlug: "acme", BitriseYML: "not: valid: yaml:"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "parse bitrise.yml")
+}
+
+func TestCreate_AutoDetectOrg_SingleWorkspaceWins(t *testing.T) {
+	api := newStubAPI(t)
+	api.handle("/organizations", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `{"data":[{"slug":"only-org","name":"Only"}]}`)
+	})
+	api.handle("/apps/register", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `{"slug":"x"}`)
+	})
+	api.handle("/apps/x/finish", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `{"build_trigger_token":"t","branch_name":"main"}`)
+	})
+
+	svc := NewService(api.client())
+	got, err := svc.Create(context.Background(), CreateOptions{RepoURL: "https://github.com/a/b.git"})
+	require.NoError(t, err)
+	assert.Equal(t, "only-org", got.OrgSlug)
+
+	var reg bitriseapi.RegisterAppRequest
+	require.NoError(t, json.Unmarshal(api.bodies["/apps/register"], &reg))
+	assert.Equal(t, "only-org", reg.OrganizationSlug)
+}
+
+func TestCreate_AutoDetectOrg_NoneFails(t *testing.T) {
+	api := newStubAPI(t)
+	api.handle("/organizations", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `{"data":[]}`)
+	})
+
+	svc := NewService(api.client())
+	_, err := svc.Create(context.Background(), CreateOptions{RepoURL: "https://github.com/a/b.git"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no workspaces")
+}
+
+func TestCreate_AutoDetectOrg_MultipleFails(t *testing.T) {
+	api := newStubAPI(t)
+	api.handle("/organizations", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `{"data":[{"slug":"a","name":"A"},{"slug":"b","name":"B"}]}`)
+	})
+
+	svc := NewService(api.client())
+	_, err := svc.Create(context.Background(), CreateOptions{RepoURL: "https://github.com/a/b.git"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "multiple workspaces")
+}
+
+func TestCreate_RequiresRepoURL(t *testing.T) {
+	svc := NewService(newAPIClient(t, "https://unused.test"))
+	_, err := svc.Create(context.Background(), CreateOptions{OrgSlug: "acme"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "repo URL is required")
+}
+
+func TestResolveProvider(t *testing.T) {
+	for input, want := range map[string]string{"": DefaultProvider, "auto": DefaultProvider, "github": "github"} {
+		got, err := resolveProvider(input)
+		require.NoError(t, err)
+		assert.Equal(t, want, got)
+	}
+	_, err := resolveProvider("hg")
+	require.Error(t, err)
+}
+
+func TestConfigIDForProjectType(t *testing.T) {
+	// Pins the full project-type → config_id mapping. The expected values are
+	// the server's own preset IDs (see the doc comment on
+	// configIDForProjectType); any change here should be a reviewed,
+	// intentional diff checked against that source.
+	cases := map[string]string{
+		"android":              "default-android-config",
+		"cordova":              "default-cordova-config",
+		"fastlane":             "default-fastlane-ios-config",
+		"flutter":              "flutter-config-test-ios-android-web-0",
+		"ionic":                "default-ionic-config",
+		"ios":                  "default-ios-config",
+		"java":                 "default-java-gradle-config",
+		"kotlin-multiplatform": "default-kotlin-multiplatform-config",
+		"macos":                "default-macos-config",
+		"node-js":              "default-node-js-npm-config",
+		"python":               "default-python-pip-config",
+		"react-native":         "default-react-native-config",
+		"ruby":                 "default-ruby-config",
+		"":                     "other-config",
+		"other":                "other-config",
+		"xamarin":              "other-config",
+		"unknown":              "other-config",
+	}
+	for input, want := range cases {
+		assert.Equal(t, want, configIDForProjectType(input), "input %q", input)
+	}
+}
+
+func TestDeriveTitle(t *testing.T) {
+	cases := map[string]string{
+		"https://github.com/acme/widget.git": "widget",
+		"https://github.com/acme/widget":     "widget",
+		"git@github.com:acme/widget.git":     "widget",
+		"":                                   "",
+	}
+	for input, want := range cases {
+		assert.Equal(t, want, deriveTitle(input), "input %q", input)
+	}
+}
+
+// stubAPI is the multiplexer used by Create's tests. It maps URL paths to
+// canned responses and records the request bodies that arrived.
+type stubAPI struct {
+	t        *testing.T
+	baseURL  string
+	registry map[string]http.HandlerFunc
+	bodies   map[string][]byte
+}
+
+func newStubAPI(t *testing.T) *stubAPI {
+	t.Helper()
+	s := &stubAPI{t: t, registry: map[string]http.HandlerFunc{}, bodies: map[string][]byte{}}
+	srv := newFakeServer(t, func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		s.bodies[r.URL.Path] = body
+		h, ok := s.registry[r.URL.Path]
+		if !ok {
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			http.NotFound(w, r)
+			return
+		}
+		r.Body = io.NopCloser(strings.NewReader(string(body)))
+		h(w, r)
+	})
+	s.baseURL = srv.URL
+	return s
+}
+
+func (s *stubAPI) handle(path string, h http.HandlerFunc) { s.registry[path] = h }
+
+func (s *stubAPI) client() *bitriseapi.Client { return newAPIClient(s.t, s.baseURL) }

--- a/internal/app/service.go
+++ b/internal/app/service.go
@@ -1,0 +1,92 @@
+// Package app holds the business-logic layer for app operations.
+package app
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/bitrise-io/bitrise/v2/internal/bitriseapi"
+)
+
+// App is the CLI representation of a Bitrise app (project).
+type App struct {
+	Slug        string `json:"id" yaml:"id"`
+	Title       string `json:"title" yaml:"title"`
+	Provider    string `json:"provider" yaml:"provider"`
+	RepoURL     string `json:"repo_url" yaml:"repo_url"`
+	OwnerSlug   string `json:"workspace_id,omitempty" yaml:"workspace_id,omitempty"`
+	ProjectType string `json:"project_type,omitempty" yaml:"project_type,omitempty"`
+	IsDisabled  bool   `json:"is_disabled,omitempty" yaml:"is_disabled,omitempty"`
+}
+
+// ListOptions paginates and filters app lists. Filter fields map to the
+// query parameters of GET /apps.
+type ListOptions struct {
+	Limit       int
+	Cursor      string
+	SortBy      string
+	Title       string
+	ProjectType string
+}
+
+// AppsResult is one page of apps.
+type AppsResult struct {
+	Items      []App  `json:"items" yaml:"items"`
+	NextCursor string `json:"next_cursor,omitempty" yaml:"next_cursor,omitempty"`
+}
+
+// Service exposes app operations to the cmd layer.
+type Service struct {
+	client *bitriseapi.Client
+}
+
+// NewService returns a Service backed by the given API client.
+func NewService(client *bitriseapi.Client) *Service {
+	return &Service{client: client}
+}
+
+// List returns one page of apps the authenticated user can access.
+func (s *Service) List(ctx context.Context, opts ListOptions) (AppsResult, error) {
+	apps, next, err := s.client.Apps(ctx, bitriseapi.AppsListOptions{
+		SortBy:      opts.SortBy,
+		Next:        opts.Cursor,
+		Limit:       opts.Limit,
+		Title:       opts.Title,
+		ProjectType: opts.ProjectType,
+	})
+	if err != nil {
+		return AppsResult{}, err
+	}
+	items := make([]App, 0, len(apps))
+	for _, a := range apps {
+		items = append(items, fromAPI(a))
+	}
+	return AppsResult{Items: items, NextCursor: next}, nil
+}
+
+// View returns details of a single app by slug.
+func (s *Service) View(ctx context.Context, appSlug string) (App, error) {
+	a, err := s.client.App(ctx, appSlug)
+	if err != nil {
+		var apiErr *bitriseapi.APIError
+		if errors.As(err, &apiErr) && apiErr.StatusCode == http.StatusNotFound {
+			return App{}, fmt.Errorf("app %q not found", appSlug)
+		}
+		return App{}, err
+	}
+	return fromAPI(a), nil
+}
+
+func fromAPI(a bitriseapi.App) App {
+	return App{
+		Slug:        a.Slug,
+		Title:       a.Title,
+		Provider:    a.Provider,
+		RepoURL:     a.RepoURL,
+		OwnerSlug:   a.Owner.Slug,
+		ProjectType: a.ProjectType,
+		IsDisabled:  a.IsDisabled,
+	}
+}

--- a/internal/app/service_test.go
+++ b/internal/app/service_test.go
@@ -1,0 +1,106 @@
+package app
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/bitrise-io/bitrise/v2/internal/bitriseapi"
+)
+
+func TestList_MapsAPIShape(t *testing.T) {
+	srv := newFakeServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{
+			"data": [
+				{"slug":"app-1","title":"First","provider":"github","repo_url":"https://github.com/x/y","project_type":"android","is_disabled":false,"owner":{"slug":"acme"}},
+				{"slug":"app-2","title":"Second","provider":"gitlab","repo_url":"https://gitlab.com/x/y","project_type":"ios","is_disabled":true,"owner":{"slug":"bob"}}
+			],
+			"paging": {"next":"page-2"}
+		}`))
+	})
+	client := newAPIClient(t, srv.URL)
+
+	res, err := NewService(client).List(context.Background(), ListOptions{})
+	require.NoError(t, err)
+	require.Len(t, res.Items, 2)
+	assert.Equal(t, App{Slug: "app-1", Title: "First", Provider: "github", RepoURL: "https://github.com/x/y", OwnerSlug: "acme", ProjectType: "android"}, res.Items[0])
+	assert.True(t, res.Items[1].IsDisabled)
+	assert.Equal(t, "page-2", res.NextCursor)
+}
+
+func TestList_PassesOptionsAsQueryParams(t *testing.T) {
+	var gotQuery url.Values
+	srv := newFakeServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.Query()
+		_, _ = w.Write([]byte(`{"data":[]}`))
+	})
+	client := newAPIClient(t, srv.URL)
+
+	_, err := NewService(client).List(context.Background(), ListOptions{
+		Limit: 10, Cursor: "cur", SortBy: "created_at", Title: "exact-title", ProjectType: "android",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "10", gotQuery.Get("limit"))
+	assert.Equal(t, "cur", gotQuery.Get("next"))
+	assert.Equal(t, "created_at", gotQuery.Get("sort_by"))
+	assert.Equal(t, "exact-title", gotQuery.Get("title"))
+	assert.Equal(t, "android", gotQuery.Get("project_type"))
+}
+
+func TestList_PropagatesAPIError(t *testing.T) {
+	srv := newFakeServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"message":"Unauthorized"}`))
+	})
+	client := newAPIClient(t, srv.URL)
+
+	_, err := NewService(client).List(context.Background(), ListOptions{})
+	require.Error(t, err)
+	apiErr, ok := err.(*bitriseapi.APIError)
+	require.True(t, ok, "expected *bitriseapi.APIError, got %T", err)
+	assert.Equal(t, http.StatusUnauthorized, apiErr.StatusCode)
+}
+
+func TestView_HitsCorrectPath(t *testing.T) {
+	var gotPath string
+	srv := newFakeServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		_, _ = w.Write([]byte(`{"data":{"slug":"my-app","title":"App","provider":"github","owner":{"slug":"acme"}}}`))
+	})
+	client := newAPIClient(t, srv.URL)
+
+	got, err := NewService(client).View(context.Background(), "my-app")
+	require.NoError(t, err)
+	assert.Equal(t, "/apps/my-app", gotPath)
+	assert.Equal(t, App{Slug: "my-app", Title: "App", Provider: "github", OwnerSlug: "acme"}, got)
+}
+
+func TestView_AppNotFound(t *testing.T) {
+	srv := newFakeServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"message":"not found"}`))
+	})
+	client := newAPIClient(t, srv.URL)
+
+	_, err := NewService(client).View(context.Background(), "missing-app")
+	require.EqualError(t, err, `app "missing-app" not found`)
+}
+
+func newFakeServer(t *testing.T, handler http.HandlerFunc) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func newAPIClient(t *testing.T, baseURL string) *bitriseapi.Client {
+	t.Helper()
+	c, err := bitriseapi.New(baseURL, "t")
+	require.NoError(t, err)
+	return c
+}

--- a/internal/bitriseapi/apps.go
+++ b/internal/bitriseapi/apps.go
@@ -1,0 +1,165 @@
+package bitriseapi
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strconv"
+)
+
+// App is a Bitrise app (project), as returned by GET /apps and
+// GET /apps/{app-slug}.
+type App struct {
+	Slug        string   `json:"slug"`
+	Title       string   `json:"title"`
+	Provider    string   `json:"provider"`
+	RepoURL     string   `json:"repo_url"`
+	ProjectType string   `json:"project_type,omitempty"`
+	IsDisabled  bool     `json:"is_disabled"`
+	Owner       AppOwner `json:"owner"`
+}
+
+// AppOwner is the workspace or user that owns an app.
+type AppOwner struct {
+	Slug string `json:"slug"`
+}
+
+// AppsListOptions filters and paginates GET /apps. All fields are optional.
+type AppsListOptions struct {
+	SortBy      string // "created_at" or "last_build_at"
+	Next        string // pagination cursor from a previous page's response
+	Limit       int    // server default (50) when 0
+	Title       string
+	ProjectType string
+}
+
+func (o AppsListOptions) params() url.Values {
+	p := url.Values{}
+	if o.SortBy != "" {
+		p.Set("sort_by", o.SortBy)
+	}
+	if o.Next != "" {
+		p.Set("next", o.Next)
+	}
+	if o.Limit > 0 {
+		p.Set("limit", strconv.Itoa(o.Limit))
+	}
+	if o.Title != "" {
+		p.Set("title", o.Title)
+	}
+	if o.ProjectType != "" {
+		p.Set("project_type", o.ProjectType)
+	}
+	return p
+}
+
+type appsPage struct {
+	Data   []App `json:"data"`
+	Paging struct {
+		Next string `json:"next"`
+	} `json:"paging"`
+}
+
+// Apps returns one page of apps the authenticated user can access, and the
+// cursor for the next page ("" when there isn't one).
+// Endpoint: GET /apps.
+func (c *Client) Apps(ctx context.Context, opts AppsListOptions) ([]App, string, error) {
+	req, err := c.newRequest(ctx, "/apps", opts.params())
+	if err != nil {
+		return nil, "", err
+	}
+	body, err := c.do(req)
+	if err != nil {
+		return nil, "", err
+	}
+	var page appsPage
+	if err := json.Unmarshal(body, &page); err != nil {
+		return nil, "", fmt.Errorf("decode apps response: %w", err)
+	}
+	return page.Data, page.Paging.Next, nil
+}
+
+// App returns the details of a single app by slug.
+// Endpoint: GET /apps/{app-slug}.
+func (c *Client) App(ctx context.Context, appSlug string) (App, error) {
+	req, err := c.newRequest(ctx, "/apps/"+url.PathEscape(appSlug), nil)
+	if err != nil {
+		return App{}, err
+	}
+	body, err := c.do(req)
+	if err != nil {
+		return App{}, err
+	}
+	var envelope struct {
+		Data App `json:"data"`
+	}
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		return App{}, fmt.Errorf("decode app response: %w", err)
+	}
+	return envelope.Data, nil
+}
+
+// RegisterAppRequest is the body of POST /apps/register.
+//
+// IsPublic has no omitempty so the JSON always carries is_public:false when
+// not opted in, matching the website's "Add new app" flow. FlowType is the
+// analytics attribution string the server reads out of params[:flow_type].
+type RegisterAppRequest struct {
+	RepoURL           string `json:"repo_url"`
+	OrganizationSlug  string `json:"organization_slug"`
+	Provider          string `json:"provider"`
+	IsPublic          bool   `json:"is_public"`
+	Title             string `json:"title,omitempty"`
+	DefaultBranchName string `json:"default_branch_name,omitempty"`
+	FlowType          string `json:"flow_type,omitempty"`
+}
+
+// RegisterAppResponse is the response from POST /apps/register. The app is
+// in status=-1 (setup-incomplete) until FinishApp is called.
+type RegisterAppResponse struct {
+	Slug string `json:"slug"`
+}
+
+// RegisterApp creates a new app on Bitrise.
+// Endpoint: POST /apps/register.
+func (c *Client) RegisterApp(ctx context.Context, req RegisterAppRequest) (RegisterAppResponse, error) {
+	body, err := c.post(ctx, "/apps/register", nil, req)
+	if err != nil {
+		return RegisterAppResponse{}, err
+	}
+	var resp RegisterAppResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return RegisterAppResponse{}, fmt.Errorf("decode register response: %w", err)
+	}
+	return resp, nil
+}
+
+// FinishAppRequest is the body of POST /apps/{app-slug}/finish.
+type FinishAppRequest struct {
+	StackID     string `json:"stack_id"`
+	Mode        string `json:"mode"`
+	ProjectType string `json:"project_type,omitempty"`
+	Config      string `json:"config,omitempty"`
+	FlowType    string `json:"flow_type,omitempty"`
+}
+
+// FinishAppResponse is the response from POST /apps/{app-slug}/finish.
+type FinishAppResponse struct {
+	BuildTriggerToken string `json:"build_trigger_token"`
+	BranchName        string `json:"branch_name"`
+}
+
+// FinishApp activates a registered app, returning its build trigger token.
+// Endpoint: POST /apps/{app-slug}/finish.
+func (c *Client) FinishApp(ctx context.Context, appSlug string, req FinishAppRequest) (FinishAppResponse, error) {
+	body, err := c.post(ctx, "/apps/"+url.PathEscape(appSlug)+"/finish", nil, req)
+	if err != nil {
+		return FinishAppResponse{}, err
+	}
+	var resp FinishAppResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return FinishAppResponse{}, fmt.Errorf("decode finish response: %w", err)
+	}
+	return resp, nil
+}

--- a/internal/bitriseapi/apps_test.go
+++ b/internal/bitriseapi/apps_test.go
@@ -1,0 +1,127 @@
+package bitriseapi
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestApps_ParsesResponseAndPagingCursor(t *testing.T) {
+	srv := newFakeServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{
+			"data": [{"slug":"app-1","title":"First","provider":"github","repo_url":"https://github.com/x/y","project_type":"android","is_disabled":false,"owner":{"slug":"acme"}}],
+			"paging": {"next":"page-2"}
+		}`))
+	})
+
+	apps, next, err := newAPIClient(t, srv.URL, "t").Apps(context.Background(), AppsListOptions{})
+	require.NoError(t, err)
+	require.Len(t, apps, 1)
+	assert.Equal(t, App{Slug: "app-1", Title: "First", Provider: "github", RepoURL: "https://github.com/x/y", ProjectType: "android", Owner: AppOwner{Slug: "acme"}}, apps[0])
+	assert.Equal(t, "page-2", next)
+}
+
+func TestApps_SendsListOptionsAsQueryParams(t *testing.T) {
+	var gotQuery string
+	srv := newFakeServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.RawQuery
+		_, _ = w.Write([]byte(`{"data":[]}`))
+	})
+
+	_, _, err := newAPIClient(t, srv.URL, "t").Apps(context.Background(), AppsListOptions{
+		SortBy:      "created_at",
+		Next:        "cur",
+		Limit:       10,
+		Title:       "exact-title",
+		ProjectType: "android",
+	})
+	require.NoError(t, err)
+	q, err := url.ParseQuery(gotQuery)
+	require.NoError(t, err)
+	assert.Equal(t, "created_at", q.Get("sort_by"))
+	assert.Equal(t, "cur", q.Get("next"))
+	assert.Equal(t, "10", q.Get("limit"))
+	assert.Equal(t, "exact-title", q.Get("title"))
+	assert.Equal(t, "android", q.Get("project_type"))
+}
+
+func TestApps_PropagatesAPIError(t *testing.T) {
+	srv := newFakeServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"message":"Unauthorized"}`))
+	})
+
+	_, _, err := newAPIClient(t, srv.URL, "t").Apps(context.Background(), AppsListOptions{})
+	require.Error(t, err)
+	apiErr, ok := err.(*APIError)
+	require.True(t, ok, "expected *APIError, got %T", err)
+	assert.Equal(t, http.StatusUnauthorized, apiErr.StatusCode)
+}
+
+func TestApp_HitsCorrectPath(t *testing.T) {
+	var gotPath string
+	srv := newFakeServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		_, _ = w.Write([]byte(`{"data":{"slug":"my-app","title":"App","provider":"github","owner":{"slug":"acme"}}}`))
+	})
+
+	app, err := newAPIClient(t, srv.URL, "t").App(context.Background(), "my-app")
+	require.NoError(t, err)
+	assert.Equal(t, "/apps/my-app", gotPath)
+	assert.Equal(t, App{Slug: "my-app", Title: "App", Provider: "github", Owner: AppOwner{Slug: "acme"}}, app)
+}
+
+func TestApp_PropagatesAPIError(t *testing.T) {
+	srv := newFakeServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"message":"not found"}`))
+	})
+
+	_, err := newAPIClient(t, srv.URL, "t").App(context.Background(), "missing")
+	require.Error(t, err)
+	apiErr, ok := err.(*APIError)
+	require.True(t, ok, "expected *APIError, got %T", err)
+	assert.Equal(t, http.StatusNotFound, apiErr.StatusCode)
+}
+
+func TestRegisterApp(t *testing.T) {
+	var gotPath, gotMethod, gotBody string
+	srv := newFakeServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotMethod = r.Method
+		b, _ := io.ReadAll(r.Body)
+		gotBody = string(b)
+		_, _ = w.Write([]byte(`{"slug":"new-app"}`))
+	})
+
+	resp, err := newAPIClient(t, srv.URL, "t").RegisterApp(context.Background(), RegisterAppRequest{
+		RepoURL:           "https://github.com/acme/widget.git",
+		OrganizationSlug:  "acme",
+		Provider:          "custom",
+		DefaultBranchName: "main",
+		FlowType:          "cli",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "/apps/register", gotPath)
+	assert.Equal(t, http.MethodPost, gotMethod)
+	assert.Equal(t, RegisterAppResponse{Slug: "new-app"}, resp)
+	assert.JSONEq(t, `{"repo_url":"https://github.com/acme/widget.git","organization_slug":"acme","provider":"custom","is_public":false,"default_branch_name":"main","flow_type":"cli"}`, gotBody)
+}
+
+func TestFinishApp(t *testing.T) {
+	var gotPath string
+	srv := newFakeServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		_, _ = w.Write([]byte(`{"build_trigger_token":"btt","branch_name":"main"}`))
+	})
+
+	resp, err := newAPIClient(t, srv.URL, "t").FinishApp(context.Background(), "new-app", FinishAppRequest{StackID: "linux-docker-android-22.04", Mode: "manual"})
+	require.NoError(t, err)
+	assert.Equal(t, "/apps/new-app/finish", gotPath)
+	assert.Equal(t, FinishAppResponse{BuildTriggerToken: "btt", BranchName: "main"}, resp)
+}

--- a/internal/bitriseapi/organizations.go
+++ b/internal/bitriseapi/organizations.go
@@ -1,0 +1,33 @@
+package bitriseapi
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+)
+
+// Organization is a workspace the authenticated user belongs to.
+type Organization struct {
+	Slug string `json:"slug"`
+	Name string `json:"name"`
+}
+
+// Organizations returns the workspaces the authenticated user can access.
+// Endpoint: GET /organizations.
+func (c *Client) Organizations(ctx context.Context) ([]Organization, error) {
+	req, err := c.newRequest(ctx, "/organizations", nil)
+	if err != nil {
+		return nil, err
+	}
+	body, err := c.do(req)
+	if err != nil {
+		return nil, err
+	}
+	var envelope struct {
+		Data []Organization `json:"data"`
+	}
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		return nil, fmt.Errorf("decode organizations response: %w", err)
+	}
+	return envelope.Data, nil
+}

--- a/internal/bitriseapi/organizations_test.go
+++ b/internal/bitriseapi/organizations_test.go
@@ -1,0 +1,38 @@
+package bitriseapi
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOrganizations_ParsesResponse(t *testing.T) {
+	var gotPath, gotAuth string
+	srv := newFakeServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotAuth = r.Header.Get("Authorization")
+		_, _ = w.Write([]byte(`{"data":[{"slug":"acme","name":"Acme"}]}`))
+	})
+
+	orgs, err := newAPIClient(t, srv.URL, "my-token").Organizations(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "/organizations", gotPath)
+	assert.Equal(t, "token my-token", gotAuth)
+	assert.Equal(t, []Organization{{Slug: "acme", Name: "Acme"}}, orgs)
+}
+
+func TestOrganizations_PropagatesAPIError(t *testing.T) {
+	srv := newFakeServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"message":"forbidden"}`))
+	})
+
+	_, err := newAPIClient(t, srv.URL, "t").Organizations(context.Background())
+	require.Error(t, err)
+	apiErr, ok := err.(*APIError)
+	require.True(t, ok, "expected *APIError, got %T", err)
+	assert.Equal(t, http.StatusForbidden, apiErr.StatusCode)
+}


### PR DESCRIPTION
`internal/bitriseapi` gains `GET /apps` (paged), `GET /apps/{slug}`, `POST /apps/register`, `POST /apps/{slug}/finish` and `GET /organizations`.
`internal/app` wraps them in the business-logic layer the `cmd` layer will use: its own `App/AppsResult/CreateResult` types rather than the wire shapes, `List` and `View`, and the register -> finish -> optional bitrise.yml upload sequence that creating an app requires.

Registering an app leaves it in a setup-incomplete state until `/finish` runs, so `Create` always does both and reports the resulting build trigger token.

No CLI surface yet — `bitrise app` arrives in a later change.