### PR TITLE
v3 prep: build service layer and Bitrise API client

### DIFF
--- a/internal/bitriseapi/builds.go
+++ b/internal/bitriseapi/builds.go
@@ -1,0 +1,293 @@
+package bitriseapi
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"slices"
+	"strconv"
+	"time"
+)
+
+// Build is the wire-format build record returned by the Bitrise API. Many
+// fields are populated only for finished builds; treat empty values as "not
+// yet set".
+type Build struct {
+	Slug                    string    `json:"slug"`
+	BuildNumber             int       `json:"build_number"`
+	Status                  int       `json:"status"`
+	StatusText              string    `json:"status_text,omitempty"`
+	AbortReason             string    `json:"abort_reason,omitempty"`
+	Branch                  string    `json:"branch,omitempty"`
+	TriggeredWorkflow       string    `json:"triggered_workflow,omitempty"`
+	PipelineWorkflowID      string    `json:"pipeline_workflow_id,omitempty"`
+	CommitHash              string    `json:"commit_hash,omitempty"`
+	CommitMessage           string    `json:"commit_message,omitempty"`
+	Tag                     string    `json:"tag,omitempty"`
+	PullRequestID           int       `json:"pull_request_id,omitempty"`
+	PullRequestTargetBranch string    `json:"pull_request_target_branch,omitempty"`
+	PullRequestViewURL      string    `json:"pull_request_view_url,omitempty"`
+	TriggeredAt             time.Time `json:"triggered_at,omitempty"`
+	FinishedAt              time.Time `json:"finished_at,omitempty"`
+	TriggeredBy             string    `json:"triggered_by,omitempty"`
+	StackIdentifier         string    `json:"stack_identifier,omitempty"`
+	MachineTypeID           string    `json:"machine_type_id,omitempty"`
+	CreditCost              int       `json:"credit_cost,omitempty"`
+	IsOnHold                bool      `json:"is_on_hold,omitempty"`
+	Rebuildable             bool      `json:"rebuildable,omitempty"`
+}
+
+// BuildsListOptions filters and paginates GET /apps/{app-slug}/builds. All
+// fields are optional. Field names match the API's query parameters.
+type BuildsListOptions struct {
+	SortBy           string // "created_at" (default) or "running_first"
+	Branch           string
+	Workflow         string
+	CommitMessage    string
+	TriggerEventType string // push, pull-request, tag
+	PullRequestID    int
+	BuildNumber      int
+	After            int // unix timestamp
+	Before           int // unix timestamp
+	// Status is the integer status filter the API accepts: 0=in-progress,
+	// 1=success, 2=failed, 3=aborted, 4=aborted-with-success. Tri-state
+	// pointer because 0 is a meaningful filter value, not "unset".
+	Status          *int
+	IsPipelineBuild *bool // tri-state: nil=unset, true/false sent literally
+	Next            string
+	Limit           int
+}
+
+func (o BuildsListOptions) params() url.Values {
+	p := url.Values{}
+	if o.SortBy != "" {
+		p.Set("sort_by", o.SortBy)
+	}
+	if o.Branch != "" {
+		p.Set("branch", o.Branch)
+	}
+	if o.Workflow != "" {
+		p.Set("workflow", o.Workflow)
+	}
+	if o.CommitMessage != "" {
+		p.Set("commit_message", o.CommitMessage)
+	}
+	if o.TriggerEventType != "" {
+		p.Set("trigger_event_type", o.TriggerEventType)
+	}
+	if o.PullRequestID > 0 {
+		p.Set("pull_request_id", strconv.Itoa(o.PullRequestID))
+	}
+	if o.BuildNumber > 0 {
+		p.Set("build_number", strconv.Itoa(o.BuildNumber))
+	}
+	if o.After > 0 {
+		p.Set("after", strconv.Itoa(o.After))
+	}
+	if o.Before > 0 {
+		p.Set("before", strconv.Itoa(o.Before))
+	}
+	if o.Status != nil {
+		p.Set("status", strconv.Itoa(*o.Status))
+	}
+	if o.IsPipelineBuild != nil {
+		p.Set("is_pipeline_build", strconv.FormatBool(*o.IsPipelineBuild))
+	}
+	if o.Next != "" {
+		p.Set("next", o.Next)
+	}
+	if o.Limit > 0 {
+		p.Set("limit", strconv.Itoa(o.Limit))
+	}
+	return p
+}
+
+// Builds returns one page of builds for an app, and the cursor for the next
+// page ("" when there isn't one).
+// Endpoint: GET /apps/{app-slug}/builds.
+func (c *Client) Builds(ctx context.Context, appSlug string, opts BuildsListOptions) ([]Build, string, error) {
+	return getPage[Build](ctx, c, "/apps/"+url.PathEscape(appSlug)+"/builds", opts.params())
+}
+
+// Build returns details for a single build.
+// Endpoint: GET /apps/{app-slug}/builds/{build-slug}.
+func (c *Client) Build(ctx context.Context, appSlug, buildSlug string) (Build, error) {
+	return getEnvelope[Build](ctx, c, "/apps/"+url.PathEscape(appSlug)+"/builds/"+url.PathEscape(buildSlug), nil)
+}
+
+// TriggerBuildRequest is the JSON body sent to POST /apps/{app-slug}/builds.
+type TriggerBuildRequest struct {
+	HookInfo    TriggerBuildHookInfo `json:"hook_info"`
+	BuildParams TriggerBuildParams   `json:"build_params"`
+}
+
+// TriggerBuildHookInfo identifies the trigger source. CLI-initiated builds
+// use type="bitrise".
+type TriggerBuildHookInfo struct {
+	Type string `json:"type"`
+}
+
+// TriggerBuildEnv is a single environment variable injected into a triggered
+// build.
+type TriggerBuildEnv struct {
+	MappedTo string `json:"mapped_to"`
+	Value    string `json:"value"`
+	IsExpand bool   `json:"is_expand"`
+}
+
+// TriggerBuildParams holds the build-specific parameters of a trigger
+// request. Most fields are optional; the API derives defaults from the
+// app's trigger map and bitrise.yml when omitted.
+type TriggerBuildParams struct {
+	WorkflowID    string            `json:"workflow_id,omitempty"`
+	PipelineID    string            `json:"pipeline_id,omitempty"`
+	Branch        string            `json:"branch,omitempty"`
+	BranchDest    string            `json:"branch_dest,omitempty"`
+	Tag           string            `json:"tag,omitempty"`
+	CommitHash    string            `json:"commit_hash,omitempty"`
+	CommitMessage string            `json:"commit_message,omitempty"`
+	PullRequestID int               `json:"pull_request_id,omitempty"`
+	Priority      int               `json:"priority,omitempty"`
+	Environments  []TriggerBuildEnv `json:"environments,omitempty"`
+}
+
+// TriggerBuildResponse is the response from POST /apps/{app-slug}/builds.
+// The deprecated top-level fields and the modern Results array carry
+// overlapping information; for a single-result trigger, the top-level
+// fields are used. Results is the source of truth when the API splits a
+// pipeline trigger across multiple workflows.
+type TriggerBuildResponse struct {
+	BuildSlug         string                     `json:"build_slug,omitempty"`
+	BuildNumber       int                        `json:"build_number,omitempty"`
+	BuildURL          string                     `json:"build_url,omitempty"`
+	TriggeredWorkflow string                     `json:"triggered_workflow,omitempty"`
+	Service           string                     `json:"service,omitempty"`
+	Status            string                     `json:"status,omitempty"`
+	Message           string                     `json:"message,omitempty"`
+	Slug              string                     `json:"slug,omitempty"`
+	Results           []TriggerBuildResponseItem `json:"results,omitempty"`
+}
+
+// TriggerBuildResponseItem is one entry from TriggerBuildResponse.Results.
+type TriggerBuildResponseItem struct {
+	BuildSlug         string `json:"build_slug,omitempty"`
+	BuildNumber       int    `json:"build_number,omitempty"`
+	BuildURL          string `json:"build_url,omitempty"`
+	TriggeredWorkflow string `json:"triggered_workflow,omitempty"`
+	TriggeredPipeline string `json:"triggered_pipeline,omitempty"`
+	Status            string `json:"status,omitempty"`
+	Message           string `json:"message,omitempty"`
+}
+
+// TriggerBuild starts a new build.
+// Endpoint: POST /apps/{app-slug}/builds.
+func (c *Client) TriggerBuild(ctx context.Context, appSlug string, req TriggerBuildRequest) (TriggerBuildResponse, error) {
+	return postDecode[TriggerBuildResponse](ctx, c, "/apps/"+url.PathEscape(appSlug)+"/builds", nil, req)
+}
+
+// AbortBuildRequest is the JSON body for POST /apps/{app-slug}/builds/{build-slug}/abort.
+type AbortBuildRequest struct {
+	AbortReason         string `json:"abort_reason,omitempty"`
+	AbortWithSuccess    bool   `json:"abort_with_success,omitempty"`
+	SkipGitStatusReport bool   `json:"skip_git_status_report,omitempty"`
+	SkipNotifications   bool   `json:"skip_notifications,omitempty"`
+}
+
+// AbortBuildResponse is the response from POST /apps/{app-slug}/builds/{build-slug}/abort.
+type AbortBuildResponse struct {
+	Status string `json:"status"`
+}
+
+// AbortBuild stops a running or queued build.
+// Endpoint: POST /apps/{app-slug}/builds/{build-slug}/abort.
+func (c *Client) AbortBuild(ctx context.Context, appSlug, buildSlug string, req AbortBuildRequest) (AbortBuildResponse, error) {
+	return postDecode[AbortBuildResponse](ctx, c, "/apps/"+url.PathEscape(appSlug)+"/builds/"+url.PathEscape(buildSlug)+"/abort", nil, req)
+}
+
+// BuildLogResponse is the JSON returned by GET /apps/{app-slug}/builds/{build-slug}/log.
+//
+// Behavior depends on whether the build is finished: for archived builds,
+// ExpiringRawLogURL points at a time-limited URL (typically S3) holding the
+// full log and LogChunks may be empty. For in-progress builds, LogChunks
+// holds the new chunks since the requested afterTimestamp, and
+// NextAfterTimestamp carries the value to pass on the next poll.
+type BuildLogResponse struct {
+	ExpiringRawLogURL  string          `json:"expiring_raw_log_url,omitempty"`
+	IsArchived         bool            `json:"is_archived"`
+	LogChunks          []BuildLogChunk `json:"log_chunks,omitempty"`
+	NextAfterTimestamp string          `json:"next_after_timestamp,omitempty"`
+}
+
+// BuildLogChunk is one piece of build log output.
+type BuildLogChunk struct {
+	Chunk    string `json:"chunk"`
+	Position int    `json:"position"`
+}
+
+// BuildLogManifest fetches the log manifest for a build. afterTimestamp is
+// sent as the after_timestamp query parameter to request only log chunks
+// newer than that value; pass "" for the first call or a full log fetch.
+// Endpoint: GET /apps/{app-slug}/builds/{build-slug}/log.
+func (c *Client) BuildLogManifest(ctx context.Context, appSlug, buildSlug, afterTimestamp string) (BuildLogResponse, error) {
+	var params url.Values
+	if afterTimestamp != "" {
+		params = url.Values{"after_timestamp": {afterTimestamp}}
+	}
+	return get[BuildLogResponse](ctx, c, "/apps/"+url.PathEscape(appSlug)+"/builds/"+url.PathEscape(buildSlug)+"/log", params)
+}
+
+// BuildLog fetches the log for a build and writes it to w.
+//
+// For archived (finished) builds, the full log is downloaded from
+// ExpiringRawLogURL. For in-progress builds, whatever chunks are currently
+// available are written — the caller can re-run to see more. Returns the
+// manifest so callers can inspect IsArchived (e.g. to print a "still
+// running" hint).
+func (c *Client) BuildLog(ctx context.Context, appSlug, buildSlug string, w io.Writer) (BuildLogResponse, error) {
+	manifest, err := c.BuildLogManifest(ctx, appSlug, buildSlug, "")
+	if err != nil {
+		return manifest, err
+	}
+	if manifest.ExpiringRawLogURL != "" {
+		if err := c.streamRawLog(ctx, manifest.ExpiringRawLogURL, w); err != nil {
+			return manifest, err
+		}
+		return manifest, nil
+	}
+	// The API collects chunks from parallel producers and does not guarantee
+	// order even within a single manifest response (Service.Watch reorders
+	// across polls for the same reason). Clone so the returned manifest
+	// keeps the server's original ordering.
+	chunks := slices.Clone(manifest.LogChunks)
+	slices.SortFunc(chunks, func(a, b BuildLogChunk) int { return a.Position - b.Position })
+	for _, chunk := range chunks {
+		if _, err := io.WriteString(w, chunk.Chunk); err != nil {
+			return manifest, fmt.Errorf("write log chunk: %w", err)
+		}
+	}
+	return manifest, nil
+}
+
+// streamRawLog GETs rawURL and copies the body to w. rawURL is expected to
+// be a presigned URL from BuildLogResponse.ExpiringRawLogURL — no auth
+// header is sent to it.
+func (c *Client) streamRawLog(ctx context.Context, rawURL string, w io.Writer) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		return fmt.Errorf("build log URL request: %w", err)
+	}
+	resp, err := c.streamHTTPClient().Do(req)
+	if err != nil {
+		return fmt.Errorf("fetch raw log: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("fetch raw log: HTTP %d", resp.StatusCode)
+	}
+	if _, err := io.Copy(w, resp.Body); err != nil {
+		return fmt.Errorf("stream raw log: %w", err)
+	}
+	return nil
+}

