### PR TITLE
v3 prep: core bitrise build commands (list, view, log, abort, yml)

### DIFF
--- a/cli/build/abort.go
+++ b/cli/build/abort.go
@@ -1,0 +1,74 @@
+package build
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/bitrise-io/bitrise/v2/cli/cmdutil"
+	internalbuild "github.com/bitrise-io/bitrise/v2/internal/build"
+	"github.com/bitrise-io/bitrise/v2/output"
+)
+
+// NewAbortCommand returns the `build abort` subcommand.
+func NewAbortCommand() *cobra.Command {
+	var (
+		reason              string
+		abortWithSuccess    bool
+		skipGitStatusReport bool
+		skipNotifications   bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "abort BUILD_ID",
+		Short: "Abort a running or queued build",
+		Long: `Abort a running or queued build.
+
+BUILD_ID belongs to an app: pass --app ID, or set BITRISE_APP_ID.`,
+		Example: `  bitrise build abort abc123 --app my-app-id
+  bitrise build abort abc123 --app my-app-id --reason "no longer needed"
+  bitrise build abort abc123 --app my-app-id --abort-with-success`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cmdutil.LogCommandParameters(cmd)
+
+			format, _ := cmd.Flags().GetString(cmdutil.FormatKey)
+			if err := output.ConfigureOutputFormat(format); err != nil {
+				return fmt.Errorf("failed to configure output format: %w", err)
+			}
+
+			appSlug, err := cmdutil.ResolveAppSlug(cmd)
+			if err != nil {
+				return err
+			}
+
+			client, err := cmdutil.NewAPIClient(cmd)
+			if err != nil {
+				return err
+			}
+
+			res, err := internalbuild.NewService(client).Abort(cmd.Context(), internalbuild.AbortRequest{
+				AppSlug:             appSlug,
+				BuildSlug:           args[0],
+				Reason:              reason,
+				AbortWithSuccess:    abortWithSuccess,
+				SkipGitStatusReport: skipGitStatusReport,
+				SkipNotifications:   skipNotifications,
+			})
+			if err != nil {
+				return err
+			}
+
+			return output.Render(cmd.OutOrStdout(), output.Format, res, printAbortText)
+		},
+	}
+
+	cmd.Flags().StringVar(&reason, "reason", "", "reason for aborting, recorded in the build log")
+	cmd.Flags().BoolVar(&abortWithSuccess, "abort-with-success", false, "mark the aborted build as successful")
+	cmd.Flags().BoolVar(&skipGitStatusReport, "skip-git-status-report", false, "don't report the abort to the git provider's status API")
+	cmd.Flags().BoolVar(&skipNotifications, "skip-notifications", false, "don't send abort notifications")
+	cmdutil.AddAppFlag(cmd.Flags(), "app ID (or set BITRISE_APP_ID)")
+	cmd.Flags().StringP(cmdutil.FormatKey, "f", "", "Output format. Accepted: raw (default), json, yml")
+
+	return cmd
+}

