### PR TITLE
v3 prep: add `app_id` and `default_workspace_id` config keys

### DIFF
--- a/_docs/v3-breaking-changes.md
+++ b/_docs/v3-breaking-changes.md
@@ -134,13 +134,17 @@ scripts keep running: `trigger-check` was the only command removed outright, and
   build, and both are now read as identity fallbacks: `app_id` resolves as `--app` >
   `$BITRISE_APP_ID` > `$BITRISE_APP_SLUG` > per-directory file > global file, and
   `default_workspace_id` the same way via `--workspace` and `$BITRISE_WORKSPACE_ID`.
-  So a build step running `bitrise yml get`, `bitrise yml update` or `bitrise yml
-  validate` without `--app` no longer fails with `--app is required` — it acts on the
-  host app, and for `yml update` that means overwriting that app's own stored
-  bitrise.yml. Note the env var also outranks an `app_id` pinned in a
-  `.bitrise-cli.yml`. *Migrate:* pass `--app` explicitly in any build step that targets
-  a different app than the one it runs in; unset `BITRISE_APP_SLUG` for the invocation
-  if you want the old "required" error back.
+  So a build step running `bitrise yml get` or `bitrise yml update` without `--app` no
+  longer fails with `--app is required` — it acts on the host app, and for `yml update`
+  that means overwriting that app's own stored bitrise.yml. `bitrise yml validate` never
+  required `--app`, but it now picks the host app up on its own, so a build step that
+  validates online runs the app-specific checks (stacks, machine types, license pools)
+  that previously ran only when `--app` was passed explicitly — a config that validated
+  cleanly before can now report app-specific errors. `--offline` is unaffected: it skips
+  the online path, and an ambient app ID stays ignored there. Note the env var also
+  outranks an `app_id` pinned in a `.bitrise-cli.yml`. *Migrate:* pass `--app` explicitly
+  in any build step that targets a different app than the one it runs in; unset
+  `BITRISE_APP_SLUG` for the invocation to restore the previous behavior.
 - **Two new config file locations are now read, layered under the existing one.**
   Besides the pre-existing `~/.bitrise/config.json`, the CLI now also reads a global
   `~/.config/bitrise/cli/config.yml` and a per-directory `.bitrise-cli.yml` (found by

--- a/_docs/v3-breaking-changes.md
+++ b/_docs/v3-breaking-changes.md
@@ -129,6 +129,18 @@ scripts keep running: `trigger-check` was the only command removed outright, and
 
 ## Config handling
 
+- **Inside a Bitrise build, cloud commands with no `--app` now target the app the build
+  runs for.** `$BITRISE_APP_SLUG` and `$BITRISE_WORKSPACE_ID` are injected into every
+  build, and both are now read as identity fallbacks: `app_id` resolves as `--app` >
+  `$BITRISE_APP_ID` > `$BITRISE_APP_SLUG` > per-directory file > global file, and
+  `default_workspace_id` the same way via `--workspace` and `$BITRISE_WORKSPACE_ID`.
+  So a build step running `bitrise yml get`, `bitrise yml update` or `bitrise yml
+  validate` without `--app` no longer fails with `--app is required` — it acts on the
+  host app, and for `yml update` that means overwriting that app's own stored
+  bitrise.yml. Note the env var also outranks an `app_id` pinned in a
+  `.bitrise-cli.yml`. *Migrate:* pass `--app` explicitly in any build step that targets
+  a different app than the one it runs in; unset `BITRISE_APP_SLUG` for the invocation
+  if you want the old "required" error back.
 - **Two new config file locations are now read, layered under the existing one.**
   Besides the pre-existing `~/.bitrise/config.json`, the CLI now also reads a global
   `~/.config/bitrise/cli/config.yml` and a per-directory `.bitrise-cli.yml` (found by

--- a/cli/cmdutil/app.go
+++ b/cli/cmdutil/app.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+
+	"github.com/bitrise-io/bitrise/v2/internal/config"
 )
 
 // FlagApp is the app slug a command acts on.
@@ -29,13 +31,23 @@ func AddAppFlag(fs *pflag.FlagSet, help string) {
 }
 
 // ResolveAppSlug returns the app slug from --app, falling back to
-// BITRISE_APP_ID. There is no config-file fallback yet — add one when a
-// command needs it.
+// BITRISE_APP_ID, then the app_id set by `bitrise app create` or
+// `bitrise config set app_id`.
 func ResolveAppSlug(cmd *cobra.Command) (string, error) {
 	if slug := LookupAppSlug(cmd); slug != "" {
 		return slug, nil
 	}
 	return "", AppSlugRequiredErr()
+}
+
+// ResolveAppSlugArg is ResolveAppSlug for commands that also accept the app
+// slug as a positional argument (e.g. `app view [APP_ID]`), which takes
+// precedence over --app/BITRISE_APP_ID/config when given.
+func ResolveAppSlugArg(cmd *cobra.Command, args []string) (string, error) {
+	if len(args) > 0 && args[0] != "" {
+		return args[0], nil
+	}
+	return ResolveAppSlug(cmd)
 }
 
 // LookupAppSlug resolves the app slug the same way as ResolveAppSlug but
@@ -45,7 +57,10 @@ func LookupAppSlug(cmd *cobra.Command) string {
 	if v, _ := cmd.Flags().GetString(FlagApp); v != "" {
 		return v
 	}
-	return os.Getenv(EnvAppID)
+	if v := os.Getenv(EnvAppID); v != "" {
+		return v
+	}
+	return config.FromContext(cmd.Context()).AppID
 }
 
 // AppSlugRequiredErr returns the standard missing-app-slug error.

--- a/cli/cmdutil/app.go
+++ b/cli/cmdutil/app.go
@@ -13,14 +13,16 @@ import (
 // FlagApp is the app slug a command acts on.
 const FlagApp = "app"
 
-// EnvAppID overrides the app slug when --app isn't passed. Deliberately does
-// NOT also accept BITRISE_APP_SLUG the way the reference CLI does: Bitrise
-// auto-injects that variable into every build to identify the app the build
-// is running for (see analytics/tracker.go, configs/agent_config.go), so
-// honoring it here would make a bare `bitrise yml update` step running
-// inside app X's build silently target and overwrite app X's own
-// bitrise.yml.
+// EnvAppID overrides the app slug when --app isn't passed.
 const EnvAppID = "BITRISE_APP_ID"
+
+// EnvAppIDLegacy is the pre-rename name, still accepted below EnvAppID.
+// Bitrise auto-injects it into every build to identify the app the build runs
+// for (see analytics/tracker.go, configs/agent_config.go), so honoring it
+// means a bare command inside app X's build targets app X — including
+// `bitrise yml update`, which then overwrites that app's own bitrise.yml.
+// That ambient targeting is intentional and matches the released CLI.
+const EnvAppIDLegacy = "BITRISE_APP_SLUG"
 
 // AddAppFlag registers --app. Registered per-subcommand rather than as a
 // persistent parent flag, since some of these commands are also
@@ -31,8 +33,8 @@ func AddAppFlag(fs *pflag.FlagSet, help string) {
 }
 
 // ResolveAppSlug returns the app slug from --app, falling back to
-// BITRISE_APP_ID, then the app_id set by `bitrise app create` or
-// `bitrise config set app_id`.
+// BITRISE_APP_ID, then BITRISE_APP_SLUG, then the app_id set by
+// `bitrise app create` or `bitrise config set app_id`.
 func ResolveAppSlug(cmd *cobra.Command) (string, error) {
 	if slug := LookupAppSlug(cmd); slug != "" {
 		return slug, nil
@@ -58,6 +60,9 @@ func LookupAppSlug(cmd *cobra.Command) string {
 		return v
 	}
 	if v := os.Getenv(EnvAppID); v != "" {
+		return v
+	}
+	if v := os.Getenv(EnvAppIDLegacy); v != "" {
 		return v
 	}
 	return config.FromContext(cmd.Context()).AppID

--- a/cli/cmdutil/app_test.go
+++ b/cli/cmdutil/app_test.go
@@ -21,6 +21,8 @@ func TestResolveAppSlug_FromFlag(t *testing.T) {
 }
 
 func TestResolveAppSlug_MissingFlag(t *testing.T) {
+	t.Setenv(EnvAppIDLegacy, "")
+
 	cmd := &cobra.Command{}
 	AddAppFlag(cmd.Flags(), "app slug")
 
@@ -50,6 +52,8 @@ func TestResolveAppSlug_FlagTakesPrecedenceOverEnv(t *testing.T) {
 }
 
 func TestLookupAppSlug_EmptyInsteadOfError(t *testing.T) {
+	t.Setenv(EnvAppIDLegacy, "")
+
 	cmd := &cobra.Command{}
 	AddAppFlag(cmd.Flags(), "app slug")
 
@@ -63,6 +67,8 @@ func TestLookupAppSlug_EmptyInsteadOfError(t *testing.T) {
 }
 
 func TestResolveAppSlug_FromConfig(t *testing.T) {
+	t.Setenv(EnvAppIDLegacy, "")
+
 	cmd := &cobra.Command{}
 	AddAppFlag(cmd.Flags(), "app slug")
 	cmd.SetContext(config.WithResolved(t.Context(), config.Resolved{Config: config.Config{AppID: "config-app-slug"}}))
@@ -94,6 +100,8 @@ func TestResolveAppSlugArg_PositionalArgTakesPrecedence(t *testing.T) {
 }
 
 func TestResolveAppSlugArg_FallsBackToResolveAppSlug(t *testing.T) {
+	t.Setenv(EnvAppIDLegacy, "")
+
 	cmd := &cobra.Command{}
 	AddAppFlag(cmd.Flags(), "app slug")
 	require.NoError(t, cmd.Flags().Set(FlagApp, "flag-app-slug"))
@@ -106,15 +114,39 @@ func TestResolveAppSlugArg_FallsBackToResolveAppSlug(t *testing.T) {
 	require.EqualError(t, err, "--app is required")
 }
 
-func TestResolveAppSlug_LegacyAppSlugEnvNotHonored(t *testing.T) {
-	// BITRISE_APP_SLUG is auto-injected by Bitrise into every build to
-	// identify the app the build is running for — it must never be read
-	// here, or a step running inside app X's build could silently target
-	// app X's own bitrise.yml. See EnvAppID's doc comment.
-	t.Setenv("BITRISE_APP_SLUG", "ci-injected-app-slug")
+// BITRISE_APP_SLUG is auto-injected by Bitrise into every build, so honoring it
+// is what lets a bare command inside a build target the app it runs for.
+func TestResolveAppSlug_LegacyAppSlugEnvHonored(t *testing.T) {
+	t.Setenv(EnvAppIDLegacy, "ci-injected-app-slug")
+
 	cmd := &cobra.Command{}
 	AddAppFlag(cmd.Flags(), "app slug")
 
-	_, err := ResolveAppSlug(cmd)
-	require.EqualError(t, err, "--app is required")
+	slug, err := ResolveAppSlug(cmd)
+	require.NoError(t, err)
+	assert.Equal(t, "ci-injected-app-slug", slug)
+}
+
+func TestResolveAppSlug_EnvTakesPrecedenceOverLegacyEnv(t *testing.T) {
+	t.Setenv(EnvAppID, "env-app-slug")
+	t.Setenv(EnvAppIDLegacy, "ci-injected-app-slug")
+
+	cmd := &cobra.Command{}
+	AddAppFlag(cmd.Flags(), "app slug")
+
+	slug, err := ResolveAppSlug(cmd)
+	require.NoError(t, err)
+	assert.Equal(t, "env-app-slug", slug)
+}
+
+func TestResolveAppSlug_LegacyEnvTakesPrecedenceOverConfig(t *testing.T) {
+	t.Setenv(EnvAppIDLegacy, "ci-injected-app-slug")
+
+	cmd := &cobra.Command{}
+	AddAppFlag(cmd.Flags(), "app slug")
+	cmd.SetContext(config.WithResolved(t.Context(), config.Resolved{Config: config.Config{AppID: "config-app-slug"}}))
+
+	slug, err := ResolveAppSlug(cmd)
+	require.NoError(t, err)
+	assert.Equal(t, "ci-injected-app-slug", slug)
 }

--- a/cli/cmdutil/app_test.go
+++ b/cli/cmdutil/app_test.go
@@ -6,6 +6,8 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/bitrise-io/bitrise/v2/internal/config"
 )
 
 func TestResolveAppSlug_FromFlag(t *testing.T) {
@@ -58,6 +60,50 @@ func TestLookupAppSlug_EmptyInsteadOfError(t *testing.T) {
 
 	require.NoError(t, cmd.Flags().Set(FlagApp, "flag-app-slug"))
 	assert.Equal(t, "flag-app-slug", LookupAppSlug(cmd))
+}
+
+func TestResolveAppSlug_FromConfig(t *testing.T) {
+	cmd := &cobra.Command{}
+	AddAppFlag(cmd.Flags(), "app slug")
+	cmd.SetContext(config.WithResolved(t.Context(), config.Resolved{Config: config.Config{AppID: "config-app-slug"}}))
+
+	slug, err := ResolveAppSlug(cmd)
+	require.NoError(t, err)
+	assert.Equal(t, "config-app-slug", slug)
+}
+
+func TestResolveAppSlug_EnvTakesPrecedenceOverConfig(t *testing.T) {
+	t.Setenv(EnvAppID, "env-app-slug")
+	cmd := &cobra.Command{}
+	AddAppFlag(cmd.Flags(), "app slug")
+	cmd.SetContext(config.WithResolved(t.Context(), config.Resolved{Config: config.Config{AppID: "config-app-slug"}}))
+
+	slug, err := ResolveAppSlug(cmd)
+	require.NoError(t, err)
+	assert.Equal(t, "env-app-slug", slug)
+}
+
+func TestResolveAppSlugArg_PositionalArgTakesPrecedence(t *testing.T) {
+	cmd := &cobra.Command{}
+	AddAppFlag(cmd.Flags(), "app slug")
+	require.NoError(t, cmd.Flags().Set(FlagApp, "flag-app-slug"))
+
+	slug, err := ResolveAppSlugArg(cmd, []string{"arg-app-slug"})
+	require.NoError(t, err)
+	assert.Equal(t, "arg-app-slug", slug)
+}
+
+func TestResolveAppSlugArg_FallsBackToResolveAppSlug(t *testing.T) {
+	cmd := &cobra.Command{}
+	AddAppFlag(cmd.Flags(), "app slug")
+	require.NoError(t, cmd.Flags().Set(FlagApp, "flag-app-slug"))
+
+	slug, err := ResolveAppSlugArg(cmd, nil)
+	require.NoError(t, err)
+	assert.Equal(t, "flag-app-slug", slug)
+
+	_, err = ResolveAppSlugArg(&cobra.Command{}, nil)
+	require.EqualError(t, err, "--app is required")
 }
 
 func TestResolveAppSlug_LegacyAppSlugEnvNotHonored(t *testing.T) {

--- a/cli/cmdutil/webbase.go
+++ b/cli/cmdutil/webbase.go
@@ -20,10 +20,8 @@ func ResolveWebBaseURL(cmd *cobra.Command) string {
 	if v := os.Getenv(EnvWebBaseURL); v != "" {
 		return v
 	}
-	if ctx := cmd.Context(); ctx != nil {
-		if v := config.FromContext(ctx).WebBaseURL; v != "" {
-			return v
-		}
+	if v := config.FromContext(cmd.Context()).WebBaseURL; v != "" {
+		return v
 	}
 	return config.DefaultWebBaseURL
 }

--- a/cli/cmdutil/workspace.go
+++ b/cli/cmdutil/workspace.go
@@ -11,10 +11,10 @@ import (
 // FlagWorkspace is the workspace a command acts on.
 const FlagWorkspace = "workspace"
 
-// EnvWorkspaceID supplies the workspace when --workspace isn't passed. Safe to
-// honor unconditionally, unlike BITRISE_APP_SLUG (see EnvAppID): Bitrise does
-// not inject a workspace ID into builds, so this can't make a bare command
-// silently act on whatever workspace a build happens to run in.
+// EnvWorkspaceID supplies the workspace when --workspace isn't passed. Bitrise
+// auto-injects it into every build, naming the workspace that owns the app the
+// build runs for, so a bare command inside a build acts on that workspace. Same
+// intentional ambient targeting as EnvAppIDLegacy.
 const EnvWorkspaceID = "BITRISE_WORKSPACE_ID"
 
 // DefaultWorkspaceSlug returns the workspace configured as the default —

--- a/cli/cmdutil/workspace.go
+++ b/cli/cmdutil/workspace.go
@@ -1,0 +1,30 @@
+package cmdutil
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/bitrise-io/bitrise/v2/internal/config"
+)
+
+// FlagWorkspace is the workspace a command acts on.
+const FlagWorkspace = "workspace"
+
+// EnvWorkspaceID supplies the workspace when --workspace isn't passed. Safe to
+// honor unconditionally, unlike BITRISE_APP_SLUG (see EnvAppID): Bitrise does
+// not inject a workspace ID into builds, so this can't make a bare command
+// silently act on whatever workspace a build happens to run in.
+const EnvWorkspaceID = "BITRISE_WORKSPACE_ID"
+
+// DefaultWorkspaceSlug returns the workspace configured as the default —
+// BITRISE_WORKSPACE_ID, then the default_workspace_id config key — or "" when
+// neither is set. It deliberately does not read --workspace: callers own that
+// flag's precedence, and they need to know whether a value came from the flag
+// (explicit) or from here (implicit) to report it to the user.
+func DefaultWorkspaceSlug(cmd *cobra.Command) string {
+	if v := os.Getenv(EnvWorkspaceID); v != "" {
+		return v
+	}
+	return config.FromContext(cmd.Context()).DefaultWorkspaceID
+}

--- a/cli/cmdutil/workspace_test.go
+++ b/cli/cmdutil/workspace_test.go
@@ -1,0 +1,40 @@
+package cmdutil
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/bitrise-io/bitrise/v2/internal/config"
+)
+
+// A bare command has a nil Context(), which must read as "no default set"
+// rather than panicking.
+func TestDefaultWorkspaceSlug_EmptyWhenNothingSet(t *testing.T) {
+	t.Setenv(EnvWorkspaceID, "")
+
+	assert.Empty(t, DefaultWorkspaceSlug(&cobra.Command{}))
+}
+
+func TestDefaultWorkspaceSlug_FromConfig(t *testing.T) {
+	t.Setenv(EnvWorkspaceID, "")
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(config.WithResolved(t.Context(), config.Resolve(
+		config.Config{}, config.Config{}, config.Config{DefaultWorkspaceID: "cfg-ws"},
+	)))
+
+	assert.Equal(t, "cfg-ws", DefaultWorkspaceSlug(cmd))
+}
+
+func TestDefaultWorkspaceSlug_EnvWinsOverConfig(t *testing.T) {
+	t.Setenv(EnvWorkspaceID, "env-ws")
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(config.WithResolved(t.Context(), config.Resolve(
+		config.Config{}, config.Config{}, config.Config{DefaultWorkspaceID: "cfg-ws"},
+	)))
+
+	assert.Equal(t, "env-ws", DefaultWorkspaceSlug(cmd))
+}

--- a/cli/config/cmd.go
+++ b/cli/config/cmd.go
@@ -30,12 +30,17 @@ wins over both. They deliberately ignore the per-directory .bitrise-cli.yml
 — each names a host that receives credentials, and a repo you merely clone
 and run 'bitrise' inside of must not be able to silently redirect them.
 
-app_id resolves as: --app flag > $BITRISE_APP_ID > per-directory file >
-global file. default_workspace_id resolves the same way, via --workspace and
-$BITRISE_WORKSPACE_ID. Both honor the per-directory file precisely so a repo
-can pin which app and workspace its checkout belongs to; they're identifiers,
-not credentials. 'bitrise app create' writes app_id to the global file, and
-falls back to default_workspace_id when --workspace is omitted.
+app_id resolves as: --app flag > $BITRISE_APP_ID > $BITRISE_APP_SLUG >
+per-directory file > global file. default_workspace_id resolves the same way,
+via --workspace and $BITRISE_WORKSPACE_ID. Both honor the per-directory file
+precisely so a repo can pin which app and workspace its checkout belongs to;
+they're identifiers, not credentials. 'bitrise app create' writes app_id to the
+global file, and falls back to default_workspace_id when --workspace is omitted.
+
+Bitrise sets $BITRISE_APP_SLUG and $BITRISE_WORKSPACE_ID in every build, so
+inside a build a command with no --app/--workspace acts on the app the build
+runs for and the workspace owning it. Pass the flag explicitly to target
+anything else.
 
 'get'/'set'/'unset'/'list' only read and write the global file — per-dir
 files must be edited by hand.

--- a/cli/config/cmd.go
+++ b/cli/config/cmd.go
@@ -20,21 +20,28 @@ func NewCmd() *cobra.Command {
 Storage:
   Global file: ~/.config/bitrise/cli/config.yml
                (honors $XDG_CONFIG_HOME instead of ~/.config)
-
-Precedence, highest to lowest: global file > built-in default.
-web_base_url is additionally overridable via $%s, which takes precedence
-over the global file.
+  Per-dir:     .bitrise-cli.yml in the current directory or any ancestor
 
 Recognized keys: %s
 
-These two keys deliberately ignore the per-directory .bitrise-cli.yml file
-(unlike every other setting) and the legacy ~/.bitrise/config.json — both
-carry credentials to whatever host they name, and a repo you merely clone
+api_base_url and web_base_url resolve as: global file > built-in default.
+web_base_url is additionally overridable via $%s, which
+wins over both. They deliberately ignore the per-directory .bitrise-cli.yml
+— each names a host that receives credentials, and a repo you merely clone
 and run 'bitrise' inside of must not be able to silently redirect them.
-'get'/'set'/'unset'/'list' only read and write the global file.
+
+app_id resolves as: --app flag > $BITRISE_APP_ID > per-directory file >
+global file. default_workspace_id resolves the same way, via --workspace and
+$BITRISE_WORKSPACE_ID. Both honor the per-directory file precisely so a repo
+can pin which app and workspace its checkout belongs to; they're identifiers,
+not credentials. 'bitrise app create' writes app_id to the global file, and
+falls back to default_workspace_id when --workspace is omitted.
+
+'get'/'set'/'unset'/'list' only read and write the global file — per-dir
+files must be edited by hand.
 
 To manage your access token, use 'bitrise auth login/logout/status'.`,
-			cmdutil.EnvWebBaseURL, strings.Join(internalconfig.Keys, ", "),
+			strings.Join(internalconfig.Keys, ", "), cmdutil.EnvWebBaseURL,
 		),
 		RunE: cmdutil.RequireKnownSubcommand,
 	}

--- a/cli/config/list.go
+++ b/cli/config/list.go
@@ -31,8 +31,10 @@ func NewListCommand() *cobra.Command {
 		Long: `List the values currently saved in the global config file.
 
 This shows what is stored, not what every command will resolve: the
-BITRISE_WEB_BASE_URL and BITRISE_APP_ID environment variables, and an app_id
-pinned by a per-directory .bitrise-cli.yml, all take precedence at runtime.`,
+BITRISE_WEB_BASE_URL, BITRISE_APP_ID, BITRISE_APP_SLUG and BITRISE_WORKSPACE_ID
+environment variables, and an app_id or default_workspace_id pinned by a
+per-directory .bitrise-cli.yml, all take precedence at runtime. Inside a Bitrise
+build, BITRISE_APP_SLUG and BITRISE_WORKSPACE_ID are always set.`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			cmdutil.LogCommandParameters(cmd)

--- a/cli/config/list.go
+++ b/cli/config/list.go
@@ -11,14 +11,16 @@ import (
 	"github.com/bitrise-io/bitrise/v2/output"
 )
 
-// configList is the JSON/YAML shape of `config list`. Neither URL field is
-// omitempty: this command's job is to enumerate every recognized key's
-// state, so an unset key must still appear (as "") rather than vanish from
-// the JSON/YAML output while still showing as "(unset)" in raw mode.
+// configList is the JSON/YAML shape of `config list`. No field is omitempty:
+// this command's job is to enumerate every recognized key's state, so an
+// unset key must still appear (as "") rather than vanish from the JSON/YAML
+// output while still showing as "(unset)" in raw mode.
 type configList struct {
-	APIBaseURL string `json:"api_base_url" yaml:"api_base_url"`
-	WebBaseURL string `json:"web_base_url" yaml:"web_base_url"`
-	Path       string `json:"path" yaml:"path"`
+	APIBaseURL         string `json:"api_base_url" yaml:"api_base_url"`
+	WebBaseURL         string `json:"web_base_url" yaml:"web_base_url"`
+	AppID              string `json:"app_id" yaml:"app_id"`
+	DefaultWorkspaceID string `json:"default_workspace_id" yaml:"default_workspace_id"`
+	Path               string `json:"path" yaml:"path"`
 }
 
 // NewListCommand returns the `config list` subcommand.
@@ -28,8 +30,9 @@ func NewListCommand() *cobra.Command {
 		Short: "List the values currently saved in the global config file",
 		Long: `List the values currently saved in the global config file.
 
-This does not show the BITRISE_WEB_BASE_URL environment override, which
-takes precedence over it at runtime.`,
+This shows what is stored, not what every command will resolve: the
+BITRISE_WEB_BASE_URL and BITRISE_APP_ID environment variables, and an app_id
+pinned by a per-directory .bitrise-cli.yml, all take precedence at runtime.`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			cmdutil.LogCommandParameters(cmd)
@@ -47,7 +50,7 @@ takes precedence over it at runtime.`,
 			if err != nil {
 				return err
 			}
-			v := configList{APIBaseURL: cfg.APIBaseURL, WebBaseURL: cfg.WebBaseURL, Path: p}
+			v := configList{APIBaseURL: cfg.APIBaseURL, WebBaseURL: cfg.WebBaseURL, AppID: cfg.AppID, DefaultWorkspaceID: cfg.DefaultWorkspaceID, Path: p}
 
 			if output.Format == output.FormatRaw {
 				return printListHuman(cmd.OutOrStdout(), v)
@@ -61,10 +64,12 @@ takes precedence over it at runtime.`,
 }
 
 func printListHuman(w io.Writer, v configList) error {
-	_, err := fmt.Fprintf(w, "Path: %s\n\n%s: %s\n%s: %s\n",
+	_, err := fmt.Fprintf(w, "Path: %s\n\n%s: %s\n%s: %s\n%s: %s\n%s: %s\n",
 		v.Path,
 		internalconfig.KeyAPIBaseURL, unsetLabel(v.APIBaseURL),
 		internalconfig.KeyWebBaseURL, unsetLabel(v.WebBaseURL),
+		internalconfig.KeyAppID, unsetLabel(v.AppID),
+		internalconfig.KeyDefaultWorkspaceID, unsetLabel(v.DefaultWorkspaceID),
 	)
 	return err
 }

--- a/cli/config/list.go
+++ b/cli/config/list.go
@@ -11,18 +11,6 @@ import (
 	"github.com/bitrise-io/bitrise/v2/output"
 )
 
-// configList is the JSON/YAML shape of `config list`. No field is omitempty:
-// this command's job is to enumerate every recognized key's state, so an
-// unset key must still appear (as "") rather than vanish from the JSON/YAML
-// output while still showing as "(unset)" in raw mode.
-type configList struct {
-	APIBaseURL         string `json:"api_base_url" yaml:"api_base_url"`
-	WebBaseURL         string `json:"web_base_url" yaml:"web_base_url"`
-	AppID              string `json:"app_id" yaml:"app_id"`
-	DefaultWorkspaceID string `json:"default_workspace_id" yaml:"default_workspace_id"`
-	Path               string `json:"path" yaml:"path"`
-}
-
 // NewListCommand returns the `config list` subcommand.
 func NewListCommand() *cobra.Command {
 	cmd := &cobra.Command{
@@ -52,12 +40,19 @@ build, BITRISE_APP_SLUG and BITRISE_WORKSPACE_ID are always set.`,
 			if err != nil {
 				return err
 			}
-			v := configList{APIBaseURL: cfg.APIBaseURL, WebBaseURL: cfg.WebBaseURL, AppID: cfg.AppID, DefaultWorkspaceID: cfg.DefaultWorkspaceID, Path: p}
+			values, err := configValues(cfg)
+			if err != nil {
+				return err
+			}
+			// No omitempty on any key: this command's job is to enumerate every
+			// recognized key's state, so an unset key must still appear (as "")
+			// rather than vanish from the JSON/YAML output.
+			values["path"] = p
 
 			if output.Format == output.FormatRaw {
-				return printListHuman(cmd.OutOrStdout(), v)
+				return printListHuman(cmd.OutOrStdout(), p, values)
 			}
-			return output.Print(v, output.Format)
+			return output.Print(values, output.Format)
 		},
 	}
 
@@ -65,15 +60,31 @@ build, BITRISE_APP_SLUG and BITRISE_WORKSPACE_ID are always set.`,
 	return cmd
 }
 
-func printListHuman(w io.Writer, v configList) error {
-	_, err := fmt.Fprintf(w, "Path: %s\n\n%s: %s\n%s: %s\n%s: %s\n%s: %s\n",
-		v.Path,
-		internalconfig.KeyAPIBaseURL, unsetLabel(v.APIBaseURL),
-		internalconfig.KeyWebBaseURL, unsetLabel(v.WebBaseURL),
-		internalconfig.KeyAppID, unsetLabel(v.AppID),
-		internalconfig.KeyDefaultWorkspaceID, unsetLabel(v.DefaultWorkspaceID),
-	)
-	return err
+// configValues reads every key in internalconfig.Keys out of cfg, keyed by
+// its config-key name, so a key added to Keys shows up here with no matching
+// struct field to add.
+func configValues(cfg internalconfig.Config) (map[string]string, error) {
+	values := make(map[string]string, len(internalconfig.Keys))
+	for _, key := range internalconfig.Keys {
+		v, err := cfg.Get(key)
+		if err != nil {
+			return nil, err
+		}
+		values[key] = v
+	}
+	return values, nil
+}
+
+func printListHuman(w io.Writer, path string, values map[string]string) error {
+	if _, err := fmt.Fprintf(w, "Path: %s\n\n", path); err != nil {
+		return err
+	}
+	for _, key := range internalconfig.Keys {
+		if _, err := fmt.Fprintf(w, "%s: %s\n", key, unsetLabel(values[key])); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func unsetLabel(v string) string {

--- a/cli/config/list_test.go
+++ b/cli/config/list_test.go
@@ -22,6 +22,8 @@ func TestListCmd_Empty(t *testing.T) {
 	assert.Contains(t, got, "Path: ")
 	assert.Contains(t, got, "api_base_url: (unset)")
 	assert.Contains(t, got, "web_base_url: (unset)")
+	assert.Contains(t, got, "app_id: (unset)")
+	assert.Contains(t, got, "default_workspace_id: (unset)")
 }
 
 func TestListCmd_ShowsSavedValues(t *testing.T) {
@@ -33,6 +35,8 @@ func TestListCmd_ShowsSavedValues(t *testing.T) {
 
 	assert.Contains(t, out.String(), "api_base_url: https://api.example.com")
 	assert.Contains(t, out.String(), "web_base_url: (unset)")
+	assert.Contains(t, out.String(), "app_id: (unset)")
+	assert.Contains(t, out.String(), "default_workspace_id: (unset)")
 }
 
 func TestListCmd_JSONFormat(t *testing.T) {
@@ -49,6 +53,8 @@ func TestListCmd_JSONFormat(t *testing.T) {
 	out := logBuf.String()
 	assert.Contains(t, out, `"api_base_url":"https://api.example.com"`)
 	assert.Contains(t, out, `"web_base_url":""`, "unset keys must still be enumerated, not omitted")
+	assert.Contains(t, out, `"app_id":""`)
+	assert.Contains(t, out, `"default_workspace_id":""`)
 }
 
 func TestListCmd_YMLFormat(t *testing.T) {
@@ -65,6 +71,8 @@ func TestListCmd_YMLFormat(t *testing.T) {
 	out := logBuf.String()
 	assert.Contains(t, out, "api_base_url: https://api.example.com", "yaml.v2 ignores json tags; this key name regresses to \"apibaseurl\" without a yaml tag")
 	assert.Contains(t, out, `web_base_url: ""`)
+	assert.Contains(t, out, `app_id: ""`)
+	assert.Contains(t, out, `default_workspace_id: ""`)
 }
 
 func TestListCmd_RejectsPositionalArgs(t *testing.T) {

--- a/cli/yml/get.go
+++ b/cli/yml/get.go
@@ -61,7 +61,7 @@ instead of the app's current stored configuration.`,
 	}
 
 	cmd.Flags().StringVar(&buildSlug, "build", "", "build ID to retrieve the yml for")
-	cmdutil.AddAppFlag(cmd.Flags(), "app ID to retrieve the bitrise.yml for (or set BITRISE_APP_ID)")
+	cmdutil.AddAppFlag(cmd.Flags(), "app ID to retrieve the bitrise.yml for (or set BITRISE_APP_ID; inside a build, defaults to the app the build runs for)")
 	cmd.Flags().StringP(cmdutil.FormatKey, "f", "", "Output format. Accepted: raw (default), json, yml")
 
 	return cmd

--- a/cli/yml/get_test.go
+++ b/cli/yml/get_test.go
@@ -10,11 +10,14 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/bitrise-io/bitrise/v2/cli/cmdutil"
 	"github.com/bitrise-io/bitrise/v2/internal/auth"
 	"github.com/bitrise-io/bitrise/v2/internal/config"
 )
 
 func TestGetCmd_RequiresApp(t *testing.T) {
+	t.Setenv(cmdutil.EnvAppIDLegacy, "")
+
 	cmd, _ := newTestGetCmd(t, "http://unused.test")
 	err := cmd.RunE(cmd, nil)
 	require.EqualError(t, err, "--app is required")

--- a/cli/yml/update.go
+++ b/cli/yml/update.go
@@ -26,6 +26,10 @@ read from stdin explicitly.
 Note: if the app is configured to read its bitrise.yml from the repository,
 this command succeeds but the change will not affect builds.
 
+Inside a Bitrise build, omitting --app targets the app the build runs for,
+overwriting its own stored configuration. Always pass --app when updating a
+different app from a build.
+
 Bitrise stores the configuration as structured data rather than as the file
 you upload, so comments, key order and YAML anchors are not preserved: a
 later 'bitrise yml get' returns an equivalent, reformatted document.`,
@@ -66,7 +70,7 @@ later 'bitrise yml get' returns an equivalent, reformatted document.`,
 	// binding it to --file here would make `yml update -f json` open a file
 	// named "json" while `yml get -f json` selects a format.
 	cmd.Flags().StringVar(&filePath, "file", "", "path to the bitrise.yml file, or - for stdin (reads from stdin if omitted)")
-	cmdutil.AddAppFlag(cmd.Flags(), "app ID to update the bitrise.yml for (or set BITRISE_APP_ID)")
+	cmdutil.AddAppFlag(cmd.Flags(), "app ID to update the bitrise.yml for (or set BITRISE_APP_ID; inside a build, defaults to the app the build runs for)")
 
 	return cmd
 }

--- a/cli/yml/update.go
+++ b/cli/yml/update.go
@@ -61,7 +61,7 @@ later 'bitrise yml get' returns an equivalent, reformatted document.`,
 				return err
 			}
 
-			_, err = fmt.Fprintln(cmd.ErrOrStderr(), "bitrise.yml updated successfully")
+			_, err = fmt.Fprintf(cmd.ErrOrStderr(), "bitrise.yml updated for app %s\n", appSlug)
 			return err
 		},
 	}

--- a/cli/yml/update_test.go
+++ b/cli/yml/update_test.go
@@ -12,11 +12,14 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/bitrise-io/bitrise/v2/cli/cmdutil"
 	"github.com/bitrise-io/bitrise/v2/internal/auth"
 	"github.com/bitrise-io/bitrise/v2/internal/config"
 )
 
 func TestUpdateCmd_RequiresApp(t *testing.T) {
+	t.Setenv(cmdutil.EnvAppIDLegacy, "")
+
 	cmd, _ := newTestUpdateCmd(t, "http://unused.test", "")
 	err := cmd.RunE(cmd, nil)
 	require.EqualError(t, err, "--app is required")

--- a/cli/yml/update_test.go
+++ b/cli/yml/update_test.go
@@ -39,7 +39,7 @@ func TestUpdateCmd_FromStdin(t *testing.T) {
 	require.NoError(t, cmd.RunE(cmd, nil))
 
 	assert.JSONEq(t, `{"app_config_datastore_yaml":{"format_version":"13"}}`, gotBody)
-	assert.Equal(t, "bitrise.yml updated successfully\n", stderr.String())
+	assert.Equal(t, "bitrise.yml updated for app app-slug\n", stderr.String())
 }
 
 func TestUpdateCmd_EmptyContent(t *testing.T) {

--- a/cli/yml/validate.go
+++ b/cli/yml/validate.go
@@ -33,12 +33,13 @@ func NewValidateCommand() *cobra.Command {
 	cmdutil.AddConfigAndInventoryFlags(validateCommand.Flags())
 	validateCommand.Flags().String(cmdutil.FormatKey, "", "Output format. Accepted: raw (default), json.")
 	validateCommand.Flags().Bool(offlineKey, false, "Skip online validation even if authenticated; use only the local schema check.")
-	cmdutil.AddAppFlag(validateCommand.Flags(), "app ID to validate against (enables app-specific checks: stacks, machine types, license pools)")
+	cmdutil.AddAppFlag(validateCommand.Flags(), "app ID to validate against (enables app-specific checks: stacks, machine types, license pools; inside a build, defaults to the app the build runs for)")
 
 	// --offline skips the online path entirely, so accepting it together with
 	// --app would silently ignore the app-specific checks --app asks for. An
-	// ambient BITRISE_APP_ID isn't covered (cobra only sees flags) and stays
-	// silently ignored under --offline, since it isn't an explicit request.
+	// ambient BITRISE_APP_ID/BITRISE_APP_SLUG isn't covered (cobra only sees
+	// flags) and stays silently ignored under --offline, since neither is an
+	// explicit request.
 	validateCommand.MarkFlagsMutuallyExclusive(offlineKey, cmdutil.FlagApp)
 
 	return validateCommand

--- a/configs/configs.go
+++ b/configs/configs.go
@@ -1,6 +1,7 @@
 package configs
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -215,6 +216,16 @@ func SaveSetupSuccessForVersion(ver string) error {
 	})
 }
 
+// SetAppID persists appID as the default app for cloud commands (e.g. `bitrise
+// app create`), so later commands can resolve it without --app/BITRISE_APP_ID.
+// Unlike SetupVersion/LastCLIUpdateCheck/LastPluginUpdateChecks, app_id has no
+// ~/.bitrise/config.json counterpart, so it never touches the legacy file.
+func SetAppID(appID string) error {
+	return saveGlobalConfig(func(c *internalconfig.Config) {
+		c.AppID = appID
+	})
+}
+
 func (m ConfigModel) ToConfig() internalconfig.Config {
 	return internalconfig.Config{
 		SetupVersion:           m.SetupVersion,
@@ -254,7 +265,17 @@ func ResolveConfig() (internalconfig.Resolved, error) {
 // saveGlobalConfig loads the current global config.yml
 // (~/.config/bitrise/cli/config.yml), applies mutate, and saves it back,
 // returning any load/save error.
+//
+// The load-mutate-save sequence holds the same cross-process lock
+// `bitrise config set` takes, so a concurrent writer (another CLI invocation
+// setting a different key) can't have its write dropped by this one.
 func saveGlobalConfig(mutate func(*internalconfig.Config)) error {
+	unlock, err := internalconfig.Lock(context.Background())
+	if err != nil {
+		return err
+	}
+	defer unlock()
+
 	globalCfg, err := internalconfig.Load()
 	if err != nil {
 		return err

--- a/configs/configs.go
+++ b/configs/configs.go
@@ -163,8 +163,9 @@ func SaveCLIUpdateCheck() error {
 	}
 	config.LastCLIUpdateCheck = time.Now()
 
-	return saveConfig(existed, config, func(c *internalconfig.Config) {
+	return saveConfig(existed, config, func(c *internalconfig.Config) error {
 		c.LastCLIUpdateCheck = config.LastCLIUpdateCheck
+		return nil
 	})
 }
 
@@ -188,11 +189,12 @@ func SavePluginUpdateCheck(plugin string) error {
 	}
 	config.LastPluginUpdateChecks[plugin] = time.Now()
 
-	return saveConfig(existed, config, func(c *internalconfig.Config) {
+	return saveConfig(existed, config, func(c *internalconfig.Config) error {
 		if c.LastPluginUpdateChecks == nil {
 			c.LastPluginUpdateChecks = map[string]time.Time{}
 		}
 		c.LastPluginUpdateChecks[plugin] = config.LastPluginUpdateChecks[plugin]
+		return nil
 	})
 }
 
@@ -211,8 +213,9 @@ func SaveSetupSuccessForVersion(ver string) error {
 	}
 	config.SetupVersion = ver
 
-	return saveConfig(existed, config, func(c *internalconfig.Config) {
+	return saveConfig(existed, config, func(c *internalconfig.Config) error {
 		c.SetupVersion = config.SetupVersion
+		return nil
 	})
 }
 
@@ -220,9 +223,13 @@ func SaveSetupSuccessForVersion(ver string) error {
 // app create`), so later commands can resolve it without --app/BITRISE_APP_ID.
 // Unlike SetupVersion/LastCLIUpdateCheck/LastPluginUpdateChecks, app_id has no
 // ~/.bitrise/config.json counterpart, so it never touches the legacy file.
+//
+// Routed through Config.Set rather than assigning c.AppID directly, so this
+// writer and `bitrise config set app_id` can't drift if validation is ever
+// added to that key.
 func SetAppID(appID string) error {
-	return saveGlobalConfig(func(c *internalconfig.Config) {
-		c.AppID = appID
+	return saveGlobalConfig(func(c *internalconfig.Config) error {
+		return c.Set(internalconfig.KeyAppID, appID)
 	})
 }
 
@@ -264,13 +271,19 @@ func ResolveConfig() (internalconfig.Resolved, error) {
 
 // saveGlobalConfig loads the current global config.yml
 // (~/.config/bitrise/cli/config.yml), applies mutate, and saves it back,
-// returning any load/save error.
+// returning any load/save error. A failing mutate aborts before the save,
+// leaving the file untouched.
 //
 // The load-mutate-save sequence holds the same cross-process lock
 // `bitrise config set` takes, so a concurrent writer (another CLI invocation
-// setting a different key) can't have its write dropped by this one.
-func saveGlobalConfig(mutate func(*internalconfig.Config)) error {
-	unlock, err := internalconfig.Lock(context.Background())
+// setting a different key) can't have its write dropped by this one. None of
+// this function's callers have a cobra command to draw a request-scoped
+// context from, so the wait is bounded by internalconfig.LockStaleAfter
+// instead of blocking on context.Background() indefinitely.
+func saveGlobalConfig(mutate func(*internalconfig.Config) error) error {
+	ctx, cancel := context.WithTimeout(context.Background(), internalconfig.LockStaleAfter)
+	defer cancel()
+	unlock, err := internalconfig.Lock(ctx)
 	if err != nil {
 		return err
 	}
@@ -280,7 +293,9 @@ func saveGlobalConfig(mutate func(*internalconfig.Config)) error {
 	if err != nil {
 		return err
 	}
-	mutate(&globalCfg)
+	if err := mutate(&globalCfg); err != nil {
+		return err
+	}
 	return internalconfig.Save(globalCfg)
 }
 
@@ -293,7 +308,12 @@ func saveGlobalConfig(mutate func(*internalconfig.Config)) error {
 // the one field being changed, so a value that only exists in the per-dir or
 // global layer never gets copied into a file that should stay a
 // self-contained snapshot of what was actually written to it.
-func saveConfig(existed bool, legacy ConfigModel, mutate func(*internalconfig.Config)) error {
+//
+// Only the config.yml half (saveGlobalConfig) is protected by
+// internalconfig.Lock. saveLegacyConfig's read-modify-write of the legacy
+// ~/.bitrise/config.json above is not — a second concurrent call here can
+// still drop this call's update to that file.
+func saveConfig(existed bool, legacy ConfigModel, mutate func(*internalconfig.Config) error) error {
 	if existed {
 		if err := saveLegacyConfig(legacy); err != nil {
 			return err

--- a/configs/configs_test.go
+++ b/configs/configs_test.go
@@ -175,6 +175,34 @@ func TestSaveSetupSuccessForVersion_NewUser_GlobalSyncFailureFailsSave(t *testin
 	require.Equal(t, false, exists)
 }
 
+// TestSetAppID_SavesToGlobalConfig asserts app_id is written to the new
+// global config.yml and never touches the legacy file, since it has no
+// counterpart there.
+func TestSetAppID_SavesToGlobalConfig(t *testing.T) {
+	fakeHomePth, err := pathutil.NormalizedOSTempDirPath("_FAKE_HOME")
+	require.Equal(t, nil, err)
+	defer func() {
+		require.Equal(t, nil, os.RemoveAll(fakeHomePth))
+	}()
+	t.Setenv("HOME", fakeHomePth)
+	t.Setenv("XDG_CONFIG_HOME", "")
+	t.Chdir(t.TempDir())
+
+	require.Equal(t, nil, SetAppID("app-slug"))
+
+	globalCfg, err := internalconfig.Load()
+	require.Equal(t, nil, err)
+	require.Equal(t, "app-slug", globalCfg.AppID)
+
+	_, exists, err := LoadLegacyConfig()
+	require.Equal(t, nil, err)
+	require.Equal(t, false, exists)
+
+	resolved, err := ResolveConfig()
+	require.Equal(t, nil, err)
+	require.Equal(t, "app-slug", resolved.AppID)
+}
+
 // TestCheckIsSetupWasDoneForVersion_FallsBackToPerDirConfig asserts a value
 // living only in the per-directory .bitrise-cli.yml (no legacy, no global
 // file) is still observed on read.

--- a/internal/app/create.go
+++ b/internal/app/create.go
@@ -17,7 +17,7 @@ import (
 // DefaultStackID is the stack used by Create when opts.StackID is empty. Any
 // valid stack ID for the org will do — this one is broadly available — and
 // callers can override it via --stack.
-const DefaultStackID = "linux-docker-android-22.04"
+const DefaultStackID = "ubuntu-resolute-26.04-bitrise-2026-android"
 
 // DefaultProjectType is the project_type sent to /finish when opts.ProjectType
 // is empty. "other" is a safe minimal preset.
@@ -36,7 +36,7 @@ const FlowTypeCLI = "cli"
 
 // DefaultBranchFallback is the branch name sent to /apps/register when none
 // can be detected from the local git checkout.
-const DefaultBranchFallback = "master"
+const DefaultBranchFallback = "main"
 
 // CreateOptions are the inputs for Service.Create. Empty fields trigger
 // auto-detection (git, single-workspace pick) where applicable; RepoURL

--- a/internal/app/create.go
+++ b/internal/app/create.go
@@ -38,9 +38,10 @@ const FlowTypeCLI = "cli"
 // can be detected from the local git checkout.
 const DefaultBranchFallback = "main"
 
-// CreateOptions are the inputs for Service.Create. Empty fields trigger
-// auto-detection (git, single-workspace pick) where applicable; RepoURL
-// produces an error if it can't be filled in.
+// CreateOptions are the inputs for Service.Create. RepoURL and Branch are
+// expected pre-filled by the caller, which is where git detection lives (see
+// GitDetector); an empty RepoURL is an error. The only auto-detection Create
+// performs is the single-workspace pick for an empty OrgSlug.
 type CreateOptions struct {
 	RepoURL     string
 	Branch      string
@@ -74,9 +75,9 @@ type CreateResult struct {
 // Create runs the register → finish → (optional) upload sequence on the
 // Bitrise API and returns the new app's identifying details.
 //
-// Required: opts.RepoURL (or a detectable git remote) and a workspace (via
-// opts.OrgSlug or single-workspace detection). Defaults are applied for
-// Branch, Provider, StackID, ProjectType.
+// Required: opts.RepoURL and a workspace (via opts.OrgSlug or
+// single-workspace detection). Defaults are applied for Branch, Provider,
+// StackID, ProjectType.
 func (s *Service) Create(ctx context.Context, opts CreateOptions) (CreateResult, error) {
 	if opts.RepoURL == "" {
 		return CreateResult{}, errors.New("repo URL is required (pass --repo-url or run inside a git repo with an 'origin' remote)")
@@ -264,6 +265,11 @@ func deriveTitle(repoURL string) string {
 
 // GitDetector detects the cwd's git remote URL and current branch. The
 // default implementation shells out to `git`. Tests inject a stub.
+//
+// Deliberately unused inside this package: it is consumed by the `app create`
+// command layer, which resolves RepoURL and Branch from git before handing
+// CreateOptions to Create. That command isn't migrated yet, so this type
+// currently has no caller in-tree.
 type GitDetector interface {
 	RemoteURL(ctx context.Context) (string, error)
 	CurrentBranch(ctx context.Context) (string, error)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -35,6 +35,8 @@ type Config struct {
 	LastPluginUpdateChecks map[string]time.Time `yaml:"last_plugin_update_checks,omitempty"`
 	APIBaseURL             string               `yaml:"api_base_url,omitempty"`
 	WebBaseURL             string               `yaml:"web_base_url,omitempty"`
+	AppID                  string               `yaml:"app_id,omitempty"`
+	DefaultWorkspaceID     string               `yaml:"default_workspace_id,omitempty"`
 }
 
 // DirFileName is the file looked up in the working directory and its

--- a/internal/config/keys.go
+++ b/internal/config/keys.go
@@ -20,6 +20,12 @@ const (
 // settings.
 var Keys = []string{KeyAPIBaseURL, KeyWebBaseURL, KeyAppID, KeyDefaultWorkspaceID}
 
+// URLKeys is the subset of Keys whose value Set validates as an absolute
+// https URL (see validateURL) rather than accepting it as a plain
+// identifier. Exported so tests can assert that invariant over every such
+// key without hardcoding the list.
+var URLKeys = []string{KeyAPIBaseURL, KeyWebBaseURL}
+
 // Get returns the stored value of a known key.
 func (c *Config) Get(key string) (string, error) {
 	switch key {

--- a/internal/config/keys.go
+++ b/internal/config/keys.go
@@ -8,15 +8,17 @@ import (
 )
 
 const (
-	KeyAPIBaseURL = "api_base_url"
-	KeyWebBaseURL = "web_base_url"
+	KeyAPIBaseURL         = "api_base_url"
+	KeyWebBaseURL         = "web_base_url"
+	KeyAppID              = "app_id"
+	KeyDefaultWorkspaceID = "default_workspace_id"
 )
 
 // Keys is the subset of Config's fields exposed to `bitrise config
 // get/set/unset` — SetupVersion/LastCLIUpdateCheck/LastPluginUpdateChecks are
 // deliberately excluded: the CLI writes those itself, they aren't user
 // settings.
-var Keys = []string{KeyAPIBaseURL, KeyWebBaseURL}
+var Keys = []string{KeyAPIBaseURL, KeyWebBaseURL, KeyAppID, KeyDefaultWorkspaceID}
 
 // Get returns the stored value of a known key.
 func (c *Config) Get(key string) (string, error) {
@@ -25,6 +27,10 @@ func (c *Config) Get(key string) (string, error) {
 		return c.APIBaseURL, nil
 	case KeyWebBaseURL:
 		return c.WebBaseURL, nil
+	case KeyAppID:
+		return c.AppID, nil
+	case KeyDefaultWorkspaceID:
+		return c.DefaultWorkspaceID, nil
 	default:
 		return "", unknownKeyErr(key)
 	}
@@ -49,6 +55,13 @@ func (c *Config) Set(key, value string) error {
 			}
 		}
 		next.WebBaseURL = value
+	case KeyAppID:
+		// An app slug, not a URL — nothing to validate locally; a wrong value
+		// surfaces as a 404 from the API.
+		next.AppID = value
+	case KeyDefaultWorkspaceID:
+		// A workspace slug; same reasoning as KeyAppID.
+		next.DefaultWorkspaceID = value
 	default:
 		return unknownKeyErr(key)
 	}

--- a/internal/config/keys_test.go
+++ b/internal/config/keys_test.go
@@ -52,7 +52,7 @@ func TestConfig_Set_WebBaseURL(t *testing.T) {
 }
 
 func TestConfig_Set_RejectsPlainHTTP(t *testing.T) {
-	for _, key := range []string{KeyAPIBaseURL, KeyWebBaseURL} {
+	for _, key := range URLKeys {
 		var c Config
 		err := c.Set(key, "http://api.example.com")
 		require.Error(t, err, key)
@@ -60,19 +60,22 @@ func TestConfig_Set_RejectsPlainHTTP(t *testing.T) {
 	}
 }
 
-func TestConfig_SetGetUnset_AppID(t *testing.T) {
-	var c Config
+func TestConfig_SetGetUnset_IdentifierKeys(t *testing.T) {
+	for _, key := range []string{KeyAppID, KeyDefaultWorkspaceID} {
+		var c Config
 
-	// not a URL — no scheme validation applies to this key
-	require.NoError(t, c.Set(KeyAppID, "my-app-slug"))
-	assert.Equal(t, "my-app-slug", c.AppID)
+		// not a URL — no scheme validation applies to these keys
+		require.NoError(t, c.Set(key, "my-slug"), key)
 
-	v, err := c.Get(KeyAppID)
-	require.NoError(t, err)
-	assert.Equal(t, "my-app-slug", v)
+		v, err := c.Get(key)
+		require.NoError(t, err, key)
+		assert.Equal(t, "my-slug", v, key)
 
-	require.NoError(t, c.Unset(KeyAppID))
-	assert.Equal(t, "", c.AppID)
+		require.NoError(t, c.Unset(key), key)
+		v, err = c.Get(key)
+		require.NoError(t, err, key)
+		assert.Equal(t, "", v, key)
+	}
 }
 
 func TestConfig_Set_AllowsPlainHTTPForLoopback(t *testing.T) {

--- a/internal/config/keys_test.go
+++ b/internal/config/keys_test.go
@@ -52,12 +52,27 @@ func TestConfig_Set_WebBaseURL(t *testing.T) {
 }
 
 func TestConfig_Set_RejectsPlainHTTP(t *testing.T) {
-	for _, key := range Keys {
+	for _, key := range []string{KeyAPIBaseURL, KeyWebBaseURL} {
 		var c Config
 		err := c.Set(key, "http://api.example.com")
 		require.Error(t, err, key)
 		assert.ErrorContains(t, err, `must use https (got "http")`)
 	}
+}
+
+func TestConfig_SetGetUnset_AppID(t *testing.T) {
+	var c Config
+
+	// not a URL — no scheme validation applies to this key
+	require.NoError(t, c.Set(KeyAppID, "my-app-slug"))
+	assert.Equal(t, "my-app-slug", c.AppID)
+
+	v, err := c.Get(KeyAppID)
+	require.NoError(t, err)
+	assert.Equal(t, "my-app-slug", v)
+
+	require.NoError(t, c.Unset(KeyAppID))
+	assert.Equal(t, "", c.AppID)
 }
 
 func TestConfig_Set_AllowsPlainHTTPForLoopback(t *testing.T) {

--- a/internal/config/lock.go
+++ b/internal/config/lock.go
@@ -7,11 +7,18 @@ import (
 	"github.com/bitrise-io/bitrise/v2/internal/filelock"
 )
 
+// LockStaleAfter bounds how long a held lock on config.yml is honored before
+// a waiter treats it as abandoned. Exported so callers that can't offer a
+// real cancellable context (e.g. configs.saveGlobalConfig, which has no
+// cobra command to draw one from) can still cap their own wait instead of
+// blocking on context.Background() past this point.
+const LockStaleAfter = 5 * time.Second
+
 // lockOptions sizes the lease for config.yml's read-modify-write sequence,
 // which is always local disk I/O with no network calls — much faster than
 // internal/auth's OAuth ladder, so no refresh is needed to survive a
 // legitimately slow hold.
-var lockOptions = filelock.Options{StaleAfter: 5 * time.Second}
+var lockOptions = filelock.Options{StaleAfter: LockStaleAfter}
 
 // Lock acquires an exclusive, cross-process lock around a read-modify-write
 // sequence on the global config file, so concurrent `bitrise config

--- a/internal/config/resolve.go
+++ b/internal/config/resolve.go
@@ -56,6 +56,13 @@ func Resolve(legacyCfg, dirCfg, globalCfg Config) Resolved {
 		// global > default — no dirCfg, see the doc comment above.
 		APIBaseURL: FirstNonEmptyString(legacyCfg.APIBaseURL, globalCfg.APIBaseURL, DefaultAPIBaseURL),
 		WebBaseURL: FirstNonEmptyString(legacyCfg.WebBaseURL, globalCfg.WebBaseURL, DefaultWebBaseURL),
+		// legacyCfg.AppID is likewise always empty, and there's no sensible
+		// default app — effectively dir > global > unset. Both of these DO
+		// honor dirCfg, unlike the two URLs above: they name which app and
+		// workspace a checkout belongs to, which is exactly what a repo-local
+		// file should be able to pin, and neither is a credential.
+		AppID:              FirstNonEmptyString(legacyCfg.AppID, dirCfg.AppID, globalCfg.AppID),
+		DefaultWorkspaceID: FirstNonEmptyString(legacyCfg.DefaultWorkspaceID, dirCfg.DefaultWorkspaceID, globalCfg.DefaultWorkspaceID),
 	}}
 }
 
@@ -96,8 +103,14 @@ func WithResolved(ctx context.Context, r Resolved) context.Context {
 	return context.WithValue(ctx, ctxKey{}, r)
 }
 
-// FromContext retrieves Resolved from ctx, or a zero value if absent.
+// FromContext retrieves Resolved from ctx, or a zero value if absent. A nil
+// ctx is treated as absent rather than panicking: cmd.Context() is nil for a
+// bare *cobra.Command that was never executed, which is how several tests
+// drive RunE directly.
 func FromContext(ctx context.Context) Resolved {
+	if ctx == nil {
+		return Resolved{}
+	}
 	if r, ok := ctx.Value(ctxKey{}).(Resolved); ok {
 		return r
 	}

--- a/internal/config/resolve_test.go
+++ b/internal/config/resolve_test.go
@@ -58,6 +58,40 @@ func TestResolve_WebBaseURLPrecedence(t *testing.T) {
 	assert.Equal(t, "https://global.example", r.WebBaseURL)
 }
 
+func TestResolve_AppIDPrecedence(t *testing.T) {
+	dir := Config{AppID: "dir-app"}
+	global := Config{AppID: "global-app"}
+
+	// no layer set: stays unset, unlike APIBaseURL there's no default
+	r := Resolve(Config{}, Config{}, Config{})
+	assert.Equal(t, "", r.AppID)
+
+	// global only
+	r = Resolve(Config{}, Config{}, global)
+	assert.Equal(t, "global-app", r.AppID)
+
+	// dir overrides global (legacy has no concept of this field)
+	r = Resolve(Config{}, dir, global)
+	assert.Equal(t, "dir-app", r.AppID)
+}
+
+func TestResolve_DefaultWorkspaceIDPrecedence(t *testing.T) {
+	dir := Config{DefaultWorkspaceID: "dir-ws"}
+	global := Config{DefaultWorkspaceID: "global-ws"}
+
+	// no layer set: stays unset, there's no default workspace
+	r := Resolve(Config{}, Config{}, Config{})
+	assert.Equal(t, "", r.DefaultWorkspaceID)
+
+	// global only
+	r = Resolve(Config{}, Config{}, global)
+	assert.Equal(t, "global-ws", r.DefaultWorkspaceID)
+
+	// dir overrides global — a repo may pin the workspace it belongs to
+	r = Resolve(Config{}, dir, global)
+	assert.Equal(t, "dir-ws", r.DefaultWorkspaceID)
+}
+
 // TestResolve_LayerPrecedence covers the three fields sharing the generic
 // legacy > dir > global precedence (SetupVersion, LastCLIUpdateCheck,
 // LastPluginUpdateChecks) in one pass, each via a different underlying


### PR DESCRIPTION
Both name a resource a checkout belongs to rather than a host that receives credentials, so unlike `api_base_url/web_base_url` they honor the per-directory `.bitrise-cli.yml`: pinning "this repo is app X in workspace Y" is exactly what a repo-local file should be able to do. Resolution is flag > env > per-dir > global, via `cmdutil.LookupAppSlug` and the new `cmdutil.DefaultWorkspaceSlug`.

Both env vars Bitrise injects into builds are honored: `BITRISE_WORKSPACE_ID`, and `BITRISE_APP_SLUG` as a fallback below the canonical `BITRISE_APP_ID`. [Both are documented as injected into every build](https://docs.bitrise.io/en/bitrise-ci/references/available-environment-variables) — `BITRISE_WORKSPACE_ID` names "the workspace slug of the workspace that owns the project". So inside a build, a command with no `--app`/`--workspace` acts on the app the build runs for and the workspace owning it.

Two fixes fall out of this:
- `config.FromContext` now tolerates a `nil` context instead of panicking, which removes the guard every caller had to repeat.
- `configs.saveGlobalConfig` now takes the same cross-process lock `config set` uses. It performs a load-modify-save, so without it a concurrent writer could have its change dropped — which `app create` would newly be able to trigger by writing app_id.