--- a/internal/bitriseapi/builds_test.go
+++ b/internal/bitriseapi/builds_test.go
@@ -1,0 +1,330 @@
+package bitriseapi
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuilds_PathAndQueryParams(t *testing.T) {
+	var gotPath, gotQuery string
+	srv := newFakeServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotQuery = r.URL.RawQuery
+		_, _ = w.Write([]byte(`{"data":[],"paging":{"next":""}}`))
+	})
+
+	status := 1
+	pipelineBuild := true
+	_, _, err := newAPIClient(t, srv.URL, "t").Builds(context.Background(), "my-app", BuildsListOptions{
+		Branch:          "main",
+		Workflow:        "deploy",
+		Status:          &status,
+		IsPipelineBuild: &pipelineBuild,
+		Limit:           20,
+		Next:            "cur",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "/apps/my-app/builds", gotPath)
+	q, err := url.ParseQuery(gotQuery)
+	require.NoError(t, err)
+	assert.Equal(t, "main", q.Get("branch"))
+	assert.Equal(t, "deploy", q.Get("workflow"))
+	assert.Equal(t, "1", q.Get("status"))
+	assert.Equal(t, "true", q.Get("is_pipeline_build"))
+	assert.Equal(t, "20", q.Get("limit"))
+	assert.Equal(t, "cur", q.Get("next"))
+}
+
+func TestBuilds_StatusZeroIsValidFilter(t *testing.T) {
+	var gotQuery string
+	srv := newFakeServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.RawQuery
+		_, _ = w.Write([]byte(`{"data":[]}`))
+	})
+
+	zero := 0
+	_, _, err := newAPIClient(t, srv.URL, "t").Builds(context.Background(), "my-app", BuildsListOptions{Status: &zero})
+	require.NoError(t, err)
+	q, err := url.ParseQuery(gotQuery)
+	require.NoError(t, err)
+	assert.Equal(t, "0", q.Get("status"))
+}
+
+func TestBuilds_NoStatusOmitsParam(t *testing.T) {
+	var gotQuery string
+	srv := newFakeServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.RawQuery
+		_, _ = w.Write([]byte(`{"data":[]}`))
+	})
+
+	_, _, err := newAPIClient(t, srv.URL, "t").Builds(context.Background(), "my-app", BuildsListOptions{})
+	require.NoError(t, err)
+	q, err := url.ParseQuery(gotQuery)
+	require.NoError(t, err)
+	assert.False(t, q.Has("status"), "status query param should be omitted when filter is nil")
+}
+
+func TestBuilds_ParsesResponse(t *testing.T) {
+	srv := newFakeServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{
+  "data": [
+    {
+      "slug": "build-1",
+      "build_number": 42,
+      "status": 1,
+      "status_text": "success",
+      "branch": "main",
+      "triggered_workflow": "primary",
+      "commit_hash": "deadbeef",
+      "triggered_at": "2026-05-06T10:00:00Z",
+      "finished_at": "2026-05-06T10:05:00Z"
+    }
+  ],
+  "paging": {"next": "cursor-abc"}
+}`))
+	})
+
+	builds, next, err := newAPIClient(t, srv.URL, "t").Builds(context.Background(), "my-app", BuildsListOptions{})
+	require.NoError(t, err)
+	require.Len(t, builds, 1)
+	b := builds[0]
+	assert.Equal(t, "build-1", b.Slug)
+	assert.Equal(t, 42, b.BuildNumber)
+	assert.Equal(t, 1, b.Status)
+	assert.False(t, b.TriggeredAt.IsZero())
+	assert.False(t, b.FinishedAt.IsZero())
+	assert.Equal(t, "cursor-abc", next)
+}
+
+func TestBuild_Single(t *testing.T) {
+	var gotPath string
+	srv := newFakeServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		_, _ = w.Write([]byte(`{"data":{"slug":"build-xyz","build_number":7,"status":2,"status_text":"failed","triggered_workflow":"deploy"}}`))
+	})
+
+	b, err := newAPIClient(t, srv.URL, "t").Build(context.Background(), "my-app", "build-xyz")
+	require.NoError(t, err)
+	assert.Equal(t, "/apps/my-app/builds/build-xyz", gotPath)
+	assert.Equal(t, "build-xyz", b.Slug)
+	assert.Equal(t, 7, b.BuildNumber)
+	assert.Equal(t, 2, b.Status)
+	assert.Equal(t, "deploy", b.TriggeredWorkflow)
+}
+
+func TestTriggerBuild_RequestAndResponse(t *testing.T) {
+	var gotMethod, gotPath, gotContentType string
+	var gotBody []byte
+	srv := newFakeServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		gotContentType = r.Header.Get("Content-Type")
+		gotBody, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{
+  "build_slug": "new-build-001",
+  "build_number": 99,
+  "build_url": "https://app.bitrise.io/build/new-build-001",
+  "triggered_workflow": "deploy",
+  "status": "ok",
+  "message": "Build triggered"
+}`))
+	})
+
+	resp, err := newAPIClient(t, srv.URL, "t").TriggerBuild(context.Background(), "my-app", TriggerBuildRequest{
+		HookInfo: TriggerBuildHookInfo{Type: "bitrise"},
+		BuildParams: TriggerBuildParams{
+			WorkflowID: "deploy",
+			Branch:     "release/2.0",
+			CommitHash: "abc123",
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, http.MethodPost, gotMethod)
+	assert.Equal(t, "/apps/my-app/builds", gotPath)
+	assert.Equal(t, "application/json", gotContentType)
+
+	var sent map[string]any
+	require.NoError(t, json.Unmarshal(gotBody, &sent))
+	hi, _ := sent["hook_info"].(map[string]any)
+	assert.Equal(t, "bitrise", hi["type"])
+	bp, _ := sent["build_params"].(map[string]any)
+	assert.Equal(t, "deploy", bp["workflow_id"])
+	assert.Equal(t, "release/2.0", bp["branch"])
+	assert.Equal(t, "abc123", bp["commit_hash"])
+
+	assert.Equal(t, "new-build-001", resp.BuildSlug)
+	assert.Equal(t, 99, resp.BuildNumber)
+	assert.NotEmpty(t, resp.BuildURL)
+}
+
+func TestTriggerBuild_PropagatesAPIError(t *testing.T) {
+	srv := newFakeServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"message":"workflow_id is required"}`))
+	})
+
+	_, err := newAPIClient(t, srv.URL, "t").TriggerBuild(context.Background(), "my-app", TriggerBuildRequest{})
+	require.Error(t, err)
+	apiErr, ok := err.(*APIError)
+	require.True(t, ok, "expected *APIError, got %T", err)
+	assert.Equal(t, http.StatusBadRequest, apiErr.StatusCode)
+}
+
+func TestAbortBuild_RequestAndResponse(t *testing.T) {
+	var gotMethod, gotPath string
+	var gotBody []byte
+	srv := newFakeServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		gotBody, _ = io.ReadAll(r.Body)
+		_, _ = w.Write([]byte(`{"status":"ok"}`))
+	})
+
+	resp, err := newAPIClient(t, srv.URL, "t").AbortBuild(context.Background(), "my-app", "build-1", AbortBuildRequest{
+		AbortReason:      "no longer needed",
+		AbortWithSuccess: true,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, http.MethodPost, gotMethod)
+	assert.Equal(t, "/apps/my-app/builds/build-1/abort", gotPath)
+	assert.Equal(t, AbortBuildResponse{Status: "ok"}, resp)
+	assert.JSONEq(t, `{"abort_reason":"no longer needed","abort_with_success":true}`, string(gotBody))
+}
+
+func TestAbortBuild_PropagatesAPIError(t *testing.T) {
+	srv := newFakeServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"message":"build not found"}`))
+	})
+
+	_, err := newAPIClient(t, srv.URL, "t").AbortBuild(context.Background(), "my-app", "missing", AbortBuildRequest{})
+	require.Error(t, err)
+	apiErr, ok := err.(*APIError)
+	require.True(t, ok, "expected *APIError, got %T", err)
+	assert.Equal(t, http.StatusNotFound, apiErr.StatusCode)
+}
+
+func TestBuildLog_StreamsArchivedURL(t *testing.T) {
+	var gotAuthHeader string
+	rawSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuthHeader = r.Header.Get("Authorization")
+		_, _ = w.Write([]byte("FULL ARCHIVED LOG CONTENT\n"))
+	}))
+	t.Cleanup(rawSrv.Close)
+
+	apiSrv := newFakeServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"is_archived":          true,
+			"expiring_raw_log_url": rawSrv.URL,
+		})
+	})
+
+	var buf bytes.Buffer
+	manifest, err := newAPIClient(t, apiSrv.URL, "t").BuildLog(context.Background(), "my-app", "my-build", &buf)
+	require.NoError(t, err)
+	assert.True(t, manifest.IsArchived)
+	assert.Contains(t, buf.String(), "FULL ARCHIVED LOG CONTENT")
+	assert.Empty(t, gotAuthHeader, "the presigned URL must not receive our Authorization header")
+}
+
+func TestBuildLog_StreamsChunksWhenNotArchived(t *testing.T) {
+	apiSrv := newFakeServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{
+  "is_archived": false,
+  "log_chunks": [
+    {"chunk": "first chunk\n", "position": 0},
+    {"chunk": "second chunk\n", "position": 1}
+  ]
+}`))
+	})
+
+	var buf bytes.Buffer
+	manifest, err := newAPIClient(t, apiSrv.URL, "t").BuildLog(context.Background(), "my-app", "my-build", &buf)
+	require.NoError(t, err)
+	assert.False(t, manifest.IsArchived)
+	assert.Contains(t, buf.String(), "first chunk")
+	assert.Contains(t, buf.String(), "second chunk")
+}
+
+func TestBuildLog_OutOfOrderChunksAreSorted(t *testing.T) {
+	apiSrv := newFakeServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{
+  "is_archived": false,
+  "log_chunks": [
+    {"chunk": "b\n", "position": 1},
+    {"chunk": "a\n", "position": 0}
+  ]
+}`))
+	})
+
+	var buf bytes.Buffer
+	_, err := newAPIClient(t, apiSrv.URL, "t").BuildLog(context.Background(), "my-app", "my-build", &buf)
+	require.NoError(t, err)
+	assert.Equal(t, "a\nb\n", buf.String())
+}
+
+func TestBuildLog_PropagatesManifestError(t *testing.T) {
+	apiSrv := newFakeServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"message":"build not found"}`))
+	})
+
+	var buf bytes.Buffer
+	_, err := newAPIClient(t, apiSrv.URL, "t").BuildLog(context.Background(), "my-app", "missing", &buf)
+	require.Error(t, err)
+	assert.Empty(t, buf.String(), "buffer should be untouched on error")
+}
+
+func TestBuildLogManifest_SendsAfterTimestampParam(t *testing.T) {
+	var gotQuery string
+	srv := newFakeServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.RawQuery
+		_, _ = w.Write([]byte(`{"is_archived":false}`))
+	})
+
+	_, err := newAPIClient(t, srv.URL, "t").BuildLogManifest(context.Background(), "my-app", "my-build", "ts-abc")
+	require.NoError(t, err)
+	q, err := url.ParseQuery(gotQuery)
+	require.NoError(t, err)
+	assert.Equal(t, "ts-abc", q.Get("after_timestamp"))
+}
+
+func TestBuildLogManifest_OmitsAfterTimestampWhenEmpty(t *testing.T) {
+	var gotQuery string
+	srv := newFakeServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.RawQuery
+		_, _ = w.Write([]byte(`{"is_archived":false}`))
+	})
+
+	_, err := newAPIClient(t, srv.URL, "t").BuildLogManifest(context.Background(), "my-app", "my-build", "")
+	require.NoError(t, err)
+	q, err := url.ParseQuery(gotQuery)
+	require.NoError(t, err)
+	assert.False(t, q.Has("after_timestamp"), "after_timestamp should be omitted on first call")
+}
+
+func TestBuildLogManifest_ParsesNextAfterTimestamp(t *testing.T) {
+	srv := newFakeServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{
+  "is_archived": false,
+  "next_after_timestamp": "2026-05-06T10:01:00Z",
+  "log_chunks": [{"chunk": "hello\n", "position": 0}]
+}`))
+	})
+
+	manifest, err := newAPIClient(t, srv.URL, "t").BuildLogManifest(context.Background(), "my-app", "my-build", "")
+	require.NoError(t, err)
+	assert.Equal(t, "2026-05-06T10:01:00Z", manifest.NextAfterTimestamp)
+	require.Len(t, manifest.LogChunks, 1)
+	assert.Equal(t, "hello\n", manifest.LogChunks[0].Chunk)
+}