--- a/cli/build/abort_test.go
+++ b/cli/build/abort_test.go
@@ -1,0 +1,84 @@
+package build
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/bitrise-io/bitrise/v2/cli/cmdutil"
+	"github.com/bitrise-io/bitrise/v2/internal/auth"
+	"github.com/bitrise-io/bitrise/v2/internal/config"
+)
+
+func TestAbortCmd_HappyPath(t *testing.T) {
+	var gotMethod, gotPath string
+	var gotBody []byte
+	srv := newFakeServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		gotBody, _ = io.ReadAll(r.Body)
+		_, _ = w.Write([]byte(`{"status":"ok"}`))
+	})
+
+	cmd, out := newTestAbortCmd(t, srv.URL)
+	require.NoError(t, cmd.Flags().Set("app", "my-app"))
+	require.NoError(t, cmd.Flags().Set("reason", "no longer needed"))
+	require.NoError(t, cmd.RunE(cmd, []string{"build-1"}))
+
+	assert.Equal(t, http.MethodPost, gotMethod)
+	assert.Equal(t, "/apps/my-app/builds/build-1/abort", gotPath)
+	assert.Contains(t, out.String(), "build-1")
+
+	var sent map[string]any
+	require.NoError(t, json.Unmarshal(gotBody, &sent))
+	assert.Equal(t, "no longer needed", sent["abort_reason"])
+}
+
+func TestAbortCmd_RequiresApp(t *testing.T) {
+	t.Setenv(cmdutil.EnvAppIDLegacy, "")
+
+	cmd, _ := newTestAbortCmd(t, "https://unused.test")
+	err := cmd.RunE(cmd, []string{"build-1"})
+	require.EqualError(t, err, "--app is required")
+}
+
+func TestAbortCmd_BuildNotFound(t *testing.T) {
+	srv := newFakeServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"message":"not found"}`))
+	})
+
+	cmd, _ := newTestAbortCmd(t, srv.URL)
+	require.NoError(t, cmd.Flags().Set("app", "my-app"))
+	err := cmd.RunE(cmd, []string{"missing"})
+	require.EqualError(t, err, `build "missing" not found`)
+}
+
+func TestAbortCmd_RejectsWrongArgCount(t *testing.T) {
+	for _, args := range [][]string{{}, {"a", "b"}} {
+		cmd := NewAbortCommand()
+		cmd.SetArgs(args)
+		cmd.SetOut(&bytes.Buffer{})
+		cmd.SetErr(&bytes.Buffer{})
+		assert.Error(t, cmd.Execute(), "args=%v should be rejected", args)
+	}
+}
+
+func newTestAbortCmd(t *testing.T, apiBaseURL string) (*cobra.Command, *bytes.Buffer) {
+	t.Helper()
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	require.NoError(t, auth.Save(auth.Auth{Token: "test-token"}))
+
+	cmd := NewAbortCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	resolved := config.Resolve(config.Config{}, config.Config{}, config.Config{APIBaseURL: apiBaseURL})
+	cmd.SetContext(config.WithResolved(t.Context(), resolved))
+	return cmd, &out
+}

--- a/cli/build/cmd.go
+++ b/cli/build/cmd.go
@@ -1,0 +1,20 @@
+// Package build implements the `bitrise build` command group: trigger,
+// list, view, log, watch, abort, and yml operations on Bitrise builds.
+package build
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/bitrise-io/bitrise/v2/cli/cmdutil"
+)
+
+// NewCmd returns the `bitrise build` parent command.
+func NewCmd() *cobra.Command {
+	c := &cobra.Command{
+		Use:   "build",
+		Short: "Trigger, list, and inspect builds.",
+		RunE:  cmdutil.RequireKnownSubcommand,
+	}
+	c.AddCommand(NewListCommand(), NewViewCommand(), NewLogCommand(), NewAbortCommand(), NewYMLCommand())
+	return c
+}

--- a/cli/build/list.go
+++ b/cli/build/list.go
@@ -1,0 +1,244 @@
+package build
+
+import (
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"al.essio.dev/pkg/shellescape"
+	"github.com/spf13/cobra"
+
+	"github.com/bitrise-io/bitrise/v2/cli/cmdutil"
+	internalbuild "github.com/bitrise-io/bitrise/v2/internal/build"
+	"github.com/bitrise-io/bitrise/v2/internal/style"
+	"github.com/bitrise-io/bitrise/v2/output"
+)
+
+// NewListCommand returns the `build list` subcommand.
+func NewListCommand() *cobra.Command {
+	var (
+		branch           string
+		workflow         string
+		status           string
+		sortBy           string
+		commitMessage    string
+		triggerEventType string
+		pullRequestID    int
+		buildNumber      int
+		after            string
+		before           string
+		pipelineBuild    bool
+		limit            int
+		cursor           string
+		fetchAll         bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List builds for an app",
+		Long: `List builds for an app.
+
+Pagination:
+  --limit N     max items per page (server default if 0)
+  --cursor TOKEN opaque token from a previous page's next_cursor
+  --all         fetch all pages automatically
+
+In JSON mode (--format json), next_cursor holds the cursor value for scripting:
+  bitrise build list --app my-app-id --format json | jq -r '.next_cursor'`,
+		Example: `  bitrise build list --app my-app-id
+  bitrise build list --app my-app-id --branch main --status failed
+  bitrise build list --app my-app-id --all`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cmdutil.LogCommandParameters(cmd)
+
+			if fetchAll && cursor != "" {
+				return fmt.Errorf("--all and --cursor cannot be used together")
+			}
+
+			format, _ := cmd.Flags().GetString(cmdutil.FormatKey)
+			if err := output.ConfigureOutputFormat(format); err != nil {
+				return fmt.Errorf("failed to configure output format: %w", err)
+			}
+
+			appSlug, err := cmdutil.ResolveAppSlug(cmd)
+			if err != nil {
+				return err
+			}
+
+			var afterTime, beforeTime *time.Time
+			if after != "" {
+				t, err := time.Parse(time.RFC3339, after)
+				if err != nil {
+					return fmt.Errorf("invalid --after value: %w", err)
+				}
+				afterTime = &t
+			}
+			if before != "" {
+				t, err := time.Parse(time.RFC3339, before)
+				if err != nil {
+					return fmt.Errorf("invalid --before value: %w", err)
+				}
+				beforeTime = &t
+			}
+
+			client, err := cmdutil.NewAPIClient(cmd)
+			if err != nil {
+				return err
+			}
+			svc := internalbuild.NewService(client)
+
+			var isPipelineBuild *bool
+			if cmd.Flags().Changed("pipeline-build") {
+				isPipelineBuild = &pipelineBuild
+			}
+
+			makeOpts := func(cur string) internalbuild.ListOptions {
+				return internalbuild.ListOptions{
+					AppSlug:          appSlug,
+					Branch:           branch,
+					Workflow:         workflow,
+					Status:           status,
+					SortBy:           sortBy,
+					CommitMessage:    commitMessage,
+					TriggerEventType: triggerEventType,
+					PullRequestID:    pullRequestID,
+					BuildNumber:      buildNumber,
+					After:            afterTime,
+					Before:           beforeTime,
+					IsPipelineBuild:  isPipelineBuild,
+					Limit:            limit,
+					Cursor:           cur,
+				}
+			}
+
+			var res internalbuild.ListResult
+			if fetchAll {
+				allItems := []internalbuild.Build{}
+				seenCursors := map[string]bool{}
+				cur := ""
+				for {
+					page, pageErr := svc.List(cmd.Context(), makeOpts(cur))
+					if pageErr != nil {
+						return pageErr
+					}
+					allItems = append(allItems, page.Items...)
+					if page.NextCursor == "" {
+						break
+					}
+					if seenCursors[page.NextCursor] {
+						return fmt.Errorf("pagination stalled: the API returned the cursor %q twice", page.NextCursor)
+					}
+					seenCursors[page.NextCursor] = true
+					cur = page.NextCursor
+				}
+				res = internalbuild.ListResult{Items: allItems}
+			} else {
+				res, err = svc.List(cmd.Context(), makeOpts(cursor))
+				if err != nil {
+					return err
+				}
+			}
+
+			return output.Render(cmd.OutOrStdout(), output.Format, res, func(w io.Writer, res internalbuild.ListResult) error {
+				return printBuildsTable(w, res, nextPageCmd(cmd))
+			})
+		},
+	}
+
+	cmd.Flags().StringVar(&branch, "branch", "", "filter by branch")
+	cmd.Flags().StringVar(&workflow, "workflow", "", "filter by workflow")
+	cmd.Flags().StringVar(&status, "status", "", "filter by status: in-progress, success, failed, aborted, aborted-with-success")
+	cmd.Flags().StringVar(&sortBy, "sort-by", "", "ordering: created_at (default) or running_first")
+	cmd.Flags().StringVar(&commitMessage, "commit-message", "", "filter by commit message")
+	cmd.Flags().StringVar(&triggerEventType, "trigger-event-type", "", "filter by trigger event type: push, pull-request, tag")
+	cmd.Flags().IntVar(&pullRequestID, "pull-request-id", 0, "filter by pull request ID")
+	cmd.Flags().IntVar(&buildNumber, "build-number", 0, "filter by build number")
+	cmd.Flags().StringVar(&after, "after", "", "only builds triggered after this time (RFC3339)")
+	cmd.Flags().StringVar(&before, "before", "", "only builds triggered before this time (RFC3339)")
+	cmd.Flags().BoolVar(&pipelineBuild, "pipeline-build", false, "filter by whether the build is part of a pipeline")
+	cmd.Flags().IntVar(&limit, "limit", 0, "max items per page (server default if 0)")
+	cmd.Flags().StringVar(&cursor, "cursor", "", "pagination cursor from a previous response")
+	cmd.Flags().BoolVar(&fetchAll, "all", false, "fetch all pages automatically")
+	cmdutil.AddAppFlag(cmd.Flags(), "app ID (or set BITRISE_APP_ID)")
+	cmd.Flags().StringP(cmdutil.FormatKey, "f", "", "Output format. Accepted: raw (default), json, yml")
+
+	_ = cmd.RegisterFlagCompletionFunc("status", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+		return []string{"in-progress", "success", "failed", "aborted", "aborted-with-success"}, cobra.ShellCompDirectiveNoFileComp
+	})
+	_ = cmd.RegisterFlagCompletionFunc("sort-by", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+		return []string{"created_at", "running_first"}, cobra.ShellCompDirectiveNoFileComp
+	})
+	_ = cmd.RegisterFlagCompletionFunc("trigger-event-type", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+		return []string{"push", "pull-request", "tag"}, cobra.ShellCompDirectiveNoFileComp
+	})
+
+	return cmd
+}
+
+// nextPageCmd builds the "fetch the next page" hint shown under the table,
+// reproducing every filter flag the user actually set so the suggested
+// invocation stays scoped the same way.
+func nextPageCmd(cmd *cobra.Command) func(nextCursor string) string {
+	return func(nextCursor string) string {
+		parts := []string{"bitrise build list"}
+		for _, name := range []string{
+			"app", "branch", "workflow", "status", "sort-by", "commit-message",
+			"trigger-event-type", "pull-request-id", "build-number", "after",
+			"before", "pipeline-build", "limit",
+		} {
+			if f := cmd.Flags().Lookup(name); f != nil && f.Changed {
+				parts = append(parts, "--"+name, shellescape.Quote(f.Value.String()))
+			}
+		}
+		parts = append(parts, "--cursor", shellescape.Quote(nextCursor))
+		return strings.Join(parts, " ")
+	}
+}
+
+func printBuildsTable(w io.Writer, res internalbuild.ListResult, nextPageCmd func(string) string) error {
+	if len(res.Items) == 0 {
+		_, err := fmt.Fprintln(w, "No builds found.")
+		return err
+	}
+
+	s := style.New(w)
+	headers := []string{"NUMBER", "STATUS", "BRANCH", "WORKFLOW", "TRIGGERED", "ID"}
+	rows := make([][]string, 0, len(res.Items))
+	statuses := make([]string, 0, len(res.Items))
+	onHold := make([]bool, 0, len(res.Items))
+	for _, b := range res.Items {
+		statuses = append(statuses, b.Status)
+		onHold = append(onHold, b.IsOnHold)
+		triggered := ""
+		if !b.TriggeredAt.IsZero() {
+			triggered = b.TriggeredAt.Local().Format("2006-01-02 15:04")
+		}
+		rows = append(rows, []string{fmt.Sprintf("#%d", b.BuildNumber), b.Status, b.Branch, b.Workflow, triggered, b.Slug})
+	}
+	const colStatus = 1
+	const colSlug = 5
+	styler := func(row, col int, content string) string {
+		if col == colStatus {
+			rendered := s.BuildStatus(statuses[row]).Render(content)
+			if onHold[row] {
+				rendered += " " + s.Dim.Render("(held)")
+			}
+			return rendered
+		}
+		if col == colSlug {
+			return s.Slug.Render(content)
+		}
+		return content
+	}
+	if err := style.Table(w, headers, rows, s.Header, styler); err != nil {
+		return err
+	}
+	if res.NextCursor != "" {
+		hint := fmt.Sprintf("More results available. To fetch the next page:\n  %s", nextPageCmd(res.NextCursor))
+		_, err := fmt.Fprintf(w, "\n%s\n", s.Dim.Render(hint))
+		return err
+	}
+	return nil
+}

--- a/cli/build/list_test.go
+++ b/cli/build/list_test.go
@@ -1,0 +1,189 @@
+package build
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/bitrise-io/bitrise/v2/cli/cmdutil"
+	"github.com/bitrise-io/bitrise/v2/internal/auth"
+	"github.com/bitrise-io/bitrise/v2/internal/config"
+	"github.com/bitrise-io/bitrise/v2/log"
+)
+
+func TestListCmd_PrintsTable(t *testing.T) {
+	srv := newFakeServer(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/apps/my-app/builds", r.URL.Path)
+		_, _ = w.Write([]byte(`{"data":[{"slug":"build-1","build_number":42,"status":1,"branch":"main","triggered_workflow":"primary"}]}`))
+	})
+
+	cmd, out := newTestListCmd(t, srv.URL)
+	require.NoError(t, cmd.Flags().Set("app", "my-app"))
+	require.NoError(t, cmd.RunE(cmd, nil))
+
+	assert.Contains(t, out.String(), "#42")
+	assert.Contains(t, out.String(), "main")
+	assert.Contains(t, out.String(), "primary")
+	assert.Contains(t, out.String(), "build-1")
+}
+
+func TestListCmd_EmptyHuman(t *testing.T) {
+	srv := newFakeServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"data":[]}`))
+	})
+
+	cmd, out := newTestListCmd(t, srv.URL)
+	require.NoError(t, cmd.Flags().Set("app", "my-app"))
+	require.NoError(t, cmd.RunE(cmd, nil))
+
+	assert.Equal(t, "No builds found.\n", out.String())
+}
+
+func TestListCmd_PrintsNextPageHint(t *testing.T) {
+	srv := newFakeServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"data":[{"slug":"build-1","build_number":1,"status":1}],"paging":{"next":"page-2"}}`))
+	})
+
+	cmd, out := newTestListCmd(t, srv.URL)
+	require.NoError(t, cmd.Flags().Set("app", "my-app"))
+	require.NoError(t, cmd.Flags().Set("branch", "main"))
+	require.NoError(t, cmd.RunE(cmd, nil))
+
+	assert.Contains(t, out.String(), "More results available")
+	assert.Contains(t, out.String(), "bitrise build list --app my-app --branch main --cursor page-2")
+}
+
+func TestListCmd_RequiresApp(t *testing.T) {
+	t.Setenv(cmdutil.EnvAppIDLegacy, "")
+
+	cmd, _ := newTestListCmd(t, "https://unused.test")
+	err := cmd.RunE(cmd, nil)
+	require.EqualError(t, err, "--app is required")
+}
+
+func TestListCmd_AllFetchesEveryPage(t *testing.T) {
+	pages := 0
+	srv := newFakeServer(t, func(w http.ResponseWriter, r *http.Request) {
+		pages++
+		if r.URL.Query().Get("next") == "" {
+			_, _ = w.Write([]byte(`{"data":[{"slug":"build-1","build_number":1,"status":1}],"paging":{"next":"page-2"}}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"data":[{"slug":"build-2","build_number":2,"status":1}]}`))
+	})
+
+	cmd, out := newTestListCmd(t, srv.URL)
+	require.NoError(t, cmd.Flags().Set("app", "my-app"))
+	require.NoError(t, cmd.Flags().Set("all", "true"))
+	require.NoError(t, cmd.RunE(cmd, nil))
+
+	assert.Equal(t, 2, pages)
+	assert.Contains(t, out.String(), "build-1")
+	assert.Contains(t, out.String(), "build-2")
+	assert.NotContains(t, out.String(), "More results available")
+}
+
+func TestListCmd_AllStopsOnRepeatedCursor(t *testing.T) {
+	requests := 0
+	srv := newFakeServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		requests++
+		_, _ = w.Write([]byte(`{"data":[{"slug":"build-1","build_number":1,"status":1}],"paging":{"next":"page-2"}}`))
+	})
+
+	cmd, _ := newTestListCmd(t, srv.URL)
+	require.NoError(t, cmd.Flags().Set("app", "my-app"))
+	require.NoError(t, cmd.Flags().Set("all", "true"))
+
+	err := cmd.RunE(cmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `pagination stalled: the API returned the cursor "page-2" twice`)
+	assert.Equal(t, 2, requests, "must stop on the second repeat, not loop forever")
+}
+
+func TestListCmd_AllEmptyResultEmitsEmptyArray(t *testing.T) {
+	srv := newFakeServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"data":[]}`))
+	})
+
+	var logBuf strings.Builder
+	log.InitGlobalLogger(log.LoggerOpts{LoggerType: log.ConsoleLogger, Producer: log.BitriseCLI, Writer: &logBuf})
+
+	cmd, _ := newTestListCmd(t, srv.URL)
+	require.NoError(t, cmd.Flags().Set("app", "my-app"))
+	require.NoError(t, cmd.Flags().Set("all", "true"))
+	require.NoError(t, cmd.Flags().Set("format", "json"))
+	require.NoError(t, cmd.RunE(cmd, nil))
+
+	assert.Contains(t, logBuf.String(), `"items":[]`, "an empty --all result must match the single-page path's non-nil items array")
+}
+
+func TestListCmd_RejectsAllWithCursor(t *testing.T) {
+	cmd, _ := newTestListCmd(t, "https://unused.test")
+	require.NoError(t, cmd.Flags().Set("app", "my-app"))
+	require.NoError(t, cmd.Flags().Set("all", "true"))
+	require.NoError(t, cmd.Flags().Set("cursor", "x"))
+
+	err := cmd.RunE(cmd, nil)
+	require.EqualError(t, err, "--all and --cursor cannot be used together")
+}
+
+func TestListCmd_InvalidAfterValue(t *testing.T) {
+	cmd, _ := newTestListCmd(t, "https://unused.test")
+	require.NoError(t, cmd.Flags().Set("app", "my-app"))
+	require.NoError(t, cmd.Flags().Set("after", "not-a-date"))
+
+	err := cmd.RunE(cmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid --after value")
+}
+
+func TestListCmd_PropagatesAPIError(t *testing.T) {
+	srv := newFakeServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"message":"forbidden"}`))
+	})
+
+	cmd, _ := newTestListCmd(t, srv.URL)
+	require.NoError(t, cmd.Flags().Set("app", "my-app"))
+	err := cmd.RunE(cmd, nil)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "forbidden")
+}
+
+func TestListCmd_RejectsPositionalArgs(t *testing.T) {
+	cmd := NewListCommand()
+	cmd.SetArgs([]string{"unexpected"})
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+
+	assert.Error(t, cmd.Execute(), "positional args should be rejected before the command runs")
+}
+
+// newTestListCmd builds a NewListCommand() wired to apiBaseURL, with its
+// output captured in the returned buffer.
+func newTestListCmd(t *testing.T, apiBaseURL string) (*cobra.Command, *bytes.Buffer) {
+	t.Helper()
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	require.NoError(t, auth.Save(auth.Auth{Token: "test-token"}))
+
+	cmd := NewListCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	resolved := config.Resolve(config.Config{}, config.Config{}, config.Config{APIBaseURL: apiBaseURL})
+	cmd.SetContext(config.WithResolved(t.Context(), resolved))
+	return cmd, &out
+}
+
+func newFakeServer(t *testing.T, handler http.HandlerFunc) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	return srv
+}

--- a/cli/build/log.go
+++ b/cli/build/log.go
@@ -1,0 +1,86 @@
+package build
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/bitrise-io/bitrise/v2/cli/cmdutil"
+	internalbuild "github.com/bitrise-io/bitrise/v2/internal/build"
+)
+
+// NewLogCommand returns the `build log` subcommand.
+func NewLogCommand() *cobra.Command {
+	var (
+		wait     bool
+		interval time.Duration
+	)
+
+	cmd := &cobra.Command{
+		Use:   "log BUILD_ID",
+		Short: "Print the build log",
+		Long: `Print the log output for a single build.
+
+BUILD_ID belongs to an app: pass --app ID, or set BITRISE_APP_ID.
+
+--wait waits for the build to finish before printing the log — useful when
+the build is still in-progress. Ctrl-C detaches without affecting the
+running build.
+
+Output is always raw text — logs stream as-is, ignoring --format.`,
+		Example: `  bitrise build log abc123 --app my-app-id
+  bitrise build log abc123 --app my-app-id --wait
+  bitrise build log abc123 --app my-app-id --wait --interval 10s
+  bitrise build log abc123 --app my-app-id > build.log`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cmdutil.LogCommandParameters(cmd)
+
+			appSlug, err := cmdutil.ResolveAppSlug(cmd)
+			if err != nil {
+				return err
+			}
+			buildSlug := args[0]
+
+			client, err := cmdutil.NewAPIClient(cmd)
+			if err != nil {
+				return err
+			}
+			svc := internalbuild.NewService(client)
+
+			if wait {
+				b, err := svc.View(cmd.Context(), appSlug, buildSlug)
+				if err != nil {
+					return err
+				}
+				if b.Status == "in-progress" {
+					url := b.BuildURL
+					if url == "" {
+						url = buildWebURL(cmdutil.ResolveWebBaseURL(cmd), appSlug, buildSlug)
+					}
+					if _, err := fmt.Fprintf(cmd.ErrOrStderr(), "Waiting for build #%d to finish\n%s\n", b.BuildNumber, url); err != nil {
+						return err
+					}
+
+					if _, err := svc.WaitForCompletion(cmd.Context(), appSlug, buildSlug, interval); err != nil {
+						if errors.Is(err, context.Canceled) {
+							return writeDetachNotice(cmd.ErrOrStderr(), "build log --wait "+buildSlug)
+						}
+						return err
+					}
+				}
+			}
+
+			return svc.Log(cmd.Context(), appSlug, buildSlug, cmd.OutOrStdout())
+		},
+	}
+
+	cmd.Flags().BoolVar(&wait, "wait", false, "wait for the build to finish before printing the log")
+	cmd.Flags().DurationVar(&interval, "interval", 3*time.Second, "polling interval when --wait is active")
+	cmdutil.AddAppFlag(cmd.Flags(), "app ID (or set BITRISE_APP_ID)")
+
+	return cmd
+}

--- a/cli/build/log_test.go
+++ b/cli/build/log_test.go
@@ -1,0 +1,133 @@
+package build
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/bitrise-io/bitrise/v2/cli/cmdutil"
+	"github.com/bitrise-io/bitrise/v2/internal/auth"
+	"github.com/bitrise-io/bitrise/v2/internal/config"
+)
+
+func TestLogCmd_StreamsLogChunks(t *testing.T) {
+	var gotPath string
+	srv := newFakeServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		_, _ = w.Write([]byte(`{"is_archived":false,"log_chunks":[{"chunk":"line one\n","position":0},{"chunk":"line two\n","position":1}]}`))
+	})
+
+	cmd, out := newTestLogCmd(t, srv.URL)
+	require.NoError(t, cmd.Flags().Set("app", "my-app"))
+	require.NoError(t, cmd.RunE(cmd, []string{"b-1"}))
+
+	assert.Equal(t, "/apps/my-app/builds/b-1/log", gotPath)
+	assert.Contains(t, out.String(), "line one")
+	assert.Contains(t, out.String(), "line two")
+}
+
+func TestLogCmd_OrdersOutOfPositionChunks(t *testing.T) {
+	srv := newFakeServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"is_archived":false,"log_chunks":[{"chunk":"two\n","position":1},{"chunk":"zero\n","position":0},{"chunk":"three\n","position":3},{"chunk":"one\n","position":2}]}`))
+	})
+
+	cmd, out := newTestLogCmd(t, srv.URL)
+	require.NoError(t, cmd.Flags().Set("app", "my-app"))
+	require.NoError(t, cmd.RunE(cmd, []string{"b-1"}))
+
+	assert.Equal(t, "zero\ntwo\none\nthree\n", out.String())
+}
+
+func TestLogCmd_WaitPolls_ThenPrintsLog(t *testing.T) {
+	var viewCalls atomic.Int32
+	srv := newFakeServer(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/apps/my-app/builds/b-1":
+			n := int(viewCalls.Add(1))
+			if n == 1 {
+				_, _ = w.Write([]byte(`{"data":{"slug":"b-1","build_number":5,"status":0,"triggered_at":"2026-05-06T10:00:00Z"}}`))
+			} else {
+				_, _ = w.Write([]byte(`{"data":{"slug":"b-1","build_number":5,"status":1,"triggered_at":"2026-05-06T10:00:00Z"}}`))
+			}
+		case "/apps/my-app/builds/b-1/log":
+			_, _ = w.Write([]byte(`{"is_archived":false,"log_chunks":[{"chunk":"done\n","position":0}]}`))
+		}
+	})
+
+	cmd, out := newTestLogCmd(t, srv.URL)
+	require.NoError(t, cmd.Flags().Set("app", "my-app"))
+	require.NoError(t, cmd.Flags().Set("wait", "true"))
+	require.NoError(t, cmd.Flags().Set("interval", "1ms"))
+	require.NoError(t, cmd.RunE(cmd, []string{"b-1"}))
+
+	assert.Contains(t, out.String(), "Waiting for build")
+	assert.Contains(t, out.String(), "done")
+}
+
+func TestLogCmd_WaitSkipsPolling_WhenAlreadyFinished(t *testing.T) {
+	var viewCalls atomic.Int32
+	srv := newFakeServer(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/apps/my-app/builds/b-1":
+			viewCalls.Add(1)
+			_, _ = w.Write([]byte(`{"data":{"slug":"b-1","build_number":5,"status":1,"triggered_at":"2026-05-06T10:00:00Z"}}`))
+		case "/apps/my-app/builds/b-1/log":
+			_, _ = w.Write([]byte(`{"is_archived":false,"log_chunks":[{"chunk":"all good\n","position":0}]}`))
+		}
+	})
+
+	cmd, out := newTestLogCmd(t, srv.URL)
+	require.NoError(t, cmd.Flags().Set("app", "my-app"))
+	require.NoError(t, cmd.Flags().Set("wait", "true"))
+	require.NoError(t, cmd.Flags().Set("interval", "1ms"))
+	require.NoError(t, cmd.RunE(cmd, []string{"b-1"}))
+
+	assert.NotContains(t, out.String(), "Waiting for build", "should not print wait header for a finished build")
+	assert.Equal(t, 1, int(viewCalls.Load()), "expected exactly 1 View call")
+	assert.Contains(t, out.String(), "all good")
+}
+
+func TestLogCmd_StreamsArchivedLog(t *testing.T) {
+	rawSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("ARCHIVED LOG CONTENT\n"))
+	}))
+	t.Cleanup(rawSrv.Close)
+
+	srv := newFakeServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"is_archived":true,"expiring_raw_log_url":"` + rawSrv.URL + `"}`))
+	})
+
+	cmd, out := newTestLogCmd(t, srv.URL)
+	require.NoError(t, cmd.Flags().Set("app", "my-app"))
+	require.NoError(t, cmd.RunE(cmd, []string{"b-1"}))
+
+	assert.Contains(t, out.String(), "ARCHIVED LOG CONTENT")
+}
+
+func TestLogCmd_RequiresApp(t *testing.T) {
+	t.Setenv(cmdutil.EnvAppIDLegacy, "")
+
+	cmd, _ := newTestLogCmd(t, "https://unused.test")
+	err := cmd.RunE(cmd, []string{"b-1"})
+	require.EqualError(t, err, "--app is required")
+}
+
+func newTestLogCmd(t *testing.T, apiBaseURL string) (*cobra.Command, *bytes.Buffer) {
+	t.Helper()
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	require.NoError(t, auth.Save(auth.Auth{Token: "test-token"}))
+
+	cmd := NewLogCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	resolved := config.Resolve(config.Config{}, config.Config{}, config.Config{APIBaseURL: apiBaseURL})
+	cmd.SetContext(config.WithResolved(t.Context(), resolved))
+	return cmd, &out
+}

--- a/cli/build/main_test.go
+++ b/cli/build/main_test.go
@@ -1,0 +1,18 @@
+package build
+
+import (
+	"os"
+	"testing"
+
+	"github.com/bitrise-io/bitrise/v2/analytics/analyticstest"
+	"github.com/bitrise-io/bitrise/v2/cli/cmdutil"
+)
+
+// TestMain installs a no-op analytics tracker: RunE calls
+// cmdutil.LogCommandParameters, which panics on the package-level tracker's
+// zero value if nothing has called cmdutil.SetTracker (normally done once at
+// real CLI startup, cli/cli.go).
+func TestMain(m *testing.M) {
+	cmdutil.SetTracker(analyticstest.NoOpTracker{})
+	os.Exit(m.Run())
+}

--- a/cli/build/utils.go
+++ b/cli/build/utils.go
@@ -1,0 +1,103 @@
+package build
+
+import (
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	internalbuild "github.com/bitrise-io/bitrise/v2/internal/build"
+)
+
+// printBuildText writes a full key/value dump of a build. Used by `build
+// view`'s --format raw output.
+func printBuildText(w io.Writer, b internalbuild.Build) error {
+	var buf strings.Builder
+	fmt.Fprintf(&buf, "Build #%d\n", b.BuildNumber)
+	fmt.Fprintf(&buf, "App:          %s\n", b.AppSlug)
+	fmt.Fprintf(&buf, "Status:       %s\n", b.Status)
+	if b.StatusText != "" {
+		fmt.Fprintf(&buf, "Status Text:  %s\n", b.StatusText)
+	}
+	if b.AbortReason != "" {
+		fmt.Fprintf(&buf, "Abort Reason: %s\n", b.AbortReason)
+	}
+	if b.IsOnHold {
+		fmt.Fprintln(&buf, "On Hold:      yes")
+	}
+	if b.Rebuildable {
+		fmt.Fprintln(&buf, "Rebuildable:  yes")
+	}
+	if b.Workflow != "" {
+		fmt.Fprintf(&buf, "Workflow:     %s\n", b.Workflow)
+	}
+	if b.PipelineWorkflowID != "" {
+		fmt.Fprintf(&buf, "Pipeline WF:  %s\n", b.PipelineWorkflowID)
+	}
+	if b.Branch != "" {
+		fmt.Fprintf(&buf, "Branch:       %s\n", b.Branch)
+	}
+	if b.Tag != "" {
+		fmt.Fprintf(&buf, "Tag:          %s\n", b.Tag)
+	}
+	if b.PullRequestID != 0 {
+		fmt.Fprintf(&buf, "Pull Request: #%d", b.PullRequestID)
+		if b.PullRequestTargetBranch != "" {
+			fmt.Fprintf(&buf, " -> %s", b.PullRequestTargetBranch)
+		}
+		fmt.Fprintln(&buf)
+		if b.PullRequestViewURL != "" {
+			fmt.Fprintf(&buf, "PR URL:       %s\n", b.PullRequestViewURL)
+		}
+	}
+	if b.CommitHash != "" {
+		fmt.Fprintf(&buf, "Commit:       %s\n", b.CommitHash)
+	}
+	if b.CommitMessage != "" {
+		fmt.Fprintf(&buf, "Message:      %s\n", b.CommitMessage)
+	}
+	if !b.TriggeredAt.IsZero() {
+		fmt.Fprintf(&buf, "Triggered:    %s\n", b.TriggeredAt.Local().Format(time.RFC3339))
+	}
+	if b.TriggeredBy != "" {
+		fmt.Fprintf(&buf, "Triggered By: %s\n", b.TriggeredBy)
+	}
+	if b.FinishedAt != nil {
+		fmt.Fprintf(&buf, "Finished:     %s\n", b.FinishedAt.Local().Format(time.RFC3339))
+	}
+	if b.StackIdentifier != "" {
+		fmt.Fprintf(&buf, "Stack:        %s\n", b.StackIdentifier)
+	}
+	if b.MachineTypeID != "" {
+		fmt.Fprintf(&buf, "Machine Type: %s\n", b.MachineTypeID)
+	}
+	if b.CreditCost != 0 {
+		fmt.Fprintf(&buf, "Credit Cost:  %d\n", b.CreditCost)
+	}
+	if b.BuildURL != "" {
+		fmt.Fprintf(&buf, "URL:          %s\n", b.BuildURL)
+	}
+	_, err := io.WriteString(w, buf.String())
+	return err
+}
+
+// printAbortText writes the short confirmation line for `build abort`.
+func printAbortText(w io.Writer, r internalbuild.AbortResult) error {
+	_, err := fmt.Fprintf(w, "Build aborted: %s\n", r.BuildSlug)
+	return err
+}
+
+// buildWebURL constructs the web URL for a build, for commands where the
+// service's Build.BuildURL isn't populated by the API (only the trigger
+// response provides one; view/list/watch build the URL themselves instead).
+func buildWebURL(webBaseURL, appSlug, buildSlug string) string {
+	return fmt.Sprintf("%s/app/%s/build/%s", webBaseURL, appSlug, buildSlug)
+}
+
+// writeDetachNotice writes the standard Ctrl-C detach message to w. resumeCmd
+// is the command (without the "bitrise " prefix) the user can run to resume.
+// Shared by every wait/watch path so the wording stays consistent.
+func writeDetachNotice(w io.Writer, resumeCmd string) error {
+	_, err := fmt.Fprintf(w, "\nDetached — build is still running.\nUse 'bitrise %s' to resume.\n", resumeCmd)
+	return err
+}

