### PR TITLE
v3 prep: add the `app` command

### DIFF
--- a/_docs/v3-breaking-changes.md
+++ b/_docs/v3-breaking-changes.md
@@ -142,9 +142,13 @@ scripts keep running: `trigger-check` was the only command removed outright, and
   that previously ran only when `--app` was passed explicitly — a config that validated
   cleanly before can now report app-specific errors. `--offline` is unaffected: it skips
   the online path, and an ambient app ID stays ignored there. Note the env var also
-  outranks an `app_id` pinned in a `.bitrise-cli.yml`. *Migrate:* pass `--app` explicitly
-  in any build step that targets a different app than the one it runs in; unset
-  `BITRISE_APP_SLUG` for the invocation to restore the previous behavior.
+  outranks an `app_id` pinned in a `.bitrise-cli.yml`. `bitrise stack list` picks up
+  `$BITRISE_WORKSPACE_ID` the same way: without `--workspace`, a build step now returns
+  the host workspace's stacks, including any custom stacks configured for it, where it
+  previously always returned the global list. *Migrate:* pass `--app`/`--workspace`
+  explicitly in any build step that targets a different app or workspace than the one
+  it runs in; unset `BITRISE_APP_SLUG`/`BITRISE_WORKSPACE_ID` for the invocation to
+  restore the previous behavior.
 - **Two new config file locations are now read, layered under the existing one.**
   Besides the pre-existing `~/.bitrise/config.json`, the CLI now also reads a global
   `~/.config/bitrise/cli/config.yml` and a per-directory `.bitrise-cli.yml` (found by

--- a/cli/app/cmd.go
+++ b/cli/app/cmd.go
@@ -1,0 +1,20 @@
+// Package app implements the `bitrise app` command group: list, view, and
+// create apps on Bitrise.
+package app
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/bitrise-io/bitrise/v2/cli/cmdutil"
+)
+
+// NewCmd returns the `bitrise app` parent command.
+func NewCmd() *cobra.Command {
+	c := &cobra.Command{
+		Use:   "app",
+		Short: "List, inspect, and manage apps.",
+		RunE:  cmdutil.RequireKnownSubcommand,
+	}
+	c.AddCommand(NewListCommand(), NewViewCommand(), NewCreateCommand())
+	return c
+}

--- a/cli/app/create.go
+++ b/cli/app/create.go
@@ -1,0 +1,283 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/bitrise-io/bitrise/v2/cli/cmdutil"
+	"github.com/bitrise-io/bitrise/v2/configs"
+	internalapp "github.com/bitrise-io/bitrise/v2/internal/app"
+	internalconfig "github.com/bitrise-io/bitrise/v2/internal/config"
+	"github.com/bitrise-io/bitrise/v2/output"
+)
+
+// createFlags bundles app create's parsed flag values so runCreate can take
+// a detector parameter (for git-detection injection in tests) without also
+// threading nine separate flag values through it.
+type createFlags struct {
+	repoURL     string
+	branch      string
+	title       string
+	provider    string
+	workspace   string
+	stackID     string
+	projectType string
+	public      bool
+	bitriseYML  string
+}
+
+// NewCreateCommand returns the `app create` subcommand.
+func NewCreateCommand() *cobra.Command {
+	var flags createFlags
+
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Register a new app on Bitrise",
+		Long: `Register a new app on Bitrise.
+
+Auto-detection from the current git repo:
+  --repo-url     git remote get-url origin
+  --branch       git symbolic-ref --short HEAD (else "master")
+  --title        last path segment of the repo URL (".git" stripped)
+
+Workspace, highest to lowest:
+  --workspace WORKSPACE_ID
+  $BITRISE_WORKSPACE_ID
+  the default_workspace_id config key ('bitrise config set')
+  auto-detected, when your account has exactly one workspace
+
+So --workspace is only required if you belong to several workspaces and
+haven't set a default.
+
+bitrise.yml handling:
+  --bitrise-yml PATH                upload that file as the app's config
+  (no flag, ./bitrise.yml exists)   upload it
+  (no flag, no file)                skip — server preset for --project-type applies
+
+The new app's ID is saved as the default app_id in
+~/.config/bitrise/cli/config.yml, so later commands (e.g. 'bitrise yml get')
+target it without --app.`,
+		Example: `  bitrise app create
+  bitrise app create --repo-url https://github.com/me/proj --workspace acme
+  bitrise app create --bitrise-yml ./ci/bitrise.yml --stack osx-xcode-16.0.x
+  bitrise app create --format json`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runCreate(cmd, internalapp.ExecGitDetector{}, flags)
+		},
+	}
+
+	cmd.Flags().StringVar(&flags.repoURL, "repo-url", "", "git repo URL (default: 'git remote get-url origin' in cwd)")
+	cmd.Flags().StringVar(&flags.branch, "branch", "", "default branch (default: 'git symbolic-ref --short HEAD', else 'master')")
+	cmd.Flags().StringVar(&flags.title, "title", "", "app title (default: last path segment of repo URL)")
+	cmd.Flags().StringVar(&flags.provider, "provider", "auto", "git provider: auto, github, gitlab, bitbucket, custom")
+	cmd.Flags().StringVar(&flags.workspace, cmdutil.FlagWorkspace, "", "workspace ID to own the app (or set BITRISE_WORKSPACE_ID / default_workspace_id; auto-detected if you have exactly one)")
+	cmd.Flags().StringVar(&flags.stackID, "stack", "", fmt.Sprintf("build stack ID (default %q)", internalapp.DefaultStackID))
+	cmd.Flags().StringVar(&flags.projectType, "project-type", "", fmt.Sprintf("project type for server-side preset (default %q)", internalapp.DefaultProjectType))
+	cmd.Flags().BoolVar(&flags.public, "public", false, "create as a public app")
+	cmd.Flags().StringVar(&flags.bitriseYML, "bitrise-yml", "", "path to bitrise.yml to upload (default: ./bitrise.yml if present, else skip)")
+	cmd.Flags().StringP(cmdutil.FormatKey, "f", "", "Output format. Accepted: raw (default), json, yml")
+
+	_ = cmd.RegisterFlagCompletionFunc("provider", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+		return []string{"auto", "github", "gitlab", "bitbucket", "custom"}, cobra.ShellCompDirectiveNoFileComp
+	})
+	_ = cmd.RegisterFlagCompletionFunc("project-type", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+		return []string{"ios", "android", "flutter", "react-native", "xamarin", "cordova", "ionic", "other"}, cobra.ShellCompDirectiveNoFileComp
+	})
+
+	return cmd
+}
+
+func runCreate(cmd *cobra.Command, detector internalapp.GitDetector, flags createFlags) error {
+	cmdutil.LogCommandParameters(cmd)
+
+	format, _ := cmd.Flags().GetString(cmdutil.FormatKey)
+	if err := output.ConfigureOutputFormat(format); err != nil {
+		return fmt.Errorf("failed to configure output format: %w", err)
+	}
+
+	ctx := cmd.Context()
+	resolvedRepoURL, gitURLDetected, err := resolveRepoURL(ctx, flags.repoURL, detector)
+	if err != nil {
+		return err
+	}
+	resolvedBranch, gitBranchDetected, err := resolveBranch(ctx, flags.branch, detector)
+	if err != nil {
+		return err
+	}
+	yamlContent, yamlSource, err := resolveBitriseYML(flags.bitriseYML)
+	if err != nil {
+		return err
+	}
+
+	// --workspace wins; otherwise fall back to BITRISE_WORKSPACE_ID /
+	// default_workspace_id. Still empty means Service.Create auto-detects,
+	// which only succeeds when the account has exactly one workspace.
+	resolvedWorkspace := flags.workspace
+	workspaceFromDefault := false
+	if resolvedWorkspace == "" {
+		resolvedWorkspace = cmdutil.DefaultWorkspaceSlug(cmd)
+		workspaceFromDefault = resolvedWorkspace != ""
+	}
+
+	stderr := cmd.ErrOrStderr()
+	// These breadcrumbs explain what the command inferred. They're suppressed
+	// for machine-readable output so a script's stderr stays clean; the two
+	// notices in persistAppSlug are not, since they report a file this command
+	// changed and a setting that will override it.
+	if output.Format == output.FormatRaw {
+		if gitURLDetected {
+			fmt.Fprintf(stderr, "Detected repo URL from git: %s\n", resolvedRepoURL)
+		}
+		if gitBranchDetected {
+			fmt.Fprintf(stderr, "Detected branch from git: %s\n", resolvedBranch)
+		}
+		if workspaceFromDefault {
+			fmt.Fprintf(stderr, "Using default workspace: %s\n", resolvedWorkspace)
+		}
+		switch yamlSource {
+		case yamlSourceFlag:
+			fmt.Fprintf(stderr, "Uploading bitrise.yml from %s\n", flags.bitriseYML)
+		case yamlSourceCwd:
+			fmt.Fprintln(stderr, "Uploading bitrise.yml from ./bitrise.yml")
+		case yamlSourceNone:
+			presetProjectType := flags.projectType
+			if presetProjectType == "" {
+				presetProjectType = internalapp.DefaultProjectType
+			}
+			fmt.Fprintf(stderr, "No bitrise.yml provided — using server preset for project-type=%s\n", presetProjectType)
+		}
+	}
+
+	client, err := cmdutil.NewAPIClient(cmd)
+	if err != nil {
+		return err
+	}
+
+	res, err := internalapp.NewService(client).Create(ctx, internalapp.CreateOptions{
+		RepoURL:     resolvedRepoURL,
+		Branch:      resolvedBranch,
+		Title:       flags.title,
+		Provider:    flags.provider,
+		OrgSlug:     resolvedWorkspace,
+		StackID:     flags.stackID,
+		ProjectType: flags.projectType,
+		Public:      flags.public,
+		BitriseYML:  yamlContent,
+	})
+	if err != nil {
+		return err
+	}
+
+	if err := persistAppSlug(stderr, res.Slug); err != nil {
+		return err
+	}
+
+	if output.Format == output.FormatRaw {
+		return printCreateText(cmd.OutOrStdout(), res)
+	}
+	return output.Print(res, output.Format)
+}
+
+// resolveRepoURL returns the explicit flag value or the cwd's git origin.
+// The second return is true when the value came from git detection.
+func resolveRepoURL(ctx context.Context, flagValue string, d internalapp.GitDetector) (string, bool, error) {
+	if flagValue != "" {
+		return flagValue, false, nil
+	}
+	v, err := d.RemoteURL(ctx)
+	if err != nil {
+		return "", false, fmt.Errorf("detect git remote: %w", err)
+	}
+	if v == "" {
+		return "", false, errors.New("--repo-url is required (no git origin detected in this directory)")
+	}
+	return v, true, nil
+}
+
+// resolveBranch returns the explicit flag value or the cwd's current branch.
+// An empty detection result is not an error — Service.Create falls back to
+// DefaultBranchFallback.
+func resolveBranch(ctx context.Context, flagValue string, d internalapp.GitDetector) (string, bool, error) {
+	if flagValue != "" {
+		return flagValue, false, nil
+	}
+	v, err := d.CurrentBranch(ctx)
+	if err != nil {
+		return "", false, fmt.Errorf("detect git branch: %w", err)
+	}
+	return v, v != "", nil
+}
+
+type yamlSource int
+
+const (
+	yamlSourceNone yamlSource = iota
+	yamlSourceFlag
+	yamlSourceCwd
+)
+
+// resolveBitriseYML reads the bitrise.yml to upload: an explicit --bitrise-yml
+// path, else ./bitrise.yml if present, else none.
+func resolveBitriseYML(flagPath string) (string, yamlSource, error) {
+	if flagPath != "" {
+		data, err := os.ReadFile(flagPath)
+		if err != nil {
+			return "", yamlSourceNone, fmt.Errorf("read %s: %w", flagPath, err)
+		}
+		return string(data), yamlSourceFlag, nil
+	}
+	const cwdPath = "bitrise.yml"
+	data, err := os.ReadFile(cwdPath)
+	if errors.Is(err, fs.ErrNotExist) {
+		return "", yamlSourceNone, nil
+	}
+	if err != nil {
+		return "", yamlSourceNone, fmt.Errorf("read %s: %w", cwdPath, err)
+	}
+	return string(data), yamlSourceCwd, nil
+}
+
+// persistAppSlug saves slug as the global default app_id and warns on stderr
+// if a per-directory .bitrise-cli.yml will still override it at runtime.
+func persistAppSlug(stderr io.Writer, slug string) error {
+	if err := configs.SetAppID(slug); err != nil {
+		return fmt.Errorf("save app_id: %w", err)
+	}
+	cfgPath, _ := internalconfig.Path()
+	fmt.Fprintf(stderr, "Set app_id=%s in %s\n", slug, cfgPath)
+
+	dirCfg, dirPath, err := internalconfig.LoadDir()
+	if err == nil && dirPath != "" && dirCfg.AppID != "" && dirCfg.AppID != slug {
+		fmt.Fprintf(stderr, "Note: %s pins app_id=%s, which still wins at runtime\n", dirPath, dirCfg.AppID)
+	}
+	return nil
+}
+
+func printCreateText(w io.Writer, r internalapp.CreateResult) error {
+	var b strings.Builder
+	fmt.Fprintf(&b, "Created app %s\n", r.Slug)
+	fmt.Fprintf(&b, "Title:               %s\n", r.Title)
+	fmt.Fprintf(&b, "Repo URL:            %s\n", r.RepoURL)
+	fmt.Fprintf(&b, "Default branch:      %s\n", r.DefaultBranch)
+	fmt.Fprintf(&b, "Workspace:           %s\n", r.OrgSlug)
+	fmt.Fprintf(&b, "Stack:               %s\n", r.StackID)
+	fmt.Fprintf(&b, "Project type:        %s\n", r.ProjectType)
+	if !r.BitriseYMLUploaded {
+		fmt.Fprintln(&b, "Config:              server preset")
+	}
+	// Masked like 'auth status' does, so the token doesn't land in a shell
+	// scrollback or CI log by default; --format json still carries the value.
+	if r.BuildTriggerToken != "" {
+		fmt.Fprintln(&b, "Build trigger token: ******** (set, use --format json to read it)")
+	}
+	_, err := io.WriteString(w, b.String())
+	return err
+}