--- a/internal/bitriseapi/client.go
+++ b/internal/bitriseapi/client.go
@@ -146,6 +146,18 @@ func (c *Client) post(ctx context.Context, path string, params url.Values, body 
 	return c.do(req)
 }
 
+// streamHTTPClient returns an http.Client sharing the configured client's
+// transport, but with no overall timeout — for downloading a build's
+// archived log, which can be large and legitimately slower than
+// defaultTimeout. Cancellation is left to the caller's context.
+func (c *Client) streamHTTPClient() *http.Client {
+	return &http.Client{
+		Transport:     c.httpClient.Transport,
+		CheckRedirect: c.httpClient.CheckRedirect,
+		Jar:           c.httpClient.Jar,
+	}
+}
+
 // get performs an authenticated GET against path and decodes the JSON
 // response body into T.
 func get[T any](ctx context.Context, c *Client, path string, params url.Values) (T, error) {

--- a/internal/build/service.go
+++ b/internal/build/service.go
@@ -1,0 +1,406 @@
+// Package build holds the business-logic layer for build operations.
+package build
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/bitrise-io/bitrise/v2/internal/bitriseapi"
+)
+
+// Build is the CLI-facing build record. JSON/YAML tags define the stable
+// --format json/yml shape.
+type Build struct {
+	Slug                    string     `json:"id" yaml:"id"`
+	AppSlug                 string     `json:"app_id" yaml:"app_id"`
+	BuildNumber             int        `json:"build_number" yaml:"build_number"`
+	Status                  string     `json:"status" yaml:"status"`
+	StatusText              string     `json:"status_text,omitempty" yaml:"status_text,omitempty"`
+	AbortReason             string     `json:"abort_reason,omitempty" yaml:"abort_reason,omitempty"`
+	IsOnHold                bool       `json:"is_on_hold,omitempty" yaml:"is_on_hold,omitempty"`
+	Rebuildable             bool       `json:"rebuildable,omitempty" yaml:"rebuildable,omitempty"`
+	Workflow                string     `json:"workflow,omitempty" yaml:"workflow,omitempty"`
+	PipelineWorkflowID      string     `json:"pipeline_workflow_id,omitempty" yaml:"pipeline_workflow_id,omitempty"`
+	Branch                  string     `json:"branch,omitempty" yaml:"branch,omitempty"`
+	Tag                     string     `json:"tag,omitempty" yaml:"tag,omitempty"`
+	PullRequestID           int        `json:"pull_request_id,omitempty" yaml:"pull_request_id,omitempty"`
+	PullRequestTargetBranch string     `json:"pull_request_target_branch,omitempty" yaml:"pull_request_target_branch,omitempty"`
+	PullRequestViewURL      string     `json:"pull_request_view_url,omitempty" yaml:"pull_request_view_url,omitempty"`
+	CommitHash              string     `json:"commit_hash,omitempty" yaml:"commit_hash,omitempty"`
+	CommitMessage           string     `json:"commit_message,omitempty" yaml:"commit_message,omitempty"`
+	TriggeredAt             time.Time  `json:"triggered_at,omitempty" yaml:"triggered_at,omitempty"`
+	TriggeredBy             string     `json:"triggered_by,omitempty" yaml:"triggered_by,omitempty"`
+	FinishedAt              *time.Time `json:"finished_at,omitempty" yaml:"finished_at,omitempty"`
+	StackIdentifier         string     `json:"stack_identifier,omitempty" yaml:"stack_identifier,omitempty"`
+	MachineTypeID           string     `json:"machine_type_id,omitempty" yaml:"machine_type_id,omitempty"`
+	CreditCost              int        `json:"credit_cost,omitempty" yaml:"credit_cost,omitempty"`
+	BuildURL                string     `json:"build_url,omitempty" yaml:"build_url,omitempty"`
+}
+
+// TriggerEnv is an environment variable to inject into a triggered build.
+type TriggerEnv struct {
+	Key   string
+	Value string
+}
+
+// TriggerRequest describes a build to start.
+type TriggerRequest struct {
+	AppSlug       string
+	Workflow      string
+	Pipeline      string
+	Branch        string
+	BranchDest    string
+	Tag           string
+	CommitHash    string
+	CommitMessage string
+	PullRequestID int
+	Priority      int
+	Environments  []TriggerEnv
+}
+
+// ListOptions filters and paginates build lists. Status is a CLI-friendly
+// string ("success", "failed", "aborted", "aborted-with-success",
+// "in-progress"); the service translates it to the API's integer value.
+// IsPipelineBuild is a tri-state: nil = no filter, true/false = filtered.
+type ListOptions struct {
+	AppSlug          string
+	Branch           string
+	Workflow         string
+	CommitMessage    string
+	TriggerEventType string
+	PullRequestID    int
+	BuildNumber      int
+	After            *time.Time
+	Before           *time.Time
+	Status           string
+	SortBy           string
+	IsPipelineBuild  *bool
+	Limit            int
+	Cursor           string
+}
+
+// ListResult is one page of builds plus the cursor for the next page.
+type ListResult struct {
+	Items      []Build `json:"items" yaml:"items"`
+	NextCursor string  `json:"next_cursor,omitempty" yaml:"next_cursor,omitempty"`
+}
+
+// Service exposes build operations to the cmd layer.
+type Service struct {
+	client *bitriseapi.Client
+}
+
+// NewService returns a Service backed by the given API client. The client
+// must be non-nil — every method makes a network call.
+func NewService(client *bitriseapi.Client) *Service {
+	return &Service{client: client}
+}
+
+// Trigger starts a new build for the given app + workflow.
+// Endpoint: POST /apps/{app-slug}/builds.
+func (s *Service) Trigger(ctx context.Context, req TriggerRequest) (Build, error) {
+	if s.client == nil {
+		return Build{}, fmt.Errorf("API client not configured")
+	}
+	if req.AppSlug == "" {
+		return Build{}, fmt.Errorf("app ID is required")
+	}
+	envs := make([]bitriseapi.TriggerBuildEnv, 0, len(req.Environments))
+	for _, e := range req.Environments {
+		envs = append(envs, bitriseapi.TriggerBuildEnv{MappedTo: e.Key, Value: e.Value, IsExpand: true})
+	}
+	resp, err := s.client.TriggerBuild(ctx, req.AppSlug, bitriseapi.TriggerBuildRequest{
+		HookInfo: bitriseapi.TriggerBuildHookInfo{Type: "bitrise"},
+		BuildParams: bitriseapi.TriggerBuildParams{
+			WorkflowID:    req.Workflow,
+			PipelineID:    req.Pipeline,
+			Branch:        req.Branch,
+			BranchDest:    req.BranchDest,
+			Tag:           req.Tag,
+			CommitHash:    req.CommitHash,
+			CommitMessage: req.CommitMessage,
+			PullRequestID: req.PullRequestID,
+			Priority:      req.Priority,
+			Environments:  envs,
+		},
+	})
+	if err != nil {
+		var apiErr *bitriseapi.APIError
+		if errors.As(err, &apiErr) && apiErr.StatusCode == http.StatusNotFound {
+			return Build{}, fmt.Errorf("app %q not found", req.AppSlug)
+		}
+		return Build{}, err
+	}
+	return triggerRespToBuild(resp, req), nil
+}
+
+// List returns one page of builds for an app.
+// Endpoint: GET /apps/{app-slug}/builds.
+func (s *Service) List(ctx context.Context, opts ListOptions) (ListResult, error) {
+	if s.client == nil {
+		return ListResult{}, fmt.Errorf("API client not configured")
+	}
+	if opts.AppSlug == "" {
+		return ListResult{}, fmt.Errorf("app is required")
+	}
+	statusInt, err := parseStatusFilter(opts.Status)
+	if err != nil {
+		return ListResult{}, err
+	}
+	apiOpts := bitriseapi.BuildsListOptions{
+		SortBy:           opts.SortBy,
+		Branch:           opts.Branch,
+		Workflow:         opts.Workflow,
+		CommitMessage:    opts.CommitMessage,
+		TriggerEventType: opts.TriggerEventType,
+		PullRequestID:    opts.PullRequestID,
+		BuildNumber:      opts.BuildNumber,
+		Status:           statusInt,
+		IsPipelineBuild:  opts.IsPipelineBuild,
+		Limit:            opts.Limit,
+		Next:             opts.Cursor,
+	}
+	if opts.After != nil {
+		apiOpts.After = int(opts.After.Unix())
+	}
+	if opts.Before != nil {
+		apiOpts.Before = int(opts.Before.Unix())
+	}
+	builds, nextCursor, err := s.client.Builds(ctx, opts.AppSlug, apiOpts)
+	if err != nil {
+		var apiErr *bitriseapi.APIError
+		if errors.As(err, &apiErr) && apiErr.StatusCode == http.StatusNotFound {
+			return ListResult{}, fmt.Errorf("app %q not found", opts.AppSlug)
+		}
+		return ListResult{}, err
+	}
+	items := make([]Build, 0, len(builds))
+	for _, b := range builds {
+		items = append(items, fromAPI(b, opts.AppSlug))
+	}
+	return ListResult{Items: items, NextCursor: nextCursor}, nil
+}
+
+// View returns details for a single build.
+// Endpoint: GET /apps/{app-slug}/builds/{build-slug}.
+func (s *Service) View(ctx context.Context, appSlug, buildSlug string) (Build, error) {
+	if s.client == nil {
+		return Build{}, fmt.Errorf("API client not configured")
+	}
+	if appSlug == "" {
+		return Build{}, fmt.Errorf("app ID is required")
+	}
+	if buildSlug == "" {
+		return Build{}, fmt.Errorf("build ID is required")
+	}
+	b, err := s.client.Build(ctx, appSlug, buildSlug)
+	if err != nil {
+		var apiErr *bitriseapi.APIError
+		if errors.As(err, &apiErr) && apiErr.StatusCode == http.StatusNotFound {
+			return Build{}, fmt.Errorf("build %q not found", buildSlug)
+		}
+		return Build{}, err
+	}
+	return fromAPI(b, appSlug), nil
+}
+
+// Log streams the build log for the given build to w. For finished builds
+// the full archived log is streamed; for in-progress builds the chunks
+// available so far are written.
+// Endpoint: GET /apps/{app-slug}/builds/{build-slug}/log.
+func (s *Service) Log(ctx context.Context, appSlug, buildSlug string, w io.Writer) error {
+	if s.client == nil {
+		return fmt.Errorf("API client not configured")
+	}
+	if appSlug == "" {
+		return fmt.Errorf("app ID is required")
+	}
+	if buildSlug == "" {
+		return fmt.Errorf("build ID is required")
+	}
+	_, err := s.client.BuildLog(ctx, appSlug, buildSlug, w)
+	if err != nil {
+		var apiErr *bitriseapi.APIError
+		if errors.As(err, &apiErr) && apiErr.StatusCode == http.StatusNotFound {
+			return fmt.Errorf("build %q not found", buildSlug)
+		}
+		return err
+	}
+	return nil
+}
+
+// AbortRequest describes a build-abort operation.
+type AbortRequest struct {
+	AppSlug             string
+	BuildSlug           string
+	Reason              string
+	AbortWithSuccess    bool
+	SkipGitStatusReport bool
+	SkipNotifications   bool
+}
+
+// AbortResult is the CLI-facing result of aborting a build.
+type AbortResult struct {
+	AppSlug   string `json:"app_id" yaml:"app_id"`
+	BuildSlug string `json:"build_id" yaml:"build_id"`
+	Status    string `json:"status" yaml:"status"`
+}
+
+// Abort stops a running or queued build.
+// Endpoint: POST /apps/{app-slug}/builds/{build-slug}/abort.
+func (s *Service) Abort(ctx context.Context, req AbortRequest) (AbortResult, error) {
+	if s.client == nil {
+		return AbortResult{}, fmt.Errorf("API client not configured")
+	}
+	if req.AppSlug == "" {
+		return AbortResult{}, fmt.Errorf("app ID is required")
+	}
+	if req.BuildSlug == "" {
+		return AbortResult{}, fmt.Errorf("build ID is required")
+	}
+	resp, err := s.client.AbortBuild(ctx, req.AppSlug, req.BuildSlug, bitriseapi.AbortBuildRequest{
+		AbortReason:         req.Reason,
+		AbortWithSuccess:    req.AbortWithSuccess,
+		SkipGitStatusReport: req.SkipGitStatusReport,
+		SkipNotifications:   req.SkipNotifications,
+	})
+	if err != nil {
+		var apiErr *bitriseapi.APIError
+		if errors.As(err, &apiErr) && apiErr.StatusCode == http.StatusNotFound {
+			return AbortResult{}, fmt.Errorf("build %q not found", req.BuildSlug)
+		}
+		return AbortResult{}, err
+	}
+	return AbortResult{
+		AppSlug:   req.AppSlug,
+		BuildSlug: req.BuildSlug,
+		Status:    resp.Status,
+	}, nil
+}
+
+// fromAPI maps a bitriseapi.Build (wire shape) into the CLI's Build type.
+// appSlug comes from the request, not the response, since the API doesn't
+// echo it back.
+func fromAPI(b bitriseapi.Build, appSlug string) Build {
+	out := Build{
+		Slug:                    b.Slug,
+		AppSlug:                 appSlug,
+		BuildNumber:             b.BuildNumber,
+		Status:                  statusString(b.Status),
+		StatusText:              b.StatusText,
+		AbortReason:             b.AbortReason,
+		IsOnHold:                b.IsOnHold,
+		Rebuildable:             b.Rebuildable,
+		Workflow:                b.TriggeredWorkflow,
+		PipelineWorkflowID:      b.PipelineWorkflowID,
+		Branch:                  b.Branch,
+		Tag:                     b.Tag,
+		PullRequestID:           b.PullRequestID,
+		PullRequestTargetBranch: b.PullRequestTargetBranch,
+		PullRequestViewURL:      b.PullRequestViewURL,
+		CommitHash:              b.CommitHash,
+		CommitMessage:           b.CommitMessage,
+		TriggeredBy:             b.TriggeredBy,
+		StackIdentifier:         b.StackIdentifier,
+		MachineTypeID:           b.MachineTypeID,
+		CreditCost:              b.CreditCost,
+	}
+	if !b.TriggeredAt.IsZero() {
+		out.TriggeredAt = b.TriggeredAt.UTC()
+	}
+	if !b.FinishedAt.IsZero() {
+		t := b.FinishedAt.UTC()
+		out.FinishedAt = &t
+	}
+	return out
+}
+
+// triggerRespToBuild collapses the trigger response into our Build shape,
+// preferring the modern Results[0] over the deprecated top-level fields.
+func triggerRespToBuild(resp bitriseapi.TriggerBuildResponse, req TriggerRequest) Build {
+	slug := resp.BuildSlug
+	number := resp.BuildNumber
+	url := resp.BuildURL
+	workflow := resp.TriggeredWorkflow
+	if len(resp.Results) > 0 {
+		r := resp.Results[0]
+		if r.BuildSlug != "" {
+			slug = r.BuildSlug
+		}
+		if r.BuildNumber != 0 {
+			number = r.BuildNumber
+		}
+		if r.BuildURL != "" {
+			url = r.BuildURL
+		}
+		if r.TriggeredWorkflow != "" {
+			workflow = r.TriggeredWorkflow
+		}
+	}
+	if workflow == "" {
+		workflow = req.Workflow
+	}
+	return Build{
+		Slug:          slug,
+		AppSlug:       req.AppSlug,
+		BuildNumber:   number,
+		Status:        "in-progress",
+		StatusText:    resp.Message,
+		Branch:        req.Branch,
+		Tag:           req.Tag,
+		Workflow:      workflow,
+		CommitHash:    req.CommitHash,
+		CommitMessage: req.CommitMessage,
+		TriggeredAt:   time.Now().UTC(),
+		BuildURL:      url,
+	}
+}
+
+// statusString translates the API's integer status into a stable string for
+// --format json/yml. Unknown values fall through as the integer for
+// forward-compat with new statuses.
+func statusString(n int) string {
+	switch n {
+	case 0:
+		return "in-progress"
+	case 1:
+		return "success"
+	case 2:
+		return "failed"
+	case 3:
+		return "aborted"
+	case 4:
+		return "aborted-with-success"
+	default:
+		return strconv.Itoa(n)
+	}
+}
+
+// parseStatusFilter is the inverse of statusString. Returns a nil pointer
+// (not an error) when s is empty, signaling "no filter requested".
+func parseStatusFilter(s string) (*int, error) {
+	if s == "" {
+		return nil, nil
+	}
+	var n int
+	switch s {
+	case "in-progress":
+		n = 0
+	case "success":
+		n = 1
+	case "failed":
+		n = 2
+	case "aborted":
+		n = 3
+	case "aborted-with-success":
+		n = 4
+	default:
+		return nil, fmt.Errorf("unknown build status %q (expected: in-progress, success, failed, aborted, aborted-with-success)", s)
+	}
+	return &n, nil
+}

