### PR TITLE
fix offline tests: disable steplib API usage, not supported yet

### DIFF
--- a/cli/run_test.go
+++ b/cli/run_test.go
@@ -2007,6 +2007,9 @@ workflows:
 }
 
 func TestInvalidStepID(t *testing.T) {
+	// StepmanUpdates is only recorded by the git-based steplib activation path, the API path never updates a local steplib.
+	t.Setenv("BITRISE_STEPLIB_API_ENABLE", "false")
+
 	configStr := `
 format_version: 1.3.0
 default_step_lib_source: "https://github.com/bitrise-io/bitrise-steplib.git"

--- a/integrationtests/cli/offline_mode_test.go
+++ b/integrationtests/cli/offline_mode_test.go
@@ -35,7 +35,7 @@ func Test_GivenOfflineMode_WhenStepNotCached_ThenFails(t *testing.T) {
 	preloadSteps(t)
 
 	cmd := command.New(testhelpers.BinPath(), "run", "not_cached", "--config", offlineModeConfigPath)
-	cmd.AppendEnvs("BITRISE_OFFLINE_MODE=true")
+	cmd.AppendEnvs("BITRISE_OFFLINE_MODE=true", "BITRISE_STEPLIB_API_ENABLE=false")
 	out, err := cmd.RunAndReturnTrimmedCombinedOutput()
 
 	require.Error(t, err, "Bitrise CLI failed, output: %s", out)
@@ -56,7 +56,7 @@ func Test_GivenOfflineMode_WhenStepCached_ThenSuceeds(t *testing.T) {
 	preloadSteps(t)
 
 	cmd := command.New(testhelpers.BinPath(), "run", "cached", "--config", offlineModeConfigPath)
-	cmd.AppendEnvs("BITRISE_OFFLINE_MODE=true")
+	cmd.AppendEnvs("BITRISE_OFFLINE_MODE=true", "BITRISE_STEPLIB_API_ENABLE=false")
 	out, err := cmd.RunAndReturnTrimmedCombinedOutput()
 
 	require.NoError(t, err, "Bitrise CLI failed, output: %s", out)


### PR DESCRIPTION
Fixed `activate steplib step: offline mode is not supported with Steplib API` errors in CI.