--- a/cli/app/create.go
+++ b/cli/app/create.go
@@ -40,11 +40,11 @@ func NewCreateCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create",
 		Short: "Register a new app on Bitrise",
-		Long: `Register a new app on Bitrise.
+		Long: fmt.Sprintf(`Register a new app on Bitrise.
 
 Auto-detection from the current git repo:
   --repo-url     git remote get-url origin
-  --branch       git symbolic-ref --short HEAD (else "master")
+  --branch       git symbolic-ref --short HEAD (else %q)
   --title        last path segment of the repo URL (".git" stripped)
 
 Workspace, highest to lowest:
@@ -63,7 +63,7 @@ bitrise.yml handling:
 
 The new app's ID is saved as the default app_id in
 ~/.config/bitrise/cli/config.yml, so later commands (e.g. 'bitrise yml get')
-target it without --app.`,
+target it without --app.`, internalapp.DefaultBranchFallback),
 		Example: `  bitrise app create
   bitrise app create --repo-url https://github.com/me/proj --workspace acme
   bitrise app create --bitrise-yml ./ci/bitrise.yml --stack osx-xcode-16.0.x
@@ -75,7 +75,7 @@ target it without --app.`,
 	}
 
 	cmd.Flags().StringVar(&flags.repoURL, "repo-url", "", "git repo URL (default: 'git remote get-url origin' in cwd)")
-	cmd.Flags().StringVar(&flags.branch, "branch", "", "default branch (default: 'git symbolic-ref --short HEAD', else 'master')")
+	cmd.Flags().StringVar(&flags.branch, "branch", "", fmt.Sprintf("default branch (default: 'git symbolic-ref --short HEAD', else %q)", internalapp.DefaultBranchFallback))
 	cmd.Flags().StringVar(&flags.title, "title", "", "app title (default: last path segment of repo URL)")
 	cmd.Flags().StringVar(&flags.provider, "provider", "auto", "git provider: auto, github, gitlab, bitbucket, custom")
 	cmd.Flags().StringVar(&flags.workspace, cmdutil.FlagWorkspace, "", "workspace ID to own the app (or set BITRISE_WORKSPACE_ID / default_workspace_id; auto-detected if you have exactly one)")
@@ -176,14 +176,22 @@ func runCreate(cmd *cobra.Command, detector internalapp.GitDetector, flags creat
 		return err
 	}
 