--- a/internal/build/service_test.go
+++ b/internal/build/service_test.go
@@ -1,0 +1,425 @@
+package build
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/bitrise-io/bitrise/v2/internal/bitriseapi"
+)
+
+func TestService_List_PathAndMapping(t *testing.T) {
+	var gotPath, gotQuery string
+	srv := newFakeServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotQuery = r.URL.RawQuery
+		_, _ = w.Write([]byte(`{
+  "data": [
+    {"slug":"b-1","build_number":42,"status":1,"status_text":"success","branch":"main","triggered_workflow":"primary",
+     "triggered_at":"2026-05-06T10:00:00Z","finished_at":"2026-05-06T10:05:00Z"},
+    {"slug":"b-2","build_number":41,"status":0,"branch":"feature","triggered_workflow":"primary","triggered_at":"2026-05-06T09:00:00Z"}
+  ],
+  "paging": {"next": "next-cur"}
+}`))
+	})
+	svc := NewService(newAPIClient(t, srv.URL))
+
+	res, err := svc.List(context.Background(), ListOptions{
+		AppSlug:  "my-app",
+		Branch:   "main",
+		Workflow: "primary",
+		Status:   "success",
+		Limit:    50,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "/apps/my-app/builds", gotPath)
+	require.Len(t, res.Items, 2)
+	assert.Equal(t, "success", res.Items[0].Status)
+	assert.Equal(t, "in-progress", res.Items[1].Status)
+	assert.NotNil(t, res.Items[0].FinishedAt)
+	assert.Nil(t, res.Items[1].FinishedAt)
+	assert.Equal(t, "my-app", res.Items[0].AppSlug)
+	assert.Equal(t, "next-cur", res.NextCursor)
+	assert.Contains(t, gotQuery, "status=1")
+}
+
+func TestService_List_StatusInProgressMapsToZero(t *testing.T) {
+	var gotQuery string
+	srv := newFakeServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.RawQuery
+		_, _ = w.Write([]byte(`{"data":[]}`))
+	})
+	svc := NewService(newAPIClient(t, srv.URL))
+
+	_, err := svc.List(context.Background(), ListOptions{AppSlug: "my-app", Status: "in-progress"})
+	require.NoError(t, err)
+	assert.Contains(t, gotQuery, "status=0")
+}
+
+func TestService_List_NewFiltersPassedThrough(t *testing.T) {
+	var gotQuery string
+	srv := newFakeServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.RawQuery
+		_, _ = w.Write([]byte(`{"data":[]}`))
+	})
+	svc := NewService(newAPIClient(t, srv.URL))
+
+	after := time.Date(2024, 1, 15, 0, 0, 0, 0, time.UTC)
+	before := time.Date(2024, 6, 1, 0, 0, 0, 0, time.UTC)
+	isPipeline := true
+
+	_, err := svc.List(context.Background(), ListOptions{
+		AppSlug:          "my-app",
+		SortBy:           "running_first",
+		CommitMessage:    "fix bug",
+		TriggerEventType: "push",
+		PullRequestID:    42,
+		BuildNumber:      99,
+		After:            &after,
+		Before:           &before,
+		IsPipelineBuild:  &isPipeline,
+	})
+	require.NoError(t, err)
+	q, err := url.ParseQuery(gotQuery)
+	require.NoError(t, err)
+	assert.Equal(t, "running_first", q.Get("sort_by"))
+	assert.Equal(t, "fix bug", q.Get("commit_message"))
+	assert.Equal(t, "push", q.Get("trigger_event_type"))
+	assert.Equal(t, "42", q.Get("pull_request_id"))
+	assert.Equal(t, "99", q.Get("build_number"))
+	assert.Equal(t, strconv.FormatInt(after.Unix(), 10), q.Get("after"))
+	assert.Equal(t, strconv.FormatInt(before.Unix(), 10), q.Get("before"))
+	assert.Equal(t, "true", q.Get("is_pipeline_build"))
+}
+
+func TestService_List_RejectsUnknownStatus(t *testing.T) {
+	srv := newFakeServer(t, func(http.ResponseWriter, *http.Request) {})
+	svc := NewService(newAPIClient(t, srv.URL))
+
+	_, err := svc.List(context.Background(), ListOptions{AppSlug: "my-app", Status: "bogus"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown build status")
+}
+
+func TestService_View_PathAndMapping(t *testing.T) {
+	var gotPath string
+	srv := newFakeServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		_, _ = w.Write([]byte(`{"data":{"slug":"b-xyz","build_number":7,"status":2,"status_text":"failed","triggered_workflow":"deploy","branch":"feature/x"}}`))
+	})
+	svc := NewService(newAPIClient(t, srv.URL))
+
+	got, err := svc.View(context.Background(), "my-app", "b-xyz")
+	require.NoError(t, err)
+	assert.Equal(t, "/apps/my-app/builds/b-xyz", gotPath)
+	assert.Equal(t, "b-xyz", got.Slug)
+	assert.Equal(t, "failed", got.Status)
+	assert.Equal(t, "deploy", got.Workflow)
+	assert.Equal(t, "my-app", got.AppSlug)
+}
+
+func TestService_View_NotFound(t *testing.T) {
+	srv := newFakeServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"message":"not found"}`))
+	})
+	svc := NewService(newAPIClient(t, srv.URL))
+
+	_, err := svc.View(context.Background(), "my-app", "missing")
+	require.EqualError(t, err, `build "missing" not found`)
+}
+
+func TestService_Trigger_BodyAndResponse(t *testing.T) {
+	var gotMethod, gotPath string
+	var gotBody []byte
+	srv := newFakeServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		gotBody, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{
+  "build_slug": "new-1",
+  "build_number": 100,
+  "build_url": "https://app.bitrise.io/build/new-1",
+  "triggered_workflow": "deploy",
+  "message": "Build triggered"
+}`))
+	})
+	svc := NewService(newAPIClient(t, srv.URL))
+
+	got, err := svc.Trigger(context.Background(), TriggerRequest{
+		AppSlug:    "my-app",
+		Workflow:   "deploy",
+		Branch:     "main",
+		CommitHash: "abc",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, http.MethodPost, gotMethod)
+	assert.Equal(t, "/apps/my-app/builds", gotPath)
+
+	var sent map[string]any
+	require.NoError(t, json.Unmarshal(gotBody, &sent))
+	hi, _ := sent["hook_info"].(map[string]any)
+	assert.Equal(t, "bitrise", hi["type"])
+	bp, _ := sent["build_params"].(map[string]any)
+	assert.Equal(t, "deploy", bp["workflow_id"])
+	assert.Equal(t, "main", bp["branch"])
+	assert.Equal(t, "abc", bp["commit_hash"])
+
+	assert.Equal(t, "new-1", got.Slug)
+	assert.Equal(t, 100, got.BuildNumber)
+	assert.NotEmpty(t, got.BuildURL)
+	assert.Equal(t, "in-progress", got.Status)
+	assert.Equal(t, "my-app", got.AppSlug)
+	assert.Equal(t, "deploy", got.Workflow)
+	assert.Equal(t, "main", got.Branch)
+}
+
+func TestService_Trigger_PrefersResultsArray(t *testing.T) {
+	srv := newFakeServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		// Modern API returns "results"; deprecated top-level fields differ.
+		_, _ = w.Write([]byte(`{
+  "build_slug": "deprecated-slug",
+  "build_url": "deprecated-url",
+  "results": [
+    {"build_slug": "result-slug", "build_number": 99, "build_url": "result-url", "triggered_workflow": "deploy"}
+  ]
+}`))
+	})
+	svc := NewService(newAPIClient(t, srv.URL))
+
+	got, err := svc.Trigger(context.Background(), TriggerRequest{AppSlug: "a", Workflow: "deploy"})
+	require.NoError(t, err)
+	assert.Equal(t, "result-slug", got.Slug)
+	assert.Equal(t, "result-url", got.BuildURL)
+	assert.Equal(t, 99, got.BuildNumber)
+}
+
+func TestService_Trigger_RequiresAppSlug(t *testing.T) {
+	srv := newFakeServer(t, func(http.ResponseWriter, *http.Request) {})
+	svc := NewService(newAPIClient(t, srv.URL))
+
+	_, err := svc.Trigger(context.Background(), TriggerRequest{Workflow: "x"})
+	require.Error(t, err)
+}
+
+func TestService_Trigger_NotFound(t *testing.T) {
+	srv := newFakeServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"message":"not found"}`))
+	})
+	svc := NewService(newAPIClient(t, srv.URL))
+
+	_, err := svc.Trigger(context.Background(), TriggerRequest{AppSlug: "missing-app", Workflow: "x"})
+	require.EqualError(t, err, `app "missing-app" not found`)
+}
+
+func TestService_Trigger_PipelineFields(t *testing.T) {
+	var gotBody []byte
+	srv := newFakeServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotBody, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"build_slug":"p-1","build_number":5,"build_url":"https://app.bitrise.io/build/p-1"}`))
+	})
+	svc := NewService(newAPIClient(t, srv.URL))
+
+	got, err := svc.Trigger(context.Background(), TriggerRequest{
+		AppSlug:    "my-app",
+		Pipeline:   "my-pipeline",
+		Branch:     "main",
+		BranchDest: "release",
+		Tag:        "v1.0.0",
+	})
+	require.NoError(t, err)
+
+	var sent map[string]any
+	require.NoError(t, json.Unmarshal(gotBody, &sent))
+	bp, _ := sent["build_params"].(map[string]any)
+	assert.Equal(t, "my-pipeline", bp["pipeline_id"])
+	assert.Equal(t, "release", bp["branch_dest"])
+	assert.Equal(t, "v1.0.0", bp["tag"])
+	assert.Nil(t, bp["workflow_id"])
+
+	assert.Equal(t, "v1.0.0", got.Tag)
+	assert.Equal(t, "main", got.Branch)
+}
+
+func TestService_Trigger_EnvsAndPriorityAndPR(t *testing.T) {
+	var gotBody []byte
+	srv := newFakeServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotBody, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"build_slug":"e-1","build_number":10}`))
+	})
+	svc := NewService(newAPIClient(t, srv.URL))
+
+	_, err := svc.Trigger(context.Background(), TriggerRequest{
+		AppSlug:       "my-app",
+		Workflow:      "primary",
+		PullRequestID: 42,
+		Priority:      1,
+		Environments: []TriggerEnv{
+			{Key: "MY_VAR", Value: "hello"},
+		},
+	})
+	require.NoError(t, err)
+
+	var sent map[string]any
+	require.NoError(t, json.Unmarshal(gotBody, &sent))
+	bp, _ := sent["build_params"].(map[string]any)
+	assert.Equal(t, float64(42), bp["pull_request_id"])
+	assert.Equal(t, float64(1), bp["priority"])
+	envs, _ := bp["environments"].([]any)
+	require.Len(t, envs, 1)
+	env, _ := envs[0].(map[string]any)
+	assert.Equal(t, "MY_VAR", env["mapped_to"])
+	assert.Equal(t, "hello", env["value"])
+	assert.Equal(t, true, env["is_expand"])
+}
+
+func TestService_Log_Streams(t *testing.T) {
+	rawSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("LOG OUTPUT"))
+	}))
+	t.Cleanup(rawSrv.Close)
+
+	srv := newFakeServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"is_archived":          true,
+			"expiring_raw_log_url": rawSrv.URL,
+		})
+	})
+	svc := NewService(newAPIClient(t, srv.URL))
+
+	var buf bytes.Buffer
+	require.NoError(t, svc.Log(context.Background(), "my-app", "b-1", &buf))
+	assert.Contains(t, buf.String(), "LOG OUTPUT")
+}
+
+func TestService_Log_RequiresSlugs(t *testing.T) {
+	srv := newFakeServer(t, func(http.ResponseWriter, *http.Request) {})
+	svc := NewService(newAPIClient(t, srv.URL))
+
+	assert.Error(t, svc.Log(context.Background(), "", "b", io.Discard))
+	assert.Error(t, svc.Log(context.Background(), "a", "", io.Discard))
+}
+
+func TestService_Abort_BodyAndResponse(t *testing.T) {
+	var gotMethod, gotPath string
+	var gotBody []byte
+	srv := newFakeServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		gotBody, _ = io.ReadAll(r.Body)
+		_, _ = w.Write([]byte(`{"status":"ok"}`))
+	})
+	svc := NewService(newAPIClient(t, srv.URL))
+
+	got, err := svc.Abort(context.Background(), AbortRequest{
+		AppSlug:          "my-app",
+		BuildSlug:        "b-1",
+		Reason:           "no longer needed",
+		AbortWithSuccess: true,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, http.MethodPost, gotMethod)
+	assert.Equal(t, "/apps/my-app/builds/b-1/abort", gotPath)
+	assert.Equal(t, AbortResult{AppSlug: "my-app", BuildSlug: "b-1", Status: "ok"}, got)
+
+	var sent map[string]any
+	require.NoError(t, json.Unmarshal(gotBody, &sent))
+	assert.Equal(t, "no longer needed", sent["abort_reason"])
+	assert.Equal(t, true, sent["abort_with_success"])
+}
+
+func TestService_Abort_RequiresSlugs(t *testing.T) {
+	srv := newFakeServer(t, func(http.ResponseWriter, *http.Request) {})
+	svc := NewService(newAPIClient(t, srv.URL))
+
+	_, err := svc.Abort(context.Background(), AbortRequest{BuildSlug: "b"})
+	assert.Error(t, err)
+	_, err = svc.Abort(context.Background(), AbortRequest{AppSlug: "a"})
+	assert.Error(t, err)
+}
+
+func TestService_Abort_NotFound(t *testing.T) {
+	srv := newFakeServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"message":"not found"}`))
+	})
+	svc := NewService(newAPIClient(t, srv.URL))
+
+	_, err := svc.Abort(context.Background(), AbortRequest{AppSlug: "my-app", BuildSlug: "missing"})
+	require.EqualError(t, err, `build "missing" not found`)
+}
+
+func TestService_NilClientFails(t *testing.T) {
+	svc := NewService(nil)
+	_, err := svc.List(context.Background(), ListOptions{AppSlug: "x"})
+	assert.Error(t, err)
+	_, err = svc.View(context.Background(), "a", "b")
+	assert.Error(t, err)
+	_, err = svc.Trigger(context.Background(), TriggerRequest{AppSlug: "a"})
+	assert.Error(t, err)
+	assert.Error(t, svc.Log(context.Background(), "a", "b", io.Discard))
+	_, err = svc.Abort(context.Background(), AbortRequest{AppSlug: "a", BuildSlug: "b"})
+	assert.Error(t, err)
+}
+
+func TestStatusString(t *testing.T) {
+	cases := map[int]string{
+		0: "in-progress",
+		1: "success",
+		2: "failed",
+		3: "aborted",
+		4: "aborted-with-success",
+		9: "9", // unknown — passthrough as integer string
+	}
+	for in, want := range cases {
+		assert.Equal(t, want, statusString(in))
+	}
+}
+
+func TestParseStatusFilter(t *testing.T) {
+	got, err := parseStatusFilter("")
+	require.NoError(t, err)
+	assert.Nil(t, got)
+
+	got, err = parseStatusFilter("success")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, 1, *got)
+
+	got, err = parseStatusFilter("in-progress")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, 0, *got)
+
+	_, err = parseStatusFilter("BOGUS")
+	assert.Error(t, err)
+}
+
+func newFakeServer(t *testing.T, handler http.HandlerFunc) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func newAPIClient(t *testing.T, baseURL string) *bitriseapi.Client {
+	t.Helper()
+	c, err := bitriseapi.New(baseURL, "t")
+	require.NoError(t, err)
+	return c
+}

