### PR TITLE
v3 prep: output.Render and bitriseapi generic client helpers

### DIFF
--- a/cli/app/create.go
+++ b/cli/app/create.go
@@ -180,11 +180,7 @@ func runCreate(cmd *cobra.Command, detector internalapp.GitDetector, flags creat
 	// point, so a failure to save app_id locally (read-only config dir, lock
 	// timeout) must not swallow the slug and build trigger token the user
 	// needs to recover manually.
-	if output.Format == output.FormatRaw {
-		if err := printCreateText(cmd.OutOrStdout(), res); err != nil {
-			return err
-		}
-	} else if err := output.Print(res, output.Format); err != nil {
+	if err := output.Render(cmd.OutOrStdout(), output.Format, res, printCreateText); err != nil {
 		return err
 	}
 

--- a/cli/app/list.go
+++ b/cli/app/list.go
@@ -103,10 +103,9 @@ In JSON mode (--format json), next_cursor holds the cursor value for scripting:
 				}
 			}
 
-			if output.Format == output.FormatRaw {
-				return printAppsTable(cmd.OutOrStdout(), res, nextPageCmd(cmd))
-			}
-			return output.Print(res, output.Format)
+			return output.Render(cmd.OutOrStdout(), output.Format, res, func(w io.Writer, res internalapp.AppsResult) error {
+				return printAppsTable(w, res, nextPageCmd(cmd))
+			})
 		},
 	}
 

--- a/cli/app/view.go
+++ b/cli/app/view.go
@@ -74,10 +74,7 @@ func runView(cmd *cobra.Command, args []string, web bool, openBrowser func(strin
 		return err
 	}
 
-	if output.Format == output.FormatRaw {
-		return printAppText(cmd.OutOrStdout(), a)
-	}
-	return output.Print(a, output.Format)
+	return output.Render(cmd.OutOrStdout(), output.Format, a, printAppText)
 }
 
 func printAppText(w io.Writer, a internalapp.App) error {

--- a/cli/config/list.go
+++ b/cli/config/list.go
@@ -49,10 +49,9 @@ build, BITRISE_APP_SLUG and BITRISE_WORKSPACE_ID are always set.`,
 			// rather than vanish from the JSON/YAML output.
 			values["path"] = p
 
-			if output.Format == output.FormatRaw {
-				return printListHuman(cmd.OutOrStdout(), p, values)
-			}
-			return output.Print(values, output.Format)
+			return output.Render(cmd.OutOrStdout(), output.Format, values, func(w io.Writer, values map[string]string) error {
+				return printListHuman(w, p, values)
+			})
 		},
 	}
 

--- a/cli/stack/list.go
+++ b/cli/stack/list.go
@@ -61,10 +61,9 @@ available stacks.`,
 				return fmt.Errorf("listing stacks failed: %w", err)
 			}
 
-			if output.Format == output.FormatRaw {
-				return printStacksTable(cmd.OutOrStdout(), result.Items)
-			}
-			return output.Print(result, output.Format)
+			return output.Render(cmd.OutOrStdout(), output.Format, result, func(w io.Writer, result internalstack.StacksResult) error {
+				return printStacksTable(w, result.Items)
+			})
 		},
 	}
 

--- a/cli/user/create.go
+++ b/cli/user/create.go
@@ -114,10 +114,7 @@ Target host:
 				return err
 			}
 
-			if output.Format == output.FormatRaw {
-				return printCreateHuman(cmd.OutOrStdout(), acct)
-			}
-			return output.Print(acct, output.Format)
+			return output.Render(cmd.OutOrStdout(), output.Format, acct, printCreateHuman)
 		},
 	}
 

--- a/cli/user/me.go
+++ b/cli/user/me.go
@@ -2,6 +2,7 @@ package user
 
 import (
 	"fmt"
+	"io"
 
 	"github.com/spf13/cobra"
 
@@ -41,11 +42,10 @@ source is active.`,
 				return fmt.Errorf("fetching user profile failed: %w", err)
 			}
 
-			if output.Format == output.FormatRaw {
-				_, err := fmt.Fprintf(cmd.OutOrStdout(), "Username: %s\nEmail:    %s\n", profile.Username, profile.Email)
+			return output.Render(cmd.OutOrStdout(), output.Format, profile, func(w io.Writer, profile internaluser.Profile) error {
+				_, err := fmt.Fprintf(w, "Username: %s\nEmail:    %s\n", profile.Username, profile.Email)
 				return err
-			}
-			return output.Print(profile, output.Format)
+			})
 		},
 	}
 

--- a/cli/yml/get.go
+++ b/cli/yml/get.go
@@ -2,6 +2,7 @@ package yml
 
 import (
 	"fmt"
+	"io"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -48,15 +49,14 @@ instead of the app's current stored configuration.`,
 				return err
 			}
 