-	if err := persistAppSlug(stderr, res.Slug); err != nil {
+	// Print before persisting: the app is already created server-side at this
+	// point, so a failure to save app_id locally (read-only config dir, lock
+	// timeout) must not swallow the slug and build trigger token the user
+	// needs to recover manually.
+	if output.Format == output.FormatRaw {
+		if err := printCreateText(cmd.OutOrStdout(), res); err != nil {
+			return err
+		}
+	} else if err := output.Print(res, output.Format); err != nil {
 		return err
 	}
 
-	if output.Format == output.FormatRaw {
-		return printCreateText(cmd.OutOrStdout(), res)
+	if err := persistAppSlug(stderr, res.Slug); err != nil {
+		fmt.Fprintf(stderr, "Warning: failed to save app_id: %v\n", err)
 	}
-	return output.Print(res, output.Format)
+	return nil
 }
 
 // resolveRepoURL returns the explicit flag value or the cwd's git origin.
@@ -276,7 +284,7 @@ func printCreateText(w io.Writer, r internalapp.CreateResult) error {
 	// Masked like 'auth status' does, so the token doesn't land in a shell
 	// scrollback or CI log by default; --format json still carries the value.
 	if r.BuildTriggerToken != "" {
-		fmt.Fprintln(&b, "Build trigger token: ******** (set, use --format json to read it)")
+		fmt.Fprintln(&b, "Build trigger token: ******** (set, use --format json or yml to read it)")
 	}
 	_, err := io.WriteString(w, b.String())
 	return err

--- a/cli/app/create_test.go
+++ b/cli/app/create_test.go
@@ -1,0 +1,323 @@
+package app
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/bitrise-io/bitrise/v2/cli/cmdutil"
+	"github.com/bitrise-io/bitrise/v2/internal/auth"
+	"github.com/bitrise-io/bitrise/v2/internal/bitriseapi"
+	"github.com/bitrise-io/bitrise/v2/internal/config"
+)
+
+func TestCreateCmd_HappyPath_PersistsAppID(t *testing.T) {
+	api := newStubAPI(t)
+	api.handle("/apps/register", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `{"slug":"new-app"}`)
+	})
+	api.handle("/apps/new-app/finish", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `{"build_trigger_token":"btt","branch_name":"main"}`)
+	})
+
+	cmd, out, errOut := newTestCreateCmd(t, api.baseURL)
+	err := runCreate(cmd, noCallDetector{t: t}, createFlags{
+		repoURL:   "https://github.com/acme/widget.git",
+		branch:    "main",
+		title:     "Widget",
+		workspace: "acme",
+	})
+	require.NoError(t, err)
+
+	assert.Contains(t, out.String(), "Created app new-app")
+	assert.Regexp(t, `Title:\s+Widget`, out.String())
+	assert.Contains(t, errOut.String(), "Set app_id=new-app in")
+	assert.NotContains(t, errOut.String(), "Detected repo URL from git")
+
+	// The trigger token is a credential: raw output masks it (like
+	// 'auth status'), --format json still carries the real value.
+	assert.Regexp(t, `Build trigger token:\s+\*+ \(set`, out.String())
+	assert.NotContains(t, out.String(), "btt", "the raw output must not leak the trigger token")
+
+	globalCfg, loadErr := config.Load()
+	require.NoError(t, loadErr)
+	assert.Equal(t, "new-app", globalCfg.AppID)
+}
+
+func TestCreateCmd_DetectsRepoURLAndBranchFromGit(t *testing.T) {
+	api := newStubAPI(t)
+	api.handle("/apps/register", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `{"slug":"x"}`)
+	})
+	api.handle("/apps/x/finish", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `{"build_trigger_token":"t","branch_name":"detected-branch"}`)
+	})
+
+	cmd, _, errOut := newTestCreateCmd(t, api.baseURL)
+	detector := stubGitDetector{remoteURL: "https://github.com/a/b.git", branch: "detected-branch"}
+	err := runCreate(cmd, detector, createFlags{workspace: "acme"})
+	require.NoError(t, err)
+
+	assert.Contains(t, errOut.String(), "Detected repo URL from git: https://github.com/a/b.git")
+	assert.Contains(t, errOut.String(), "Detected branch from git: detected-branch")
+
+	var reg bitriseapi.RegisterAppRequest
+	require.NoError(t, json.Unmarshal(api.bodies["/apps/register"], &reg))
+	assert.Equal(t, "https://github.com/a/b.git", reg.RepoURL)
+	assert.Equal(t, "detected-branch", reg.DefaultBranchName)
+}
+
+func TestCreateCmd_NoRepoURLDetected_Fails(t *testing.T) {
+	cmd, _, _ := newTestCreateCmd(t, "https://unused.test")
+	err := runCreate(cmd, stubGitDetector{}, createFlags{workspace: "acme"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--repo-url is required")
+}
+
+func TestCreateCmd_UploadsExplicitBitriseYML(t *testing.T) {
+	api := newStubAPI(t)
+	api.handle("/apps/register", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `{"slug":"x"}`)
+	})
+	api.handle("/apps/x/finish", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `{"build_trigger_token":"t","branch_name":"main"}`)
+	})
+	api.handle("/apps/x/bitrise.yml", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `{}`)
+	})
+
+	ymlPath := t.TempDir() + "/bitrise.yml"
+	require.NoError(t, os.WriteFile(ymlPath, []byte("format_version: \"11\"\n"), 0o600))
+
+	cmd, out, errOut := newTestCreateCmd(t, api.baseURL)
+	err := runCreate(cmd, stubGitDetector{}, createFlags{
+		repoURL: "https://github.com/a/b.git", workspace: "acme", bitriseYML: ymlPath,
+	})
+	require.NoError(t, err)
+
+	assert.Contains(t, errOut.String(), "Uploading bitrise.yml from "+ymlPath)
+	assert.NotContains(t, out.String(), "Config:") // "server preset" line only appears when not uploaded
+	assert.JSONEq(t, `{"app_config_datastore_yaml":{"format_version":"11"}}`, string(api.bodies["/apps/x/bitrise.yml"]))
+}
+
+func TestCreateCmd_NoBitriseYML_UsesServerPreset(t *testing.T) {
+	api := newStubAPI(t)
+	api.handle("/apps/register", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `{"slug":"x"}`)
+	})
+	api.handle("/apps/x/finish", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `{"build_trigger_token":"t","branch_name":"main"}`)
+	})
+
+	t.Chdir(t.TempDir())
+	cmd, out, errOut := newTestCreateCmd(t, api.baseURL)
+	err := runCreate(cmd, stubGitDetector{}, createFlags{repoURL: "https://github.com/a/b.git", workspace: "acme"})
+	require.NoError(t, err)
+
+	assert.Contains(t, errOut.String(), "No bitrise.yml provided — using server preset for project-type=other")
+	assert.Regexp(t, `Config:\s+server preset`, out.String())
+}
+
+func TestCreateCmd_WarnsWhenPerDirConfigOverridesAppID(t *testing.T) {
+	api := newStubAPI(t)
+	api.handle("/apps/register", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `{"slug":"new-app"}`)
+	})
+	api.handle("/apps/new-app/finish", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `{"build_trigger_token":"t","branch_name":"main"}`)
+	})
+
+	dir := t.TempDir()
+	t.Chdir(dir)
+	require.NoError(t, os.WriteFile(dir+"/.bitrise-cli.yml", []byte("app_id: other-app\n"), 0o600))
+
+	cmd, _, errOut := newTestCreateCmd(t, api.baseURL)
+	err := runCreate(cmd, stubGitDetector{}, createFlags{repoURL: "https://github.com/a/b.git", workspace: "acme"})
+	require.NoError(t, err)
+
+	assert.Contains(t, errOut.String(), "pins app_id=other-app, which still wins at runtime")
+}
+
+func TestCreateCmd_PropagatesAutoDetectWorkspaceError(t *testing.T) {
+	api := newStubAPI(t)
+	api.handle("/organizations", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `{"data":[]}`)
+	})
+
+	cmd, _, _ := newTestCreateCmd(t, api.baseURL)
+	err := runCreate(cmd, stubGitDetector{}, createFlags{repoURL: "https://github.com/a/b.git"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no workspaces")
+}
+
+func TestCreateCmd_UsesDefaultWorkspaceFromConfig(t *testing.T) {
+	t.Setenv(cmdutil.EnvWorkspaceID, "")
+	api := newStubAPI(t)
+	api.handle("/organizations", func(w http.ResponseWriter, _ *http.Request) {
+		t.Error("auto-detect must not run when default_workspace_id is set")
+		_, _ = io.WriteString(w, `{"data":[]}`)
+	})
+	api.handle("/apps/register", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `{"slug":"new-app"}`)
+	})
+	api.handle("/apps/new-app/finish", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `{"build_trigger_token":"t","branch_name":"main"}`)
+	})
+
+	cmd, _, errOut := newTestCreateCmdWithConfig(t, api.baseURL, config.Config{DefaultWorkspaceID: "cfg-ws"})
+	require.NoError(t, runCreate(cmd, noCallDetector{t: t}, createFlags{
+		repoURL: "https://github.com/a/b.git",
+		branch:  "main",
+	}))
+
+	var reg map[string]any
+	require.NoError(t, json.Unmarshal(api.bodies["/apps/register"], &reg))
+	assert.Equal(t, "cfg-ws", reg["organization_slug"])
+	assert.Contains(t, errOut.String(), "Using default workspace: cfg-ws")
+}
+
+func TestCreateCmd_WorkspaceFlagWinsOverDefault(t *testing.T) {
+	t.Setenv(cmdutil.EnvWorkspaceID, "")
+	api := newStubAPI(t)
+	api.handle("/apps/register", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `{"slug":"new-app"}`)
+	})
+	api.handle("/apps/new-app/finish", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `{"build_trigger_token":"t","branch_name":"main"}`)
+	})
+
+	cmd, _, errOut := newTestCreateCmdWithConfig(t, api.baseURL, config.Config{DefaultWorkspaceID: "cfg-ws"})
+	require.NoError(t, runCreate(cmd, noCallDetector{t: t}, createFlags{
+		repoURL:   "https://github.com/a/b.git",
+		branch:    "main",
+		workspace: "flag-ws",
+	}))
+
+	var reg map[string]any
+	require.NoError(t, json.Unmarshal(api.bodies["/apps/register"], &reg))
+	assert.Equal(t, "flag-ws", reg["organization_slug"])
+	assert.NotContains(t, errOut.String(), "Using default workspace", "an explicit --workspace is not a default")
+}
+
+func TestCreateCmd_SuppressesInferenceBreadcrumbsForJSON(t *testing.T) {
+	t.Setenv(cmdutil.EnvWorkspaceID, "")
+	api := newStubAPI(t)
+	api.handle("/apps/register", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `{"slug":"new-app"}`)
+	})
+	api.handle("/apps/new-app/finish", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `{"build_trigger_token":"t","branch_name":"main"}`)
+	})
+
+	cmd, _, errOut := newTestCreateCmdWithConfig(t, api.baseURL, config.Config{DefaultWorkspaceID: "cfg-ws"})
+	require.NoError(t, cmd.Flags().Set("format", "json"))
+	require.NoError(t, runCreate(cmd, stubGitDetector{remoteURL: "https://github.com/a/b.git", branch: "dev"}, createFlags{}))
+
+	errText := errOut.String()
+	assert.NotContains(t, errText, "Detected repo URL from git")
+	assert.NotContains(t, errText, "Detected branch from git")
+	assert.NotContains(t, errText, "Using default workspace")
+	assert.NotContains(t, errText, "No bitrise.yml provided")
+	// The app_id notice is not an inference hint — it reports a file this
+	// command wrote, so it stays even for machine-readable output.
+	assert.Contains(t, errText, "Set app_id=new-app in")
+}
+
+func TestCreateCmd_RejectsArgs(t *testing.T) {
+	cmd := NewCreateCommand()
+	cmd.SetArgs([]string{"unexpected"})
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+
+	assert.Error(t, cmd.Execute(), "positional args should be rejected before the command runs")
+}
+
+// stubGitDetector is an internalapp.GitDetector stand-in for tests that
+// exercise git auto-detection.
+type stubGitDetector struct {
+	remoteURL string
+	branch    string
+}
+
+func (d stubGitDetector) RemoteURL(context.Context) (string, error)     { return d.remoteURL, nil }
+func (d stubGitDetector) CurrentBranch(context.Context) (string, error) { return d.branch, nil }
+
+// noCallDetector fails the test if git detection is invoked, for cases where
+// --repo-url/--branch are set explicitly and detection should be skipped.
+type noCallDetector struct{ t *testing.T }
+
+func (d noCallDetector) RemoteURL(context.Context) (string, error) {
+	d.t.Fatal("RemoteURL should not be called when --repo-url is set")
+	return "", nil
+}
+
+func (d noCallDetector) CurrentBranch(context.Context) (string, error) {
+	d.t.Fatal("CurrentBranch should not be called when --branch is set")
+	return "", nil
+}
+
+// newTestCreateCmd builds a NewCreateCommand() wired to apiBaseURL, with
+// stdout/stderr captured in the returned buffers. Tests call runCreate
+// directly with their own createFlags rather than setting flags on cmd, so
+// this cmd only needs to supply the --format flag and a resolved context.
+func newTestCreateCmd(t *testing.T, apiBaseURL string) (*cobra.Command, *bytes.Buffer, *bytes.Buffer) {
+	t.Helper()
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	require.NoError(t, auth.Save(auth.Auth{Token: "test-token"}))
+
+	cmd := NewCreateCommand()
+	var out, errOut bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&errOut)
+	resolved := config.Resolve(config.Config{}, config.Config{}, config.Config{APIBaseURL: apiBaseURL})
+	cmd.SetContext(config.WithResolved(t.Context(), resolved))
+	return cmd, &out, &errOut
+}
+
+// newTestCreateCmdWithConfig is newTestCreateCmd for tests that need extra
+// resolved config keys (e.g. default_workspace_id) alongside the API base URL.
+func newTestCreateCmdWithConfig(t *testing.T, apiBaseURL string, global config.Config) (*cobra.Command, *bytes.Buffer, *bytes.Buffer) {
+	t.Helper()
+	cmd, out, errOut := newTestCreateCmd(t, apiBaseURL)
+	global.APIBaseURL = apiBaseURL
+	cmd.SetContext(config.WithResolved(t.Context(), config.Resolve(config.Config{}, config.Config{}, global)))
+	return cmd, out, errOut
+}
+
+// stubAPI is the multiplexer used by create's tests. It maps URL paths to
+// canned responses and records the request bodies that arrived.
+type stubAPI struct {
+	baseURL  string
+	registry map[string]http.HandlerFunc
+	bodies   map[string][]byte
+}
+
+func newStubAPI(t *testing.T) *stubAPI {
+	t.Helper()
+	s := &stubAPI{registry: map[string]http.HandlerFunc{}, bodies: map[string][]byte{}}
+	srv := newFakeServer(t, func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		s.bodies[r.URL.Path] = body
+		h, ok := s.registry[r.URL.Path]
+		if !ok {
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			http.NotFound(w, r)
+			return
+		}
+		r.Body = io.NopCloser(strings.NewReader(string(body)))
+		h(w, r)
+	})
+	s.baseURL = srv.URL
+	return s
+}
+
+func (s *stubAPI) handle(path string, h http.HandlerFunc) { s.registry[path] = h }