--- a/cli/build/view.go
+++ b/cli/build/view.go
@@ -1,0 +1,78 @@
+package build
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/bitrise-io/bitrise/v2/cli/cmdutil"
+	internalbuild "github.com/bitrise-io/bitrise/v2/internal/build"
+	"github.com/bitrise-io/bitrise/v2/output"
+)
+
+// NewViewCommand returns the `build view` subcommand.
+func NewViewCommand() *cobra.Command {
+	var web bool
+
+	cmd := &cobra.Command{
+		Use:   "view BUILD_ID",
+		Short: "Show details of a single build",
+		Long: `Show details for a single build identified by its ID.
+
+BUILD_ID belongs to an app: pass --app ID, or set BITRISE_APP_ID (or run
+"bitrise config set app_id ID").`,
+		Example: `  bitrise build view abc123 --app my-app-id
+  bitrise build view abc123 --app my-app-id --format json
+  bitrise build view abc123 --app my-app-id --web`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runView(cmd, args, web, cmdutil.OpenBrowser)
+		},
+	}
+
+	cmdutil.AddAppFlag(cmd.Flags(), "app ID (or set BITRISE_APP_ID)")
+	cmd.Flags().BoolVar(&web, "web", false, "open the build page in the browser instead of printing")
+	cmd.Flags().StringP(cmdutil.FormatKey, "f", "", "Output format. Accepted: raw (default), json, yml")
+
+	return cmd
+}
+
+// runView is NewViewCommand's RunE, with browser-opening injected so tests
+// can exercise --web without launching a real browser.
+func runView(cmd *cobra.Command, args []string, web bool, openBrowser func(string) error) error {
+	cmdutil.LogCommandParameters(cmd)
+
+	format, _ := cmd.Flags().GetString(cmdutil.FormatKey)
+	if err := output.ConfigureOutputFormat(format); err != nil {
+		return fmt.Errorf("failed to configure output format: %w", err)
+	}
+
+	appSlug, err := cmdutil.ResolveAppSlug(cmd)
+	if err != nil {
+		return err
+	}
+	buildSlug := args[0]
+
+	if web {
+		url := buildWebURL(cmdutil.ResolveWebBaseURL(cmd), appSlug, buildSlug)
+		if err := openBrowser(url); err != nil {
+			return err
+		}
+		_, err := fmt.Fprintf(cmd.ErrOrStderr(), "Opened %s\n", url)
+		return err
+	}
+
+	client, err := cmdutil.NewAPIClient(cmd)
+	if err != nil {
+		return err
+	}
+	b, err := internalbuild.NewService(client).View(cmd.Context(), appSlug, buildSlug)
+	if err != nil {
+		return err
+	}
+	if b.BuildURL == "" {
+		b.BuildURL = buildWebURL(cmdutil.ResolveWebBaseURL(cmd), appSlug, buildSlug)
+	}
+
+	return output.Render(cmd.OutOrStdout(), output.Format, b, printBuildText)
+}