--- a/internal/build/watch.go
+++ b/internal/build/watch.go
@@ -142,15 +142,17 @@ func (s *Service) Watch(ctx context.Context, appSlug, buildSlug string, w io.Wri
 		}
 	}
 
-	// One final call to flush any chunks buffered after the last poll.
-	if lastAfterTimestamp != "" {
-		final, err := s.client.BuildLogManifest(ctx, appSlug, buildSlug, lastAfterTimestamp)
-		if err != nil {
-			return Build{}, err
-		}
-		if _, err := flushContiguous(w, buffer, &nextEmit, final.LogChunks); err != nil {
-			return Build{}, err
-		}
+	// One final call to flush any chunks buffered after the last poll. Runs
+	// unconditionally, even if lastAfterTimestamp is still "" (a poll's
+	// NextAfterTimestamp can come back empty), so a stuck-empty cursor can't
+	// permanently skip this catch-up — worst case it's a full log refetch,
+	// and flushContiguous drops anything already emitted.
+	final, err := s.client.BuildLogManifest(ctx, appSlug, buildSlug, lastAfterTimestamp)
+	if err != nil {
+		return Build{}, err
+	}
+	if _, err := flushContiguous(w, buffer, &nextEmit, final.LogChunks); err != nil {
+		return Build{}, err
 	}
 
 	// Failsafe drain: any chunks still buffered (a position before them

--- a/internal/build/watch.go
+++ b/internal/build/watch.go
@@ -1,0 +1,270 @@
+package build
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"slices"
+	"time"
+
+	"github.com/bitrise-io/bitrise/v2/internal/bitriseapi"
+)
+
+// Watch streams the build log to w using the API's delta-log protocol,
+// blocking until the build finishes. Returns the final Build so the caller
+// can determine the exit code. Ctrl-C (context cancellation) causes Watch to
+// return context.Canceled; the build continues running on Bitrise.
+//
+// For builds that are already finished when Watch is called, the archived
+// log is fetched and streamed immediately.
+func (s *Service) Watch(ctx context.Context, appSlug, buildSlug string, w io.Writer, interval time.Duration) (Build, error) {
+	if s.client == nil {
+		return Build{}, fmt.Errorf("API client not configured")
+	}
+	if appSlug == "" {
+		return Build{}, fmt.Errorf("app ID is required")
+	}
+	if buildSlug == "" {
+		return Build{}, fmt.Errorf("build ID is required")
+	}
+	if interval <= 0 {
+		interval = 3 * time.Second
+	}
+
+	// The log manifest returns 404 for up to ~15s after trigger while the
+	// runner provisions. Retry on 404 for up to 10 intervals (~30s at the
+	// default 3s interval) before giving up.
+	const maxInitialRetries = 10
+	var (
+		manifest bitriseapi.BuildLogResponse
+		err      error
+	)
+	for attempt := 0; ; attempt++ {
+		manifest, err = s.client.BuildLogManifest(ctx, appSlug, buildSlug, "")
+		if err == nil {
+			break
+		}
+		var apiErr *bitriseapi.APIError
+		if !errors.As(err, &apiErr) || apiErr.StatusCode != http.StatusNotFound {
+			return Build{}, err
+		}
+		if attempt >= maxInitialRetries {
+			return Build{}, fmt.Errorf("build %q not found", buildSlug)
+		}
+		select {
+		case <-ctx.Done():
+			return Build{}, ctx.Err()
+		case <-time.After(interval):
+		}
+	}
+
+	// Already finished: stream the archived log via the existing Log path.
+	if manifest.IsArchived || manifest.ExpiringRawLogURL != "" {
+		if err := s.Log(ctx, appSlug, buildSlug, w); err != nil {
+			return Build{}, err
+		}
+		return s.View(ctx, appSlug, buildSlug)
+	}
+
+	// In-progress: maintain a position-keyed buffer across polls so chunks
+	// delivered out of order can be reordered before reaching the writer.
+	// The Bitrise log API returns chunks in arbitrary order across polls
+	// because the server collects them from parallel producers; without
+	// cross-poll buffering, a chunk at position N can land on screen before
+	// position N-1 arrives in the next poll.
+	//
+	// The cursor (nextEmit) is lazy-initialized to the lowest position in
+	// the first non-empty batch — we don't assume positions start at zero,
+	// since the API doesn't document the numbering and may be 1-indexed.
+	// A "stale buffer" guard force-drains after maxStaleFlushes polls with
+	// no progress: positions can have real gaps (parallel sections, dropped
+	// chunks), and waiting for a chunk that never arrives would stall
+	// streaming until the build finishes.
+	const maxStaleFlushes = 3
+	buffer := map[int]string{}
+	nextEmit := -1
+	staleFlushes := 0
+	flush := func(batch []bitriseapi.BuildLogChunk) error {
+		emitted, err := flushContiguous(w, buffer, &nextEmit, batch)
+		if err != nil {
+			return err
+		}
+		if emitted > 0 {
+			staleFlushes = 0
+			return nil
+		}
+		if len(buffer) == 0 {
+			return nil
+		}
+		staleFlushes++
+		if staleFlushes < maxStaleFlushes {
+			return nil
+		}
+		if err := drainRemaining(w, buffer, &nextEmit); err != nil {
+			return err
+		}
+		staleFlushes = 0
+		return nil
+	}
+
+	if err := flush(manifest.LogChunks); err != nil {
+		return Build{}, err
+	}
+
+	lastAfterTimestamp := ""
+	afterTimestamp := manifest.NextAfterTimestamp
+	var current bitriseapi.Build
+	for {
+		select {
+		case <-ctx.Done():
+			return Build{}, ctx.Err()
+		case <-time.After(interval):
+		}
+		current, err = s.client.Build(ctx, appSlug, buildSlug)
+		if err != nil {
+			return Build{}, err
+		}
+		if afterTimestamp != "" {
+			manifest, err = s.client.BuildLogManifest(ctx, appSlug, buildSlug, afterTimestamp)
+			if err != nil {
+				return Build{}, err
+			}
+			if err := flush(manifest.LogChunks); err != nil {
+				return Build{}, err
+			}
+			lastAfterTimestamp = afterTimestamp
+			afterTimestamp = manifest.NextAfterTimestamp
+		}
+		if current.Status != 0 {
+			break
+		}
+	}
+
+	// One final call to flush any chunks buffered after the last poll.
+	if lastAfterTimestamp != "" {
+		final, err := s.client.BuildLogManifest(ctx, appSlug, buildSlug, lastAfterTimestamp)
+		if err != nil {
+			return Build{}, err
+		}
+		if _, err := flushContiguous(w, buffer, &nextEmit, final.LogChunks); err != nil {
+			return Build{}, err
+		}
+	}
+
+	// Failsafe drain: any chunks still buffered (a position before them
+	// never arrived from the server) get emitted in position order. Better
+	// to surface them with a gap than to silently drop log lines.
+	if err := drainRemaining(w, buffer, &nextEmit); err != nil {
+		return Build{}, err
+	}
+
+	return fromAPI(current, appSlug), nil
+}
+
+// flushContiguous merges batch into buffer and writes any chunks whose
+// position extends the contiguous run from *nextEmit. Returns the number of
+// chunks emitted. Out-of-order chunks stay in buffer until the gap before
+// them fills in via a later poll or the stale-buffer drain.
+//
+// *nextEmit == -1 signals "not yet initialized"; the first non-empty batch
+// initializes it to the lowest position seen so the algorithm works
+// regardless of whether the API uses 0-indexed or 1-indexed positions.
+//
+// Replay handling:
+//   - position < *nextEmit (after init): already emitted, drop silently
+//   - position already in buffer: keep the first-arrived copy
+func flushContiguous(w io.Writer, buffer map[int]string, nextEmit *int, batch []bitriseapi.BuildLogChunk) (int, error) {
+	for _, c := range batch {
+		if *nextEmit >= 0 && c.Position < *nextEmit {
+			continue
+		}
+		if _, exists := buffer[c.Position]; exists {
+			continue
+		}
+		buffer[c.Position] = c.Chunk
+	}
+	if *nextEmit < 0 {
+		if len(buffer) == 0 {
+			return 0, nil
+		}
+		min := -1
+		for p := range buffer {
+			if min < 0 || p < min {
+				min = p
+			}
+		}
+		*nextEmit = min
+	}
+	emitted := 0
+	for {
+		chunk, ok := buffer[*nextEmit]
+		if !ok {
+			return emitted, nil
+		}
+		if _, err := io.WriteString(w, chunk); err != nil {
+			return emitted, fmt.Errorf("write log chunk: %w", err)
+		}
+		delete(buffer, *nextEmit)
+		*nextEmit++
+		emitted++
+	}
+}
+
+// drainRemaining writes any chunks still in buffer in position order and
+// advances *nextEmit past the highest drained position so future chunks at
+// positions below it are dropped as already-emitted. Called both as the
+// final failsafe at build end and as the stale-buffer escape hatch when a
+// gap has stalled streaming for too many polls.
+func drainRemaining(w io.Writer, buffer map[int]string, nextEmit *int) error {
+	if len(buffer) == 0 {
+		return nil
+	}
+	positions := make([]int, 0, len(buffer))
+	for p := range buffer {
+		positions = append(positions, p)
+	}
+	slices.Sort(positions)
+	for _, p := range positions {
+		if _, err := io.WriteString(w, buffer[p]); err != nil {
+			return fmt.Errorf("write log chunk: %w", err)
+		}
+		delete(buffer, p)
+	}
+	*nextEmit = positions[len(positions)-1] + 1
+	return nil
+}
+
+// WaitForCompletion blocks until the build is no longer in-progress, polling
+// at the given interval. Returns the final Build. Ctrl-C (context
+// cancellation) returns context.Canceled; the build keeps running on
+// Bitrise.
+func (s *Service) WaitForCompletion(ctx context.Context, appSlug, buildSlug string, interval time.Duration) (Build, error) {
+	if s.client == nil {
+		return Build{}, fmt.Errorf("API client not configured")
+	}
+	if appSlug == "" {
+		return Build{}, fmt.Errorf("app ID is required")
+	}
+	if buildSlug == "" {
+		return Build{}, fmt.Errorf("build ID is required")
+	}
+	if interval <= 0 {
+		interval = 3 * time.Second
+	}
+	for {
+		b, err := s.View(ctx, appSlug, buildSlug)
+		if err != nil {
+			return Build{}, err
+		}
+		if b.Status != "in-progress" {
+			return b, nil
+		}
+		select {
+		case <-ctx.Done():
+			return Build{}, ctx.Err()
+		case <-time.After(interval):
+		}
+	}
+}