--- a/cli/app/create_test.go
+++ b/cli/app/create_test.go
@@ -53,6 +53,35 @@ func TestCreateCmd_HappyPath_PersistsAppID(t *testing.T) {
 	assert.Equal(t, "new-app", globalCfg.AppID)
 }
 
+func TestCreateCmd_PrintsResultEvenWhenPersistAppIDFails(t *testing.T) {
+	api := newStubAPI(t)
+	api.handle("/apps/register", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `{"slug":"new-app"}`)
+	})
+	api.handle("/apps/new-app/finish", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `{"build_trigger_token":"btt","branch_name":"main"}`)
+	})
+
+	cmd, out, errOut := newTestCreateCmd(t, api.baseURL)
+	// internalconfig.Save renames a temp file onto this path; making it an
+	// existing directory forces that rename to fail regardless of the
+	// process's privileges (unlike a read-only permission bit, which root
+	// ignores), without touching auth.yaml alongside it.
+	cfgPath, err := config.Path()
+	require.NoError(t, err)
+	require.NoError(t, os.MkdirAll(cfgPath, 0o700))
+
+	runErr := runCreate(cmd, noCallDetector{t: t}, createFlags{
+		repoURL:   "https://github.com/acme/widget.git",
+		branch:    "main",
+		workspace: "acme",
+	})
+	require.NoError(t, runErr, "the app was already created remotely; a local save failure must not turn into a command error")
+
+	assert.Contains(t, out.String(), "Created app new-app", "the result must still print despite the save failure")
+	assert.Contains(t, errOut.String(), "Warning: failed to save app_id")
+}
+
 func TestCreateCmd_DetectsRepoURLAndBranchFromGit(t *testing.T) {
 	api := newStubAPI(t)
 	api.handle("/apps/register", func(w http.ResponseWriter, _ *http.Request) {
@@ -148,6 +177,7 @@ func TestCreateCmd_WarnsWhenPerDirConfigOverridesAppID(t *testing.T) {
 }
 
 func TestCreateCmd_PropagatesAutoDetectWorkspaceError(t *testing.T) {
+	t.Setenv(cmdutil.EnvWorkspaceID, "")
 	api := newStubAPI(t)
 	api.handle("/organizations", func(w http.ResponseWriter, _ *http.Request) {
 		_, _ = io.WriteString(w, `{"data":[]}`)

--- a/cli/app/list.go
+++ b/cli/app/list.go
@@ -1,0 +1,179 @@
+package app
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/bitrise-io/bitrise/v2/cli/cmdutil"
+	internalapp "github.com/bitrise-io/bitrise/v2/internal/app"
+	"github.com/bitrise-io/bitrise/v2/internal/style"
+	"github.com/bitrise-io/bitrise/v2/output"
+)
+
+// NewListCommand returns the `app list` subcommand.
+func NewListCommand() *cobra.Command {
+	var (
+		limit       int
+		cursor      string
+		sortBy      string
+		title       string
+		projectType string
+		fetchAll    bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List apps the authenticated user can access",
+		Long: `List all apps the authenticated user can access.
+
+Filters:
+  --title TITLE          filter apps by title
+  --project-type TYPE    e.g. ios, android
+  --sort-by FIELD        ordering accepted by the API (created_at, last_build_at)
+
+Pagination:
+  --limit N     max items per page (server default if 0)
+  --cursor TOKEN opaque token from a previous page's next_cursor
+  --all         fetch all pages automatically
+
+In JSON mode (--format json), next_cursor holds the cursor value for scripting:
+  bitrise app list --format json | jq -r '.next_cursor'`,
+		Example: `  bitrise app list
+  bitrise app list --all
+  bitrise app list --format json | jq -r '.next_cursor'
+  bitrise app list --project-type ios --limit 100`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cmdutil.LogCommandParameters(cmd)
+
+			if fetchAll && cursor != "" {
+				return fmt.Errorf("--all and --cursor cannot be used together")
+			}
+
+			format, _ := cmd.Flags().GetString(cmdutil.FormatKey)
+			if err := output.ConfigureOutputFormat(format); err != nil {
+				return fmt.Errorf("failed to configure output format: %w", err)
+			}
+
+			client, err := cmdutil.NewAPIClient(cmd)
+			if err != nil {
+				return err
+			}
+			svc := internalapp.NewService(client)
+
+			makeOpts := func(cur string) internalapp.ListOptions {
+				return internalapp.ListOptions{
+					Limit:       limit,
+					Cursor:      cur,
+					SortBy:      sortBy,
+					Title:       title,
+					ProjectType: projectType,
+				}
+			}
+
+			var res internalapp.AppsResult
+			if fetchAll {
+				var allItems []internalapp.App
+				cur := ""
+				for {
+					page, pageErr := svc.List(cmd.Context(), makeOpts(cur))
+					if pageErr != nil {
+						return pageErr
+					}
+					allItems = append(allItems, page.Items...)
+					if page.NextCursor == "" {
+						break
+					}
+					cur = page.NextCursor
+				}
+				res = internalapp.AppsResult{Items: allItems}
+			} else {
+				res, err = svc.List(cmd.Context(), makeOpts(cursor))
+				if err != nil {
+					return err
+				}
+			}
+
+			if output.Format == output.FormatRaw {
+				return printAppsTable(cmd.OutOrStdout(), res, nextPageCmd(cmd))
+			}
+			return output.Print(res, output.Format)
+		},
+	}
+
+	cmd.Flags().IntVar(&limit, "limit", 0, "max items per page (server default if 0)")
+	cmd.Flags().StringVar(&cursor, "cursor", "", "pagination cursor from a previous response")
+	cmd.Flags().BoolVar(&fetchAll, "all", false, "fetch all pages automatically")
+	cmd.Flags().StringVar(&sortBy, "sort-by", "", "ordering accepted by the API (created_at, last_build_at)")
+	cmd.Flags().StringVar(&title, "title", "", "filter apps by title")
+	cmd.Flags().StringVar(&projectType, "project-type", "", "filter by project type (ios, android, ...)")
+	cmd.Flags().StringP(cmdutil.FormatKey, "f", "", "Output format. Accepted: raw (default), json, yml")
+
+	_ = cmd.RegisterFlagCompletionFunc("sort-by", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+		return []string{"created_at", "last_build_at"}, cobra.ShellCompDirectiveNoFileComp
+	})
+	_ = cmd.RegisterFlagCompletionFunc("project-type", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+		return []string{"ios", "android", "flutter", "react-native", "xamarin", "cordova", "ionic", "other"}, cobra.ShellCompDirectiveNoFileComp
+	})
+
+	return cmd
+}
+
+// nextPageCmd builds the "fetch the next page" hint shown under the table,
+// reproducing every filter flag the user actually set so the suggested
+// invocation stays scoped the same way.
+func nextPageCmd(cmd *cobra.Command) func(nextCursor string) string {
+	return func(nextCursor string) string {
+		parts := []string{"bitrise app list"}
+		for _, name := range []string{"title", "project-type", "sort-by", "limit"} {
+			if f := cmd.Flags().Lookup(name); f != nil && f.Changed {
+				parts = append(parts, "--"+name, f.Value.String())
+			}
+		}
+		parts = append(parts, "--cursor", nextCursor)
+		return strings.Join(parts, " ")
+	}
+}
+
+func printAppsTable(w io.Writer, res internalapp.AppsResult, nextPageCmd func(string) string) error {
+	if len(res.Items) == 0 {
+		_, err := fmt.Fprintln(w, "No apps found.")
+		return err
+	}
+
+	s := style.New(w)
+	headers := []string{"TITLE", "PROVIDER", "PROJECT_TYPE", "WORKSPACE", "DISABLED", "ID"}
+	rows := make([][]string, 0, len(res.Items))
+	disabled := make([]bool, 0, len(res.Items))
+	for _, a := range res.Items {
+		dis := ""
+		if a.IsDisabled {
+			dis = "yes"
+		}
+		disabled = append(disabled, a.IsDisabled)
+		rows = append(rows, []string{a.Title, a.Provider, a.ProjectType, a.OwnerSlug, dis, a.Slug})
+	}
+	const colSlug = 5
+	styler := func(row, col int, content string) string {
+		if disabled[row] {
+			// Whole row dimmed when the app is disabled.
+			return s.Dim.Render(content)
+		}
+		if col == colSlug {
+			return s.Slug.Render(content)
+		}
+		return content
+	}
+	if err := style.Table(w, headers, rows, s.Header, styler); err != nil {
+		return err
+	}
+	if res.NextCursor != "" {
+		hint := fmt.Sprintf("More results available. To fetch the next page:\n  %s", nextPageCmd(res.NextCursor))
+		_, err := fmt.Fprintf(w, "\n%s\n", s.Dim.Render(hint))
+		return err
+	}
+	return nil
+}

--- a/cli/app/list.go
+++ b/cli/app/list.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"strings"
 
+	"al.essio.dev/pkg/shellescape"
 	"github.com/spf13/cobra"
 
 	"github.com/bitrise-io/bitrise/v2/cli/cmdutil"
@@ -76,7 +77,8 @@ In JSON mode (--format json), next_cursor holds the cursor value for scripting:
 
 			var res internalapp.AppsResult
 			if fetchAll {
-				var allItems []internalapp.App
+				allItems := []internalapp.App{}
+				seenCursors := map[string]bool{}
 				cur := ""
 				for {
 					page, pageErr := svc.List(cmd.Context(), makeOpts(cur))
@@ -87,6 +89,10 @@ In JSON mode (--format json), next_cursor holds the cursor value for scripting:
 					if page.NextCursor == "" {
 						break
 					}
+					if seenCursors[page.NextCursor] {
+						return fmt.Errorf("pagination stalled: the API returned the cursor %q twice", page.NextCursor)
+					}
+					seenCursors[page.NextCursor] = true
 					cur = page.NextCursor
 				}
 				res = internalapp.AppsResult{Items: allItems}
@@ -130,10 +136,10 @@ func nextPageCmd(cmd *cobra.Command) func(nextCursor string) string {
 		parts := []string{"bitrise app list"}
 		for _, name := range []string{"title", "project-type", "sort-by", "limit"} {
 			if f := cmd.Flags().Lookup(name); f != nil && f.Changed {
-				parts = append(parts, "--"+name, f.Value.String())
+				parts = append(parts, "--"+name, shellescape.Quote(f.Value.String()))
 			}
 		}
-		parts = append(parts, "--cursor", nextCursor)
+		parts = append(parts, "--cursor", shellescape.Quote(nextCursor))
 		return strings.Join(parts, " ")
 	}
 }

--- a/cli/app/list_test.go
+++ b/cli/app/list_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -12,6 +13,7 @@ import (
 
 	"github.com/bitrise-io/bitrise/v2/internal/auth"
 	"github.com/bitrise-io/bitrise/v2/internal/config"
+	"github.com/bitrise-io/bitrise/v2/log"
 )
 
 func TestListCmd_PrintsTable(t *testing.T) {
@@ -51,6 +53,18 @@ func TestListCmd_PrintsNextPageHint(t *testing.T) {
 	assert.Contains(t, out.String(), "bitrise app list --title my --cursor page-2")
 }
 
+func TestListCmd_NextPageHintQuotesValuesWithSpaces(t *testing.T) {
+	srv := newFakeServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"data":[{"slug":"my-app","title":"My App","provider":"github","owner":{}}],"paging":{"next":"page-2"}}`))
+	})
+
+	cmd, out := newTestListCmd(t, srv.URL)
+	require.NoError(t, cmd.Flags().Set("title", "My App"))
+	require.NoError(t, cmd.RunE(cmd, nil))
+
+	assert.Contains(t, out.String(), "bitrise app list --title 'My App' --cursor page-2")
+}
+
 func TestListCmd_AllFetchesEveryPage(t *testing.T) {
 	pages := 0
 	srv := newFakeServer(t, func(w http.ResponseWriter, r *http.Request) {
@@ -70,6 +84,38 @@ func TestListCmd_AllFetchesEveryPage(t *testing.T) {
 	assert.Contains(t, out.String(), "First")
 	assert.Contains(t, out.String(), "Second")
 	assert.NotContains(t, out.String(), "More results available")
+}
+
+func TestListCmd_AllStopsOnRepeatedCursor(t *testing.T) {
+	requests := 0
+	srv := newFakeServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		requests++
+		_, _ = w.Write([]byte(`{"data":[{"slug":"app-1","title":"First","provider":"github","owner":{}}],"paging":{"next":"page-2"}}`))
+	})
+
+	cmd, _ := newTestListCmd(t, srv.URL)
+	require.NoError(t, cmd.Flags().Set("all", "true"))
+
+	err := cmd.RunE(cmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `pagination stalled: the API returned the cursor "page-2" twice`)
+	assert.Equal(t, 2, requests, "must stop on the second repeat, not loop forever")
+}
+
+func TestListCmd_AllEmptyResultEmitsEmptyArray(t *testing.T) {
+	srv := newFakeServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"data":[]}`))
+	})
+
+	var logBuf strings.Builder
+	log.InitGlobalLogger(log.LoggerOpts{LoggerType: log.ConsoleLogger, Producer: log.BitriseCLI, Writer: &logBuf})
+
+	cmd, _ := newTestListCmd(t, srv.URL)
+	require.NoError(t, cmd.Flags().Set("all", "true"))
+	require.NoError(t, cmd.Flags().Set("format", "json"))
+	require.NoError(t, cmd.RunE(cmd, nil))
+
+	assert.Contains(t, logBuf.String(), `"items":[]`, "an empty --all result must match the single-page path's non-nil items array")
 }
 
 func TestListCmd_RejectsAllWithCursor(t *testing.T) {

--- a/cli/app/list_test.go
+++ b/cli/app/list_test.go
@@ -1,0 +1,126 @@
+package app
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/bitrise-io/bitrise/v2/internal/auth"
+	"github.com/bitrise-io/bitrise/v2/internal/config"
+)
+
+func TestListCmd_PrintsTable(t *testing.T) {
+	srv := newFakeServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"data":[{"slug":"my-app","title":"My App","provider":"github","project_type":"android","owner":{"slug":"acme"}}]}`))
+	})
+
+	cmd, out := newTestListCmd(t, srv.URL)
+	require.NoError(t, cmd.RunE(cmd, nil))
+
+	assert.Contains(t, out.String(), "My App")
+	assert.Contains(t, out.String(), "my-app")
+	assert.Contains(t, out.String(), "acme")
+}
+
+func TestListCmd_EmptyHuman(t *testing.T) {
+	srv := newFakeServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"data":[]}`))
+	})
+
+	cmd, out := newTestListCmd(t, srv.URL)
+	require.NoError(t, cmd.RunE(cmd, nil))
+
+	assert.Equal(t, "No apps found.\n", out.String())
+}
+
+func TestListCmd_PrintsNextPageHint(t *testing.T) {
+	srv := newFakeServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"data":[{"slug":"my-app","title":"My App","provider":"github","owner":{"slug":"acme"}}],"paging":{"next":"page-2"}}`))
+	})
+
+	cmd, out := newTestListCmd(t, srv.URL)
+	require.NoError(t, cmd.Flags().Set("title", "my"))
+	require.NoError(t, cmd.RunE(cmd, nil))
+
+	assert.Contains(t, out.String(), "More results available")
+	assert.Contains(t, out.String(), "bitrise app list --title my --cursor page-2")
+}
+
+func TestListCmd_AllFetchesEveryPage(t *testing.T) {
+	pages := 0
+	srv := newFakeServer(t, func(w http.ResponseWriter, r *http.Request) {
+		pages++
+		if r.URL.Query().Get("next") == "" {
+			_, _ = w.Write([]byte(`{"data":[{"slug":"app-1","title":"First","provider":"github","owner":{}}],"paging":{"next":"page-2"}}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"data":[{"slug":"app-2","title":"Second","provider":"github","owner":{}}]}`))
+	})
+
+	cmd, out := newTestListCmd(t, srv.URL)
+	require.NoError(t, cmd.Flags().Set("all", "true"))
+	require.NoError(t, cmd.RunE(cmd, nil))
+
+	assert.Equal(t, 2, pages)
+	assert.Contains(t, out.String(), "First")
+	assert.Contains(t, out.String(), "Second")
+	assert.NotContains(t, out.String(), "More results available")
+}
+
+func TestListCmd_RejectsAllWithCursor(t *testing.T) {
+	cmd, _ := newTestListCmd(t, "https://unused.test")
+	require.NoError(t, cmd.Flags().Set("all", "true"))
+	require.NoError(t, cmd.Flags().Set("cursor", "x"))
+
+	err := cmd.RunE(cmd, nil)
+	require.EqualError(t, err, "--all and --cursor cannot be used together")
+}
+
+func TestListCmd_PropagatesAPIError(t *testing.T) {
+	srv := newFakeServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"message":"forbidden"}`))
+	})
+
+	cmd, _ := newTestListCmd(t, srv.URL)
+	err := cmd.RunE(cmd, nil)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "forbidden")
+}
+
+func TestListCmd_RejectsPositionalArgs(t *testing.T) {
+	cmd := NewListCommand()
+	cmd.SetArgs([]string{"unexpected"})
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+
+	assert.Error(t, cmd.Execute(), "positional args should be rejected before the command runs")
+}
+
+// newTestListCmd builds a NewListCommand() wired to apiBaseURL, with its
+// output captured in the returned buffer.
+func newTestListCmd(t *testing.T, apiBaseURL string) (*cobra.Command, *bytes.Buffer) {
+	t.Helper()
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	require.NoError(t, auth.Save(auth.Auth{Token: "test-token"}))
+
+	cmd := NewListCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	resolved := config.Resolve(config.Config{}, config.Config{}, config.Config{APIBaseURL: apiBaseURL})
+	cmd.SetContext(config.WithResolved(t.Context(), resolved))
+	return cmd, &out
+}
+
+func newFakeServer(t *testing.T, handler http.HandlerFunc) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	return srv
+}