--- a/cli/build/view_test.go
+++ b/cli/build/view_test.go
@@ -1,0 +1,111 @@
+package build
+
+import (
+	"bytes"
+	"net/http"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/bitrise-io/bitrise/v2/cli/cmdutil"
+	"github.com/bitrise-io/bitrise/v2/internal/auth"
+	"github.com/bitrise-io/bitrise/v2/internal/config"
+)
+
+func TestViewCmd_HappyPath(t *testing.T) {
+	var gotPath string
+	srv := newFakeServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		_, _ = w.Write([]byte(`{"data":{"slug":"build-1","build_number":7,"status":1,"branch":"main","triggered_workflow":"primary"}}`))
+	})
+
+	cmd := newTestViewCmd(t, srv.URL)
+	require.NoError(t, cmd.Flags().Set("app", "my-app"))
+	out, err := runViewCapture(t, cmd, []string{"build-1"}, false, unusedBrowser(t))
+	require.NoError(t, err)
+
+	assert.Equal(t, "/apps/my-app/builds/build-1", gotPath)
+	assert.Regexp(t, `Build #7`, out)
+	assert.Regexp(t, `Status:\s+success`, out)
+	assert.Regexp(t, `Branch:\s+main`, out)
+	assert.Regexp(t, `Workflow:\s+primary`, out)
+}
+
+func TestViewCmd_RequiresApp(t *testing.T) {
+	t.Setenv(cmdutil.EnvAppIDLegacy, "")
+
+	cmd := newTestViewCmd(t, "https://unused.test")
+	_, err := runViewCapture(t, cmd, []string{"build-1"}, false, unusedBrowser(t))
+	require.EqualError(t, err, "--app is required")
+}
+
+func TestViewCmd_BuildNotFound(t *testing.T) {
+	srv := newFakeServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"message":"not found"}`))
+	})
+
+	cmd := newTestViewCmd(t, srv.URL)
+	require.NoError(t, cmd.Flags().Set("app", "my-app"))
+	_, err := runViewCapture(t, cmd, []string{"missing"}, false, unusedBrowser(t))
+	require.EqualError(t, err, `build "missing" not found`)
+}
+
+func TestViewCmd_Web_OpensBrowserAndSkipsAPICall(t *testing.T) {
+	cmd := newTestViewCmd(t, "https://unused.test")
+	require.NoError(t, cmd.Flags().Set("app", "my-app"))
+	t.Setenv(cmdutil.EnvWebBaseURL, "https://app.bitrise.io")
+
+	var gotURL string
+	_, err := runViewCapture(t, cmd, []string{"build-1"}, true, func(url string) error {
+		gotURL = url
+		return nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "https://app.bitrise.io/app/my-app/build/build-1", gotURL)
+}
+
+func TestViewCmd_RejectsWrongArgCount(t *testing.T) {
+	for _, args := range [][]string{{}, {"a", "b"}} {
+		cmd := NewViewCommand()
+		cmd.SetArgs(args)
+		cmd.SetOut(&bytes.Buffer{})
+		cmd.SetErr(&bytes.Buffer{})
+		assert.Error(t, cmd.Execute(), "args=%v should be rejected", args)
+	}
+}
+
+// unusedBrowser fails the test if the browser opener is ever invoked, for
+// cases where --web is off and no browser call is expected.
+func unusedBrowser(t *testing.T) func(string) error {
+	t.Helper()
+	return func(url string) error {
+		t.Fatalf("unexpected browser open: %s", url)
+		return nil
+	}
+}
+
+// runViewCapture calls runView and returns whatever it wrote to cmd's output.
+func runViewCapture(t *testing.T, cmd *cobra.Command, args []string, web bool, openBrowser func(string) error) (string, error) {
+	t.Helper()
+	err := runView(cmd, args, web, openBrowser)
+	buf, ok := cmd.OutOrStdout().(*bytes.Buffer)
+	require.True(t, ok)
+	return buf.String(), err
+}
+
+// newTestViewCmd builds a NewViewCommand() wired to apiBaseURL, with its
+// output captured for runViewCapture to retrieve.
+func newTestViewCmd(t *testing.T, apiBaseURL string) *cobra.Command {
+	t.Helper()
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	require.NoError(t, auth.Save(auth.Auth{Token: "test-token"}))
+
+	cmd := NewViewCommand()
+	cmd.SetOut(&bytes.Buffer{})
+	resolved := config.Resolve(config.Config{}, config.Config{}, config.Config{APIBaseURL: apiBaseURL})
+	cmd.SetContext(config.WithResolved(t.Context(), resolved))
+	return cmd
+}

--- a/cli/build/yml.go
+++ b/cli/build/yml.go
@@ -1,0 +1,64 @@
+package build
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/bitrise-io/bitrise/v2/cli/cmdutil"
+	internalyml "github.com/bitrise-io/bitrise/v2/internal/yml"
+	"github.com/bitrise-io/bitrise/v2/output"
+)
+
+// NewYMLCommand returns the `build yml` subcommand.
+func NewYMLCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "yml BUILD_ID",
+		Short: "Print the bitrise.yml a specific build ran with",
+		Long: `Print the bitrise.yml configuration that a specific build ran with.
+
+This is a shortcut for "bitrise yml get --app ID --build BUILD_ID".`,
+		Example: `  bitrise build yml abc123 --app my-app-id
+  bitrise build yml abc123 --app my-app-id --format json`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cmdutil.LogCommandParameters(cmd)
+
+			format, _ := cmd.Flags().GetString(cmdutil.FormatKey)
+			if err := output.ConfigureOutputFormat(format); err != nil {
+				return err
+			}
+
+			appSlug, err := cmdutil.ResolveAppSlug(cmd)
+			if err != nil {
+				return err
+			}
+
+			client, err := cmdutil.NewAPIClient(cmd)
+			if err != nil {
+				return err
+			}
+
+			result, err := internalyml.NewService(client).Get(cmd.Context(), appSlug, args[0])
+			if err != nil {
+				return err
+			}
+
+			return output.Render(cmd.OutOrStdout(), output.Format, result, func(w io.Writer, result internalyml.GetResult) error {
+				content := result.Content
+				if content != "" && !strings.HasSuffix(content, "\n") {
+					content += "\n"
+				}
+				_, err := fmt.Fprint(w, content)
+				return err
+			})
+		},
+	}
+
+	cmdutil.AddAppFlag(cmd.Flags(), "app ID (or set BITRISE_APP_ID)")
+	cmd.Flags().StringP(cmdutil.FormatKey, "f", "", "Output format. Accepted: raw (default), json, yml")
+
+	return cmd
+}

--- a/cli/build/yml_test.go
+++ b/cli/build/yml_test.go
@@ -1,0 +1,61 @@
+package build
+
+import (
+	"bytes"
+	"net/http"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/bitrise-io/bitrise/v2/cli/cmdutil"
+	"github.com/bitrise-io/bitrise/v2/internal/auth"
+	"github.com/bitrise-io/bitrise/v2/internal/config"
+)
+
+func TestYMLCmd_HappyPath(t *testing.T) {
+	var gotPath string
+	srv := newFakeServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		_, _ = w.Write([]byte("format_version: \"13\"\n"))
+	})
+
+	cmd, out := newTestYMLCmd(t, srv.URL)
+	require.NoError(t, cmd.Flags().Set("app", "my-app"))
+	require.NoError(t, cmd.RunE(cmd, []string{"build-1"}))
+
+	assert.Equal(t, "/apps/my-app/builds/build-1/bitrise.yml", gotPath)
+	assert.Equal(t, "format_version: \"13\"\n", out.String())
+}
+
+func TestYMLCmd_RequiresApp(t *testing.T) {
+	t.Setenv(cmdutil.EnvAppIDLegacy, "")
+
+	cmd, _ := newTestYMLCmd(t, "https://unused.test")
+	err := cmd.RunE(cmd, []string{"build-1"})
+	require.EqualError(t, err, "--app is required")
+}
+
+func TestYMLCmd_RejectsWrongArgCount(t *testing.T) {
+	for _, args := range [][]string{{}, {"a", "b"}} {
+		cmd := NewYMLCommand()
+		cmd.SetArgs(args)
+		cmd.SetOut(&bytes.Buffer{})
+		cmd.SetErr(&bytes.Buffer{})
+		assert.Error(t, cmd.Execute(), "args=%v should be rejected", args)
+	}
+}
+
+func newTestYMLCmd(t *testing.T, apiBaseURL string) (*cobra.Command, *bytes.Buffer) {
+	t.Helper()
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	require.NoError(t, auth.Save(auth.Auth{Token: "test-token"}))
+
+	cmd := NewYMLCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	resolved := config.Resolve(config.Config{}, config.Config{}, config.Config{APIBaseURL: apiBaseURL})
+	cmd.SetContext(config.WithResolved(t.Context(), resolved))
+	return cmd, &out
+}

--- a/cli/root.go
+++ b/cli/root.go
@@ -8,6 +8,7 @@ import (
 	"github.com/bitrise-io/bitrise/v2/cli/api"
 	"github.com/bitrise-io/bitrise/v2/cli/app"
 	"github.com/bitrise-io/bitrise/v2/cli/auth"
+	"github.com/bitrise-io/bitrise/v2/cli/build"
 	"github.com/bitrise-io/bitrise/v2/cli/cmdutil"
 	"github.com/bitrise-io/bitrise/v2/cli/config"
 	"github.com/bitrise-io/bitrise/v2/cli/local"
@@ -57,6 +58,7 @@ func newRootCommand() *cobra.Command {
 		stack.NewCmd(),
 		user.NewCmd(),
 		app.NewCmd(),
+		build.NewCmd(),
 		api.NewCmd(),
 		config.NewCmd(),
 

--- a/internal/style/style.go
+++ b/internal/style/style.go
@@ -3,11 +3,11 @@
 // must not leak into machine-readable output.
 //
 // This is a trimmed port of bitrise-cli's internal/output/style package:
-// only the styles and Table renderer that `stack list` uses today are
-// included. Theme overrides, --no-color/--theme flags, and styles used only
-// by commands not yet ported (build status, OAuth picker, etc.) are left out
-// on purpose — add them when a command that actually needs them lands,
-// rather than carrying dead code now.
+// only the styles and Table renderer actually consumed by a landed command
+// are included. Theme overrides, --no-color/--theme flags, and styles used
+// only by commands not yet ported (OAuth picker, etc.) are left out on
+// purpose — add them when a command that actually needs them lands, rather
+// than carrying dead code now.
 package style
 
 import (
@@ -17,6 +17,9 @@ import (
 	"github.com/charmbracelet/lipgloss"
 )
 
+// BrandColor is Bitrise's brand purple, used by the build-watch spinner.
+const BrandColor = lipgloss.Color("#7B61FF")
+
 // 256-color palette, paired by terminal background brightness. Each
 // AdaptiveColor pairs a color tuned for dark terminals with one tuned for
 // light terminals; lipgloss picks the appropriate side automatically.
@@ -24,6 +27,9 @@ var (
 	dimColor     = lipgloss.AdaptiveColor{Light: "240", Dark: "245"} // grey
 	successColor = lipgloss.AdaptiveColor{Light: "28", Dark: "42"}   // green
 	warnColor    = lipgloss.AdaptiveColor{Light: "136", Dark: "220"} // yellow / olive
+	failedColor  = lipgloss.AdaptiveColor{Light: "160", Dark: "203"} // red
+	runningColor = lipgloss.AdaptiveColor{Light: "25", Dark: "39"}   // blue
+	abortedColor = lipgloss.AdaptiveColor{Light: "166", Dark: "208"} // orange
 )
 
 // Styles bundles the semantic styles used across human renderers. It is
@@ -35,6 +41,13 @@ type Styles struct {
 	Slug    lipgloss.Style // technical identifiers (dimmed)
 	Success lipgloss.Style // success indicators
 	Warn    lipgloss.Style // warnings
+	Bold    lipgloss.Style // emphasis
+	Label   lipgloss.Style // field labels in key/value dumps
+	URL     lipgloss.Style // links
+
+	failed  lipgloss.Style
+	running lipgloss.Style
+	aborted lipgloss.Style
 }
 
 // New returns a Styles bundle for the given writer. ANSI escape codes are
@@ -48,6 +61,30 @@ func New(w io.Writer) Styles {
 		Slug:    r.NewStyle().Foreground(dimColor),
 		Success: r.NewStyle().Foreground(successColor),
 		Warn:    r.NewStyle().Foreground(warnColor),
+		Bold:    r.NewStyle().Bold(true),
+		Label:   r.NewStyle().Bold(true),
+		URL:     r.NewStyle().Foreground(runningColor).Underline(true),
+		failed:  r.NewStyle().Foreground(failedColor),
+		running: r.NewStyle().Foreground(runningColor),
+		aborted: r.NewStyle().Foreground(abortedColor),
+	}
+}
+
+// BuildStatus returns the style to render a build status string in
+// (success/failed/in-progress/aborted/aborted-with-success), falling back to
+// Dim for any other value.
+func (s Styles) BuildStatus(status string) lipgloss.Style {
+	switch status {
+	case "success":
+		return s.Success
+	case "failed":
+		return s.failed
+	case "in-progress":
+		return s.running
+	case "aborted", "aborted-with-success":
+		return s.aborted
+	default:
+		return s.Dim
 	}
 }
 

--- a/internal/style/style_test.go
+++ b/internal/style/style_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"strings"
 	"testing"
+
+	"github.com/charmbracelet/lipgloss"
 )
 
 func TestNew_NonTTYWriterIsAnsiFree(t *testing.T) {
@@ -18,6 +20,25 @@ func TestNew_NonTTYWriterIsAnsiFree(t *testing.T) {
 		}
 		if got := s.Success.Render(in); got != in {
 			t.Errorf("Success.Render(%q) = %q, want plain", in, got)
+		}
+	}
+}
+
+func TestBuildStatus_KnownAndUnknownValues(t *testing.T) {
+	var buf bytes.Buffer
+	s := New(&buf)
+
+	cases := map[string]lipgloss.Style{
+		"success":               s.Success,
+		"failed":                s.failed,
+		"in-progress":           s.running,
+		"aborted":               s.aborted,
+		"aborted-with-success":  s.aborted,
+		"some-unrecognized-str": s.Dim,
+	}
+	for status, want := range cases {
+		if got := s.BuildStatus(status); got.String() != want.String() {
+			t.Errorf("BuildStatus(%q) = %q, want %q", status, got.String(), want.String())
 		}
 	}
 }


### PR DESCRIPTION
Adds the `bitrise build` parent command and its five non-interactive subcommands: `list`, `view`, `log`, `abort`, and `yml`. `trigger` and `watch` (the interactive/TUI path) follow in a separate PR.

Also adds the build-status colors and Bold/Label/URL styles to `internal/style`, used by `list`'s status column and the human-format renderers here.