--- a/internal/build/watch_test.go
+++ b/internal/build/watch_test.go
@@ -1,0 +1,333 @@
+package build
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestService_Watch_DeltaStreaming(t *testing.T) {
+	// Three log polls: chunk1 (ts1), chunk2 (ts2), chunk3 (empty next ts).
+	// Build status returns in-progress until the log stream ends naturally,
+	// then the final-flush call and a View call complete the sequence.
+	var logCalls, buildCalls atomic.Int32
+	var logTimestamps []string
+
+	srv := newFakeServer(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/apps/my-app/builds/b-1/log":
+			n := int(logCalls.Add(1))
+			logTimestamps = append(logTimestamps, r.URL.Query().Get("after_timestamp"))
+			switch n {
+			case 1:
+				_, _ = w.Write([]byte(`{"is_archived":false,"log_chunks":[{"chunk":"chunk1\n","position":0}],"next_after_timestamp":"ts1"}`))
+			case 2:
+				_, _ = w.Write([]byte(`{"is_archived":false,"log_chunks":[{"chunk":"chunk2\n","position":1}],"next_after_timestamp":"ts2"}`))
+			case 3:
+				// Empty next_after_timestamp: loop exits after this poll.
+				_, _ = w.Write([]byte(`{"is_archived":false,"log_chunks":[{"chunk":"chunk3\n","position":2}]}`))
+			default: // final flush
+				_, _ = w.Write([]byte(`{"is_archived":false,"log_chunks":[{"chunk":"final\n","position":3}]}`))
+			}
+		case "/apps/my-app/builds/b-1":
+			n := int(buildCalls.Add(1))
+			// Stay in-progress while the log stream is active so we can observe
+			// all chunks; return success on the final View call.
+			if n <= 2 {
+				_, _ = w.Write([]byte(`{"data":{"slug":"b-1","build_number":1,"status":0}}`))
+			} else {
+				_, _ = w.Write([]byte(`{"data":{"slug":"b-1","build_number":1,"status":1,"triggered_workflow":"primary","branch":"main"}}`))
+			}
+		}
+	})
+	svc := NewService(newAPIClient(t, srv.URL))
+
+	var buf bytes.Buffer
+	build, err := svc.Watch(context.Background(), "my-app", "b-1", &buf, time.Millisecond)
+	require.NoError(t, err)
+
+	got := buf.String()
+	for _, want := range []string{"chunk1", "chunk2", "chunk3", "final"} {
+		assert.Contains(t, got, want)
+	}
+
+	// Verify after_timestamp progression for log calls: "", ts1, ts2, ts2 (final flush).
+	wantTimestamps := []string{"", "ts1", "ts2", "ts2"}
+	require.GreaterOrEqual(t, len(logTimestamps), len(wantTimestamps))
+	for i, want := range wantTimestamps {
+		assert.Equal(t, want, logTimestamps[i], "log call %d", i+1)
+	}
+
+	assert.Equal(t, "success", build.Status)
+}
+
+func TestService_Watch_CrossPollGapFillsInLaterFlushesInOrder(t *testing.T) {
+	// Realistic cross-poll out-of-order: poll 1 returns positions 0, 1, 3
+	// (position 2 is delayed by the server-side parallel producer); poll 2
+	// delivers position 2. Without cross-poll buffering the user would see 3
+	// emitted before 2; with the buffer we emit 0, 1, hold 3, then emit 2
+	// and 3 in order once 2 arrives.
+	var logCalls, buildCalls atomic.Int32
+	srv := newFakeServer(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/apps/my-app/builds/b-1/log":
+			n := int(logCalls.Add(1))
+			switch n {
+			case 1:
+				_, _ = w.Write([]byte(`{"is_archived":false,"log_chunks":[{"chunk":"A\n","position":0},{"chunk":"B\n","position":1},{"chunk":"D\n","position":3}],"next_after_timestamp":"ts1"}`))
+			case 2:
+				_, _ = w.Write([]byte(`{"is_archived":false,"log_chunks":[{"chunk":"C\n","position":2}],"next_after_timestamp":"ts2"}`))
+			default:
+				_, _ = w.Write([]byte(`{"is_archived":false,"log_chunks":[]}`))
+			}
+		case "/apps/my-app/builds/b-1":
+			n := int(buildCalls.Add(1))
+			if n <= 2 {
+				_, _ = w.Write([]byte(`{"data":{"slug":"b-1","build_number":1,"status":0}}`))
+			} else {
+				_, _ = w.Write([]byte(`{"data":{"slug":"b-1","build_number":1,"status":1,"triggered_workflow":"primary","branch":"main"}}`))
+			}
+		}
+	})
+	svc := NewService(newAPIClient(t, srv.URL))
+
+	var buf bytes.Buffer
+	_, err := svc.Watch(context.Background(), "my-app", "b-1", &buf, time.Millisecond)
+	require.NoError(t, err)
+	assert.Equal(t, "A\nB\nC\nD\n", buf.String(), "chunk D must be held until C arrives")
+}
+
+func TestService_Watch_LazyInitsCursorToFirstBatchMinPosition(t *testing.T) {
+	// Real-world positions may not start at 0 (e.g. 1-indexed, or numbered
+	// per build session). The first non-empty batch's lowest position
+	// becomes the cursor floor — otherwise the algorithm would stall forever
+	// waiting for a position that will never arrive.
+	var logCalls, buildCalls atomic.Int32
+	srv := newFakeServer(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/apps/my-app/builds/b-2/log":
+			n := int(logCalls.Add(1))
+			switch n {
+			case 1:
+				_, _ = w.Write([]byte(`{"is_archived":false,"log_chunks":[{"chunk":"first\n","position":100},{"chunk":"second\n","position":101}],"next_after_timestamp":"ts1"}`))
+			default:
+				_, _ = w.Write([]byte(`{"is_archived":false,"log_chunks":[]}`))
+			}
+		case "/apps/my-app/builds/b-2":
+			n := int(buildCalls.Add(1))
+			if n == 1 {
+				_, _ = w.Write([]byte(`{"data":{"slug":"b-2","build_number":2,"status":0}}`))
+			} else {
+				_, _ = w.Write([]byte(`{"data":{"slug":"b-2","build_number":2,"status":1,"triggered_workflow":"primary","branch":"main"}}`))
+			}
+		}
+	})
+	svc := NewService(newAPIClient(t, srv.URL))
+
+	var buf bytes.Buffer
+	_, err := svc.Watch(context.Background(), "my-app", "b-2", &buf, time.Millisecond)
+	require.NoError(t, err)
+	assert.Equal(t, "first\nsecond\n", buf.String(), "cursor must lazy-init to lowest position, not assume 0")
+}
+
+func TestService_Watch_StaleBufferDrainsAfterGapStalls(t *testing.T) {
+	// If a gap never fills in (the missing chunk was dropped server-side or
+	// never gets surfaced), the stale-buffer guard force-flushes after a few
+	// polls so streaming keeps moving instead of stalling until the build
+	// finishes.
+	var logCalls, buildCalls atomic.Int32
+	srv := newFakeServer(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/apps/my-app/builds/b-3/log":
+			n := int(logCalls.Add(1))
+			switch n {
+			case 1:
+				// Position 3 + 5 with a gap (4 missing) — gap never fills.
+				// Lazy init sets cursor to 3, so 3 emits immediately and 5
+				// stays buffered waiting for 4 that never comes.
+				_, _ = w.Write([]byte(`{"is_archived":false,"log_chunks":[{"chunk":"early\n","position":3},{"chunk":"late\n","position":5}],"next_after_timestamp":"ts1"}`))
+			default:
+				_, _ = w.Write([]byte(`{"is_archived":false,"log_chunks":[],"next_after_timestamp":"ts1"}`))
+			}
+		case "/apps/my-app/builds/b-3":
+			n := int(buildCalls.Add(1))
+			if n <= 6 {
+				_, _ = w.Write([]byte(`{"data":{"slug":"b-3","build_number":3,"status":0}}`))
+			} else {
+				_, _ = w.Write([]byte(`{"data":{"slug":"b-3","build_number":3,"status":1,"triggered_workflow":"primary","branch":"main"}}`))
+			}
+		}
+	})
+	svc := NewService(newAPIClient(t, srv.URL))
+
+	var buf bytes.Buffer
+	_, err := svc.Watch(context.Background(), "my-app", "b-3", &buf, time.Millisecond)
+	require.NoError(t, err)
+	assert.Equal(t, "early\nlate\n", buf.String(), "stale-buffer drain must emit both chunks in order")
+}
+
+func TestService_Watch_AlreadyArchived(t *testing.T) {
+	rawSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("ARCHIVED LOG\n"))
+	}))
+	t.Cleanup(rawSrv.Close)
+
+	srv := newFakeServer(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/apps/my-app/builds/b-done/log":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"is_archived":          true,
+				"expiring_raw_log_url": rawSrv.URL,
+			})
+		case "/apps/my-app/builds/b-done":
+			_, _ = w.Write([]byte(`{"data":{"slug":"b-done","build_number":5,"status":1}}`))
+		}
+	})
+	svc := NewService(newAPIClient(t, srv.URL))
+
+	var buf bytes.Buffer
+	build, err := svc.Watch(context.Background(), "my-app", "b-done", &buf, time.Millisecond)
+	require.NoError(t, err)
+	assert.Contains(t, buf.String(), "ARCHIVED LOG")
+	assert.Equal(t, "success", build.Status)
+}
+
+func TestService_Watch_RetriesOn404(t *testing.T) {
+	// First log call returns 404 (build not yet started); second succeeds.
+	var callCount atomic.Int32
+	srv := newFakeServer(t, func(w http.ResponseWriter, r *http.Request) {
+		n := int(callCount.Add(1))
+		switch r.URL.Path {
+		case "/apps/my-app/builds/b-1/log":
+			if n == 1 {
+				w.WriteHeader(http.StatusNotFound)
+				_, _ = w.Write([]byte(`{"message":"build not found"}`))
+				return
+			}
+			// Second call: build has started, archived immediately.
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"is_archived": true,
+				"log_chunks":  []map[string]any{{"chunk": "log line\n", "position": 0}},
+			})
+		case "/apps/my-app/builds/b-1":
+			_, _ = w.Write([]byte(`{"data":{"slug":"b-1","build_number":1,"status":1}}`))
+		}
+	})
+	svc := NewService(newAPIClient(t, srv.URL))
+
+	var buf bytes.Buffer
+	build, err := svc.Watch(context.Background(), "my-app", "b-1", &buf, time.Millisecond)
+	require.NoError(t, err)
+	assert.Equal(t, "success", build.Status)
+}
+
+func TestService_Watch_FailsOnSecond404(t *testing.T) {
+	// Both log calls return 404; Watch should return an error.
+	srv := newFakeServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/apps/my-app/builds/b-1/log" {
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"message":"build not found"}`))
+		}
+	})
+	svc := NewService(newAPIClient(t, srv.URL))
+
+	_, err := svc.Watch(context.Background(), "my-app", "b-1", io.Discard, time.Millisecond)
+	require.Error(t, err)
+	assert.EqualError(t, err, `build "b-1" not found`)
+}
+
+func TestService_Watch_StopsOnIsArchived(t *testing.T) {
+	// Poll returns IsArchived=true with a non-empty NextAfterTimestamp;
+	// Watch must stop and not loop indefinitely.
+	var logCallCount atomic.Int32
+	srv := newFakeServer(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/apps/my-app/builds/b-1/log":
+			n := int(logCallCount.Add(1))
+			if n == 1 {
+				// First call: in-progress with a next timestamp.
+				_, _ = w.Write([]byte(`{"is_archived":false,"log_chunks":[{"chunk":"line1\n","position":0}],"next_after_timestamp":"ts1"}`))
+				return
+			}
+			// Second call: archived but NextAfterTimestamp still set — this is the bug scenario.
+			_, _ = w.Write([]byte(`{"is_archived":true,"log_chunks":[{"chunk":"line2\n","position":1}],"next_after_timestamp":"ts2"}`))
+		case "/apps/my-app/builds/b-1":
+			_, _ = w.Write([]byte(`{"data":{"slug":"b-1","build_number":1,"status":1}}`))
+		}
+	})
+	svc := NewService(newAPIClient(t, srv.URL))
+
+	var buf bytes.Buffer
+	build, err := svc.Watch(context.Background(), "my-app", "b-1", &buf, time.Millisecond)
+	require.NoError(t, err)
+	assert.Contains(t, buf.String(), "line1")
+	assert.Contains(t, buf.String(), "line2")
+	assert.Equal(t, "success", build.Status)
+}
+
+func TestService_Watch_ContextCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	srv := newFakeServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		// Return a next timestamp so Watch will enter the sleep-poll loop,
+		// then cancel the context so the select fires.
+		_, _ = w.Write([]byte(`{"is_archived":false,"log_chunks":[{"chunk":"line\n","position":0}],"next_after_timestamp":"ts1"}`))
+		cancel()
+	})
+	svc := NewService(newAPIClient(t, srv.URL))
+
+	var buf bytes.Buffer
+	_, err := svc.Watch(ctx, "my-app", "b-1", &buf, 10*time.Millisecond)
+	assert.True(t, errors.Is(err, context.Canceled))
+}
+
+func TestService_Watch_StopsOnBuildStatus(t *testing.T) {
+	// Watch should exit the poll loop when the build status is no longer
+	// in-progress (0), without waiting for the log to be archived.
+	var logCalls, buildCalls atomic.Int32
+	srv := newFakeServer(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/apps/my-app/builds/b-1/log":
+			n := int(logCalls.Add(1))
+			if n == 1 {
+				// Initial call: in-progress, gives first chunks.
+				_, _ = w.Write([]byte(`{"is_archived":false,"log_chunks":[{"chunk":"line1\n","position":0}],"next_after_timestamp":"ts1"}`))
+			} else {
+				// Poll: more chunks arrive but is_archived stays false.
+				_, _ = w.Write([]byte(`{"is_archived":false,"log_chunks":[{"chunk":"line2\n","position":1}],"next_after_timestamp":"ts2"}`))
+			}
+		case "/apps/my-app/builds/b-1":
+			buildCalls.Add(1)
+			_, _ = w.Write([]byte(`{"data":{"slug":"b-1","build_number":5,"status":1,"status_text":"success"}}`))
+		}
+	})
+	svc := NewService(newAPIClient(t, srv.URL))
+
+	var buf bytes.Buffer
+	build, err := svc.Watch(context.Background(), "my-app", "b-1", &buf, time.Millisecond)
+	require.NoError(t, err)
+	assert.Contains(t, buf.String(), "line1")
+	assert.Contains(t, buf.String(), "line2")
+	assert.Equal(t, "success", build.Status)
+	assert.GreaterOrEqual(t, int(buildCalls.Load()), 1)
+	// Should have stopped after a single poll cycle, not looped many times.
+	assert.LessOrEqual(t, int(logCalls.Load()), 3, "Watch did not stop on build status")
+}
+
+func TestService_Watch_NilClientFails(t *testing.T) {
+	svc := NewService(nil)
+	_, err := svc.Watch(context.Background(), "a", "b", io.Discard, time.Second)
+	assert.Error(t, err)
+	_, err = svc.WaitForCompletion(context.Background(), "a", "b", time.Second)
+	assert.Error(t, err)
+}


### PR DESCRIPTION
Adds the `internal/bitriseapi `client methods for the builds endpoints (`list`, `view`, `trigger`, `abort`, `log`) and the `internal/build` service layer that wraps them into the CLI-facing `Build/AbortResult/ListResult` types and the polling logic used by `watch`. No CLI surface yet.