--- a/cli/app/main_test.go
+++ b/cli/app/main_test.go
@@ -1,0 +1,18 @@
+package app
+
+import (
+	"os"
+	"testing"
+
+	"github.com/bitrise-io/bitrise/v2/analytics/analyticstest"
+	"github.com/bitrise-io/bitrise/v2/cli/cmdutil"
+)
+
+// TestMain installs a no-op analytics tracker: RunE calls
+// cmdutil.LogCommandParameters, which panics on the package-level tracker's
+// zero value if nothing has called cmdutil.SetTracker (normally done once at
+// real CLI startup, cli/cli.go).
+func TestMain(m *testing.M) {
+	cmdutil.SetTracker(analyticstest.NoOpTracker{})
+	os.Exit(m.Run())
+}

--- a/cli/app/view.go
+++ b/cli/app/view.go
@@ -21,8 +21,9 @@ func NewViewCommand() *cobra.Command {
 		Short: "Show details of a single app",
 		Long: `Show details for a single app identified by its ID.
 
-APP_ID falls back to --app, then BITRISE_APP_ID, then the app_id saved by
-'bitrise app create', when omitted.`,
+APP_ID falls back to --app, then $BITRISE_APP_ID, then $BITRISE_APP_SLUG
+(injected inside a Bitrise build), then the app_id saved by 'bitrise app
+create' or 'bitrise config set app_id', when omitted.`,
 		Example: `  bitrise app view stub-app-aaa
   bitrise app view stub-app-aaa --format json
   bitrise app view stub-app-aaa --web

--- a/cli/app/view.go
+++ b/cli/app/view.go
@@ -1,0 +1,99 @@
+package app
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/bitrise-io/bitrise/v2/cli/cmdutil"
+	internalapp "github.com/bitrise-io/bitrise/v2/internal/app"
+	"github.com/bitrise-io/bitrise/v2/output"
+)
+
+// NewViewCommand returns the `app view` subcommand.
+func NewViewCommand() *cobra.Command {
+	var web bool
+
+	cmd := &cobra.Command{
+		Use:   "view [APP_ID]",
+		Short: "Show details of a single app",
+		Long: `Show details for a single app identified by its ID.
+
+APP_ID falls back to --app, then BITRISE_APP_ID, then the app_id saved by
+'bitrise app create', when omitted.`,
+		Example: `  bitrise app view stub-app-aaa
+  bitrise app view stub-app-aaa --format json
+  bitrise app view stub-app-aaa --web
+  BITRISE_APP_ID=stub-app-aaa bitrise app view`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runView(cmd, args, web, cmdutil.OpenBrowser)
+		},
+	}
+
+	cmdutil.AddAppFlag(cmd.Flags(), "app ID to view (or set BITRISE_APP_ID); overridden by the positional argument")
+	cmd.Flags().BoolVar(&web, "web", false, "open the app page in the browser instead of printing")
+	cmd.Flags().StringP(cmdutil.FormatKey, "f", "", "Output format. Accepted: raw (default), json, yml")
+
+	return cmd
+}
+
+// runView is NewViewCommand's RunE, with browser-opening injected so tests
+// can exercise --web without launching a real browser.
+func runView(cmd *cobra.Command, args []string, web bool, openBrowser func(string) error) error {
+	cmdutil.LogCommandParameters(cmd)
+
+	format, _ := cmd.Flags().GetString(cmdutil.FormatKey)
+	if err := output.ConfigureOutputFormat(format); err != nil {
+		return fmt.Errorf("failed to configure output format: %w", err)
+	}
+
+	appSlug, err := cmdutil.ResolveAppSlugArg(cmd, args)
+	if err != nil {
+		return err
+	}
+
+	if web {
+		url := fmt.Sprintf("%s/app/%s", cmdutil.ResolveWebBaseURL(cmd), appSlug)
+		if err := openBrowser(url); err != nil {
+			return err
+		}
+		_, err := fmt.Fprintf(cmd.ErrOrStderr(), "Opened %s\n", url)
+		return err
+	}
+
+	client, err := cmdutil.NewAPIClient(cmd)
+	if err != nil {
+		return err
+	}
+	a, err := internalapp.NewService(client).View(cmd.Context(), appSlug)
+	if err != nil {
+		return err
+	}
+
+	if output.Format == output.FormatRaw {
+		return printAppText(cmd.OutOrStdout(), a)
+	}
+	return output.Print(a, output.Format)
+}
+
+func printAppText(w io.Writer, a internalapp.App) error {
+	var b strings.Builder
+	fmt.Fprintf(&b, "Title:        %s\n", a.Title)
+	fmt.Fprintf(&b, "ID:           %s\n", a.Slug)
+	fmt.Fprintf(&b, "Provider:     %s\n", a.Provider)
+	fmt.Fprintf(&b, "Repo URL:     %s\n", a.RepoURL)
+	if a.OwnerSlug != "" {
+		fmt.Fprintf(&b, "Workspace:    %s\n", a.OwnerSlug)
+	}
+	if a.ProjectType != "" {
+		fmt.Fprintf(&b, "Project type: %s\n", a.ProjectType)
+	}
+	if a.IsDisabled {
+		fmt.Fprintln(&b, "Disabled:     yes")
+	}
+	_, err := io.WriteString(w, b.String())
+	return err
+}

--- a/cli/app/view_test.go
+++ b/cli/app/view_test.go
@@ -1,0 +1,111 @@
+package app
+
+import (
+	"bytes"
+	"net/http"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/bitrise-io/bitrise/v2/cli/cmdutil"
+	"github.com/bitrise-io/bitrise/v2/internal/auth"
+	"github.com/bitrise-io/bitrise/v2/internal/config"
+)
+
+func TestViewCmd_PositionalArg(t *testing.T) {
+	var gotPath string
+	srv := newFakeServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		_, _ = w.Write([]byte(`{"data":{"slug":"my-app","title":"My App","provider":"github","repo_url":"https://github.com/x/y","owner":{"slug":"acme"}}}`))
+	})
+
+	cmd, out := newTestViewCmd(t, srv.URL)
+	require.NoError(t, runView(cmd, []string{"my-app"}, false, unusedBrowser(t)))
+
+	assert.Equal(t, "/apps/my-app", gotPath)
+	// Matched padding-agnostically: the label/value pairing is the contract,
+	// the column width is cosmetic.
+	assert.Regexp(t, `Title:\s+My App`, out.String())
+	assert.Regexp(t, `ID:\s+my-app`, out.String())
+	assert.Regexp(t, `Workspace:\s+acme`, out.String())
+}
+
+func TestViewCmd_FlagFallback(t *testing.T) {
+	var gotPath string
+	srv := newFakeServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		_, _ = w.Write([]byte(`{"data":{"slug":"my-app","title":"My App","provider":"github","owner":{}}}`))
+	})
+
+	cmd, _ := newTestViewCmd(t, srv.URL)
+	require.NoError(t, cmd.Flags().Set("app", "my-app"))
+	require.NoError(t, runView(cmd, nil, false, unusedBrowser(t)))
+
+	assert.Equal(t, "/apps/my-app", gotPath)
+}
+
+func TestViewCmd_RequiresAppSlug(t *testing.T) {
+	cmd, _ := newTestViewCmd(t, "https://unused.test")
+	err := runView(cmd, nil, false, unusedBrowser(t))
+	require.EqualError(t, err, "--app is required")
+}
+
+func TestViewCmd_AppNotFound(t *testing.T) {
+	srv := newFakeServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"message":"not found"}`))
+	})
+
+	cmd, _ := newTestViewCmd(t, srv.URL)
+	err := runView(cmd, []string{"missing-app"}, false, unusedBrowser(t))
+	require.EqualError(t, err, `app "missing-app" not found`)
+}
+
+func TestViewCmd_Web_OpensBrowserAndSkipsAPICall(t *testing.T) {
+	cmd, _ := newTestViewCmd(t, "https://unused.test")
+	t.Setenv(cmdutil.EnvWebBaseURL, "https://app.bitrise.io")
+
+	var gotURL string
+	err := runView(cmd, []string{"my-app"}, true, func(url string) error {
+		gotURL = url
+		return nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "https://app.bitrise.io/app/my-app", gotURL)
+}
+
+func TestViewCmd_RejectsMultipleArgs(t *testing.T) {
+	cmd := NewViewCommand()
+	cmd.SetArgs([]string{"app-1", "app-2"})
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+
+	assert.Error(t, cmd.Execute(), "more than one positional arg should be rejected before the command runs")
+}
+
+// unusedBrowser fails the test if the browser opener is ever invoked, for
+// cases where --web is off and no browser call is expected.
+func unusedBrowser(t *testing.T) func(string) error {
+	t.Helper()
+	return func(url string) error {
+		t.Fatalf("unexpected browser open: %s", url)
+		return nil
+	}
+}
+
+// newTestViewCmd builds a NewViewCommand() wired to apiBaseURL, with its
+// output captured in the returned buffer.
+func newTestViewCmd(t *testing.T, apiBaseURL string) (*cobra.Command, *bytes.Buffer) {
+	t.Helper()
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	require.NoError(t, auth.Save(auth.Auth{Token: "test-token"}))
+
+	cmd := NewViewCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	resolved := config.Resolve(config.Config{}, config.Config{}, config.Config{APIBaseURL: apiBaseURL})
+	cmd.SetContext(config.WithResolved(t.Context(), resolved))
+	return cmd, &out
+}

--- a/cli/app/view_test.go
+++ b/cli/app/view_test.go
@@ -47,6 +47,8 @@ func TestViewCmd_FlagFallback(t *testing.T) {
 }
 
 func TestViewCmd_RequiresAppSlug(t *testing.T) {
+	t.Setenv(cmdutil.EnvAppIDLegacy, "")
+
 	cmd, _ := newTestViewCmd(t, "https://unused.test")
 	err := runView(cmd, nil, false, unusedBrowser(t))
 	require.EqualError(t, err, "--app is required")

--- a/cli/cmdutil/webbase.go
+++ b/cli/cmdutil/webbase.go
@@ -2,6 +2,7 @@ package cmdutil
 
 import (
 	"os"
+	"strings"
 
 	"github.com/bitrise-io/bitrise/v2/internal/config"
 	"github.com/spf13/cobra"
@@ -15,13 +16,15 @@ const EnvWebBaseURL = "BITRISE_WEB_BASE_URL"
 // ResolveWebBaseURL returns the resolved web base URL: BITRISE_WEB_BASE_URL,
 // then the web_base_url set via `bitrise config set` (global config file only
 // — never a per-dir .bitrise-cli.yml, see internal/config.Resolve), then the
-// built-in default.
+// built-in default. Any trailing slash is trimmed here, once, so every
+// caller can concatenate a path onto the result without producing a double
+// slash — the built-in default carries none, but a user-set value might.
 func ResolveWebBaseURL(cmd *cobra.Command) string {
 	if v := os.Getenv(EnvWebBaseURL); v != "" {
-		return v
+		return strings.TrimSuffix(v, "/")
 	}
 	if v := config.FromContext(cmd.Context()).WebBaseURL; v != "" {
-		return v
+		return strings.TrimSuffix(v, "/")
 	}
 	return config.DefaultWebBaseURL
 }

--- a/cli/cmdutil/webbase_test.go
+++ b/cli/cmdutil/webbase_test.go
@@ -37,3 +37,13 @@ func TestResolveWebBaseURL_EmptyResolvedContextFallsBackToDefault(t *testing.T) 
 
 	assert.Equal(t, config.DefaultWebBaseURL, ResolveWebBaseURL(cmd))
 }
+
+func TestResolveWebBaseURL_TrimsTrailingSlash(t *testing.T) {
+	t.Setenv(EnvWebBaseURL, "https://env.example/")
+	cmd := &cobra.Command{}
+	assert.Equal(t, "https://env.example", ResolveWebBaseURL(cmd), "callers concatenate a path onto the result and must not get a double slash")
+
+	t.Setenv(EnvWebBaseURL, "")
+	cmd.SetContext(config.WithResolved(t.Context(), config.Resolved{Config: config.Config{WebBaseURL: "https://ctx.example/"}}))
+	assert.Equal(t, "https://ctx.example", ResolveWebBaseURL(cmd))
+}

--- a/cli/root.go
+++ b/cli/root.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 
 	"github.com/bitrise-io/bitrise/v2/cli/api"
+	"github.com/bitrise-io/bitrise/v2/cli/app"
 	"github.com/bitrise-io/bitrise/v2/cli/auth"
 	"github.com/bitrise-io/bitrise/v2/cli/cmdutil"
 	"github.com/bitrise-io/bitrise/v2/cli/config"
@@ -55,6 +56,7 @@ func newRootCommand() *cobra.Command {
 		auth.NewCmd(),
 		stack.NewCmd(),
 		user.NewCmd(),
+		app.NewCmd(),
 		api.NewCmd(),
 		config.NewCmd(),
 

--- a/cli/stack/list.go
+++ b/cli/stack/list.go
@@ -20,9 +20,14 @@ func NewListCommand() *cobra.Command {
 		Short: "List available stacks and their machine configurations",
 		Long: `List all available stacks with their OS, status, and version information.
 
-When --workspace is provided, returns stacks available for that workspace,
-including any custom stacks configured for it.
-Without --workspace, returns globally available stacks.`,
+Workspace, highest to lowest:
+  --workspace WORKSPACE_ID
+  $BITRISE_WORKSPACE_ID (injected inside a Bitrise build)
+  the default_workspace_id config key ('bitrise config set')
+
+When a workspace resolves, returns stacks available for that workspace,
+including any custom stacks configured for it. Otherwise returns globally
+available stacks.`,
 		Example: `  bitrise stack list
   bitrise stack list --workspace my-workspace-id
   bitrise stack list --format json`,
@@ -35,12 +40,23 @@ Without --workspace, returns globally available stacks.`,
 				return fmt.Errorf("failed to configure output format: %w", err)
 			}
 
+			resolvedWorkspace := workspaceSlug
+			if resolvedWorkspace == "" {
+				resolvedWorkspace = cmdutil.DefaultWorkspaceSlug(cmd)
+				// Flagged so a build step doesn't silently switch from the
+				// global stack list to a workspace-scoped one without the
+				// user noticing.
+				if resolvedWorkspace != "" && output.Format == output.FormatRaw {
+					fmt.Fprintf(cmd.ErrOrStderr(), "Using default workspace: %s\n", resolvedWorkspace)
+				}
+			}
+
 			client, err := cmdutil.NewAPIClient(cmd)
 			if err != nil {
 				return err
 			}
 
-			result, err := internalstack.NewService(client).List(cmd.Context(), workspaceSlug)
+			result, err := internalstack.NewService(client).List(cmd.Context(), resolvedWorkspace)
 			if err != nil {
 				return fmt.Errorf("listing stacks failed: %w", err)
 			}
@@ -52,7 +68,7 @@ Without --workspace, returns globally available stacks.`,
 		},
 	}
 
-	cmd.Flags().StringVar(&workspaceSlug, "workspace", "", "workspace ID for workspace-specific stacks (including custom stacks)")
+	cmd.Flags().StringVar(&workspaceSlug, cmdutil.FlagWorkspace, "", "workspace ID for workspace-specific stacks (including custom stacks), or set BITRISE_WORKSPACE_ID / default_workspace_id")
 	cmd.Flags().StringP(cmdutil.FormatKey, "f", "", "Output format. Accepted: raw (default), json, yml")
 
 	return cmd

--- a/cli/stack/list_test.go
+++ b/cli/stack/list_test.go
@@ -10,12 +10,14 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/bitrise-io/bitrise/v2/cli/cmdutil"
 	"github.com/bitrise-io/bitrise/v2/internal/auth"
 	"github.com/bitrise-io/bitrise/v2/internal/config"
 	internalstack "github.com/bitrise-io/bitrise/v2/internal/stack"
 )
 
 func TestListCmd_GlobalPath(t *testing.T) {
+	t.Setenv(cmdutil.EnvWorkspaceID, "")
 	var gotPath string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotPath = r.URL.Path
@@ -43,6 +45,61 @@ func TestListCmd_WorkspaceScopedPath(t *testing.T) {
 	require.NoError(t, cmd.RunE(cmd, nil))
 
 	assert.Equal(t, "/organizations/my-workspace/available-stacks", gotPath)
+}
+
+func TestListCmd_WorkspaceFromEnv(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	t.Setenv(cmdutil.EnvWorkspaceID, "env-ws")
+	cmd, _ := newTestListCmd(t, srv.URL)
+	errOut := &bytes.Buffer{}
+	cmd.SetErr(errOut)
+	require.NoError(t, cmd.RunE(cmd, nil))
+
+	assert.Equal(t, "/organizations/env-ws/available-stacks", gotPath)
+	assert.Contains(t, errOut.String(), "Using default workspace: env-ws")
+}
+
+func TestListCmd_WorkspaceFromConfig(t *testing.T) {
+	t.Setenv(cmdutil.EnvWorkspaceID, "")
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	cmd, _ := newTestListCmdWithConfig(t, srv.URL, config.Config{DefaultWorkspaceID: "cfg-ws"})
+	errOut := &bytes.Buffer{}
+	cmd.SetErr(errOut)
+	require.NoError(t, cmd.RunE(cmd, nil))
+
+	assert.Equal(t, "/organizations/cfg-ws/available-stacks", gotPath)
+	assert.Contains(t, errOut.String(), "Using default workspace: cfg-ws")
+}
+
+func TestListCmd_WorkspaceFlagWinsOverDefault_NoBreadcrumb(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	t.Setenv(cmdutil.EnvWorkspaceID, "env-ws")
+	cmd, _ := newTestListCmd(t, srv.URL)
+	require.NoError(t, cmd.Flags().Set("workspace", "flag-ws"))
+	errOut := &bytes.Buffer{}
+	cmd.SetErr(errOut)
+	require.NoError(t, cmd.RunE(cmd, nil))
+
+	assert.Equal(t, "/organizations/flag-ws/available-stacks", gotPath)
+	assert.NotContains(t, errOut.String(), "Using default workspace", "an explicit --workspace is not a default")
 }
 
 func TestListCmd_EmptyHuman(t *testing.T) {
@@ -115,4 +172,14 @@ func newTestListCmd(t *testing.T, apiBaseURL string) (*cobra.Command, *bytes.Buf
 	resolved := config.Resolve(config.Config{}, config.Config{}, config.Config{APIBaseURL: apiBaseURL})
 	cmd.SetContext(config.WithResolved(t.Context(), resolved))
 	return cmd, &out
+}
+
+// newTestListCmdWithConfig is newTestListCmd for tests that need extra
+// resolved config keys (e.g. default_workspace_id) alongside the API base URL.
+func newTestListCmdWithConfig(t *testing.T, apiBaseURL string, global config.Config) (*cobra.Command, *bytes.Buffer) {
+	t.Helper()
+	cmd, out := newTestListCmd(t, apiBaseURL)
+	global.APIBaseURL = apiBaseURL
+	cmd.SetContext(config.WithResolved(t.Context(), config.Resolve(config.Config{}, config.Config{}, global)))
+	return cmd, out
 }

--- a/internal/app/create.go
+++ b/internal/app/create.go
@@ -264,12 +264,11 @@ func deriveTitle(repoURL string) string {
 }
 
 // GitDetector detects the cwd's git remote URL and current branch. The
-// default implementation shells out to `git`. Tests inject a stub.
+// default implementation shells out to `git`; tests inject a stub.
 //
-// Deliberately unused inside this package: it is consumed by the `app create`
-// command layer, which resolves RepoURL and Branch from git before handing
-// CreateOptions to Create. That command isn't migrated yet, so this type
-// currently has no caller in-tree.
+// Unused inside this package by design: it's consumed by the `app create`
+// command layer (cli/app/create.go), which resolves RepoURL and Branch from
+// git before handing CreateOptions to Create.
 type GitDetector interface {
 	RemoteURL(ctx context.Context) (string, error)
 	CurrentBranch(ctx context.Context) (string, error)


### PR DESCRIPTION
`bitrise app list/view/create`, covering the same surface as the reference implementation: the same three subcommands and the same flags, plus `--web` and an optional positional `APP_ID` on `view`.

`view` resolves the app from the positional argument, then `--app`, `BITRISE_APP_ID` and the `app_id` config key, so it works bare inside a directory that has one pinned. `create` infers what it can from the git checkout (origin URL, current branch, title from the repo name) and from config (`default_workspace_id`), reporting each inference on stderr — suppressed for machine-readable output so a script's stderr stays clean.

`create` saves the new app's ID as the global `app_id`, and warns when a per-directory file pins a different one that will keep winning. The build trigger token it returns is masked in the human output the way `auth status` masks tokens; `--format json` still carries the real value.