-			if output.Format == output.FormatRaw {
+			return output.Render(cmd.OutOrStdout(), output.Format, result, func(w io.Writer, result internalyml.GetResult) error {
 				content := result.Content
 				if content != "" && !strings.HasSuffix(content, "\n") {
 					content += "\n"
 				}
-				_, err = fmt.Fprint(cmd.OutOrStdout(), content)
+				_, err := fmt.Fprint(w, content)
 				return err
-			}
-			return output.Print(result, output.Format)
+			})
 		},
 	}
 

--- a/configs/configs.go
+++ b/configs/configs.go
@@ -237,9 +237,13 @@ func SetAppID(appID string) error {
 // app create`), so later commands can resolve it without --app/BITRISE_APP_ID.
 // Unlike SetupVersion/LastCLIUpdateCheck/LastPluginUpdateChecks, app_id has no
 // ~/.bitrise/config.json counterpart, so it never touches the legacy file.
+//
+// Routed through Config.Set rather than assigning c.AppID directly, so this
+// writer and `bitrise config set app_id` can't drift if validation is ever
+// added to that key.
 func SetAppID(appID string) error {
-	return saveGlobalConfig(func(c *internalconfig.Config) {
-		c.AppID = appID
+	return saveGlobalConfig(func(c *internalconfig.Config) error {
+		return c.Set(internalconfig.KeyAppID, appID)
 	})
 }
 

--- a/configs/configs.go
+++ b/configs/configs.go
@@ -233,6 +233,16 @@ func SetAppID(appID string) error {
 	})
 }
 
+// SetAppID persists appID as the default app for cloud commands (e.g. `bitrise
+// app create`), so later commands can resolve it without --app/BITRISE_APP_ID.
+// Unlike SetupVersion/LastCLIUpdateCheck/LastPluginUpdateChecks, app_id has no
+// ~/.bitrise/config.json counterpart, so it never touches the legacy file.
+func SetAppID(appID string) error {
+	return saveGlobalConfig(func(c *internalconfig.Config) {
+		c.AppID = appID
+	})
+}
+
 func (m ConfigModel) ToConfig() internalconfig.Config {
 	return internalconfig.Config{
 		SetupVersion:           m.SetupVersion,

--- a/configs/configs.go
+++ b/configs/configs.go
@@ -233,20 +233,6 @@ func SetAppID(appID string) error {
 	})
 }
 
-// SetAppID persists appID as the default app for cloud commands (e.g. `bitrise
-// app create`), so later commands can resolve it without --app/BITRISE_APP_ID.
-// Unlike SetupVersion/LastCLIUpdateCheck/LastPluginUpdateChecks, app_id has no
-// ~/.bitrise/config.json counterpart, so it never touches the legacy file.
-//
-// Routed through Config.Set rather than assigning c.AppID directly, so this
-// writer and `bitrise config set app_id` can't drift if validation is ever
-// added to that key.
-func SetAppID(appID string) error {
-	return saveGlobalConfig(func(c *internalconfig.Config) error {
-		return c.Set(internalconfig.KeyAppID, appID)
-	})
-}
-
 func (m ConfigModel) ToConfig() internalconfig.Config {
 	return internalconfig.Config{
 		SetupVersion:           m.SetupVersion,

--- a/internal/bitriseapi/apps.go
+++ b/internal/bitriseapi/apps.go
@@ -2,8 +2,6 @@ package bitriseapi
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
 	"net/url"
 	"strconv"
 )
@@ -54,50 +52,17 @@ func (o AppsListOptions) params() url.Values {
 	return p
 }
 
-type appsPage struct {
-	Data   []App `json:"data"`
-	Paging struct {
-		Next string `json:"next"`
-	} `json:"paging"`
-}
-
 // Apps returns one page of apps the authenticated user can access, and the
 // cursor for the next page ("" when there isn't one).
 // Endpoint: GET /apps.
 func (c *Client) Apps(ctx context.Context, opts AppsListOptions) ([]App, string, error) {
-	req, err := c.newRequest(ctx, "/apps", opts.params())
-	if err != nil {
-		return nil, "", err
-	}
-	body, err := c.do(req)
-	if err != nil {
-		return nil, "", err
-	}
-	var page appsPage
-	if err := json.Unmarshal(body, &page); err != nil {
-		return nil, "", fmt.Errorf("decode apps response: %w", err)
-	}
-	return page.Data, page.Paging.Next, nil
+	return getPage[App](ctx, c, "/apps", opts.params())
 }
 
 // App returns the details of a single app by slug.
 // Endpoint: GET /apps/{app-slug}.
 func (c *Client) App(ctx context.Context, appSlug string) (App, error) {
-	req, err := c.newRequest(ctx, "/apps/"+url.PathEscape(appSlug), nil)
-	if err != nil {
-		return App{}, err
-	}
-	body, err := c.do(req)
-	if err != nil {
-		return App{}, err
-	}
-	var envelope struct {
-		Data App `json:"data"`
-	}
-	if err := json.Unmarshal(body, &envelope); err != nil {
-		return App{}, fmt.Errorf("decode app response: %w", err)
-	}
-	return envelope.Data, nil
+	return getEnvelope[App](ctx, c, "/apps/"+url.PathEscape(appSlug), nil)
 }
 
 // RegisterAppRequest is the body of POST /apps/register.
@@ -124,15 +89,7 @@ type RegisterAppResponse struct {
 // RegisterApp creates a new app on Bitrise.
 // Endpoint: POST /apps/register.
 func (c *Client) RegisterApp(ctx context.Context, req RegisterAppRequest) (RegisterAppResponse, error) {
-	body, err := c.post(ctx, "/apps/register", nil, req)
-	if err != nil {
-		return RegisterAppResponse{}, err
-	}
-	var resp RegisterAppResponse
-	if err := json.Unmarshal(body, &resp); err != nil {
-		return RegisterAppResponse{}, fmt.Errorf("decode register response: %w", err)
-	}
-	return resp, nil
+	return postDecode[RegisterAppResponse](ctx, c, "/apps/register", nil, req)
 }
 
 // FinishAppRequest is the body of POST /apps/{app-slug}/finish.
@@ -153,13 +110,5 @@ type FinishAppResponse struct {
 // FinishApp activates a registered app, returning its build trigger token.
 // Endpoint: POST /apps/{app-slug}/finish.
 func (c *Client) FinishApp(ctx context.Context, appSlug string, req FinishAppRequest) (FinishAppResponse, error) {
-	body, err := c.post(ctx, "/apps/"+url.PathEscape(appSlug)+"/finish", nil, req)
-	if err != nil {
-		return FinishAppResponse{}, err
-	}
-	var resp FinishAppResponse
-	if err := json.Unmarshal(body, &resp); err != nil {
-		return FinishAppResponse{}, fmt.Errorf("decode finish response: %w", err)
-	}
-	return resp, nil
+	return postDecode[FinishAppResponse](ctx, c, "/apps/"+url.PathEscape(appSlug)+"/finish", nil, req)
 }

--- a/internal/bitriseapi/client.go
+++ b/internal/bitriseapi/client.go
@@ -146,6 +146,71 @@ func (c *Client) post(ctx context.Context, path string, params url.Values, body 
 	return c.do(req)
 }
 
+// get performs an authenticated GET against path and decodes the JSON
+// response body into T.
+func get[T any](ctx context.Context, c *Client, path string, params url.Values) (T, error) {
+	var zero T
+	req, err := c.newRequest(ctx, path, params)
+	if err != nil {
+		return zero, err
+	}
+	body, err := c.do(req)
+	if err != nil {
+		return zero, err
+	}
+	var result T
+	if err := json.Unmarshal(body, &result); err != nil {
+		return zero, fmt.Errorf("decode response: %w", err)
+	}
+	return result, nil
+}
+
+// envelope unwraps the {"data": ...} shape used by single-resource endpoints
+// (e.g. GET /apps/{app-slug}).
+type envelope[T any] struct {
+	Data T `json:"data"`
+}
+
+// getEnvelope performs a GET and unwraps a {"data": T} envelope.
+func getEnvelope[T any](ctx context.Context, c *Client, path string, params url.Values) (T, error) {
+	env, err := get[envelope[T]](ctx, c, path, params)
+	return env.Data, err
+}
+
+// page is the {"data": [...], "paging": {"next": ...}} shape used by
+// cursor-paginated list endpoints.
+type page[T any] struct {
+	Data   []T `json:"data"`
+	Paging struct {
+		Next string `json:"next"`
+	} `json:"paging"`
+}
+
+// getPage performs a GET against a cursor-paginated list endpoint, returning
+// the page's items and the cursor for the next page ("" when there isn't one).
+func getPage[T any](ctx context.Context, c *Client, path string, params url.Values) ([]T, string, error) {
+	p, err := get[page[T]](ctx, c, path, params)
+	if err != nil {
+		return nil, "", err
+	}
+	return p.Data, p.Paging.Next, nil
+}
+
+// postDecode performs an authenticated POST with reqBody as the JSON body,
+// and decodes the JSON response into Resp.
+func postDecode[Resp any](ctx context.Context, c *Client, path string, params url.Values, reqBody any) (Resp, error) {
+	var zero Resp
+	body, err := c.post(ctx, path, params, reqBody)
+	if err != nil {
+		return zero, err
+	}
+	var resp Resp
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return zero, fmt.Errorf("decode response: %w", err)
+	}
+	return resp, nil
+}
+
 func (c *Client) do(req *http.Request) ([]byte, error) {
 	resp, err := c.httpClient.Do(req)
 	if err != nil {

--- a/internal/bitriseapi/stacks.go
+++ b/internal/bitriseapi/stacks.go
@@ -2,8 +2,6 @@ package bitriseapi
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
 	"net/url"
 )
 
@@ -35,20 +33,5 @@ func (c *Client) AvailableStacks(ctx context.Context, orgSlug string) (map[strin
 	if orgSlug != "" {
 		path = "/organizations/" + url.PathEscape(orgSlug) + "/available-stacks"
 	}
-
-	req, err := c.newRequest(ctx, path, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	body, err := c.do(req)
-	if err != nil {
-		return nil, err
-	}
-
-	var result map[string]StackInfo
-	if err := json.Unmarshal(body, &result); err != nil {
-		return nil, fmt.Errorf("decode stacks response: %w", err)
-	}
-	return result, nil
+	return get[map[string]StackInfo](ctx, c, path, nil)
 }

--- a/internal/bitriseapi/yml.go
+++ b/internal/bitriseapi/yml.go
@@ -2,8 +2,6 @@ package bitriseapi
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
 	"net/url"
 )
 
@@ -67,16 +65,7 @@ func (c *Client) ValidateBitriseYML(ctx context.Context, yamlContent, appSlug st
 		params = url.Values{"app_slug": {appSlug}}
 	}
 
-	body, err := c.post(ctx, "/validate-bitrise-yml", params, struct {
+	return postDecode[ValidateBitriseYMLResponse](ctx, c, "/validate-bitrise-yml", params, struct {
 		BitriseYML string `json:"bitrise_yml"`
 	}{BitriseYML: yamlContent})
-	if err != nil {
-		return ValidateBitriseYMLResponse{}, err
-	}
-
-	var resp ValidateBitriseYMLResponse
-	if err := json.Unmarshal(body, &resp); err != nil {
-		return ValidateBitriseYMLResponse{}, fmt.Errorf("decode response: %w", err)
-	}
-	return resp, nil
 }

--- a/output/output.go
+++ b/output/output.go
@@ -3,6 +3,7 @@ package output
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 
 	"gopkg.in/yaml.v2"
 
@@ -37,6 +38,15 @@ func ConfigureOutputFormat(outFmt string) error {
 		return fmt.Errorf("invalid output format: %s", outFmt)
 	}
 	return nil
+}
+
+// Render writes result via renderRaw for FormatRaw, or via Print otherwise —
+// the "raw table/text vs. json/yml" branch every command needs, in one place.
+func Render[T any](w io.Writer, format string, result T, renderRaw func(io.Writer, T) error) error {
+	if format == FormatRaw {
+		return renderRaw(w, result)
+	}
+	return Print(result, format)
 }
 
 // Print marshals outModel per format and writes it via the logger. Returns an


### PR DESCRIPTION
Pulls two duplicated patterns out of the upcoming build-commands change: the raw-vs-json/yml branch every command's `RunE` repeats (now `output.Render`), and the request/decode boilerplate every `bitriseapi` method repeats (now generic `get/getEnvelope/getPage/postDecode` helpers). Adopts both across the existing `app/config/stack/user/yml` commands and API methods. No behavior change.