### PR TITLE
v3 prep: `purr` command

### DIFF
--- a/cli/cmdutil/secret.go
+++ b/cli/cmdutil/secret.go
@@ -40,7 +40,7 @@ func CheckPasswordStdinPiped(passwordStdin, isTerminal bool, exampleCmd string) 
 }
 
 func readSecretInput(in io.Reader, stderr io.Writer, prompt string, fromStdin bool, trim func(string) string) (string, error) {
-	if fd, ok := terminalFd(in); ok && !fromStdin {
+	if fd, ok := TerminalFd(in); ok && !fromStdin {
 		if _, err := fmt.Fprint(stderr, prompt); err != nil {
 			return "", err
 		}

--- a/cli/cmdutil/terminal.go
+++ b/cli/cmdutil/terminal.go
@@ -7,9 +7,9 @@ import (
 	"golang.org/x/term"
 )
 
-// terminalFd reports whether stream is an *os.File backed by a TTY. fd is
+// TerminalFd reports whether stream is an *os.File backed by a TTY. fd is
 // only meaningful when isTerminal is true.
-func terminalFd(stream any) (fd int, isTerminal bool) {
+func TerminalFd(stream any) (fd int, isTerminal bool) {
 	f, ok := stream.(*os.File)
 	if !ok {
 		return 0, false
@@ -22,13 +22,13 @@ func terminalFd(stream any) (fd int, isTerminal bool) {
 // never are, so callers can pick an interactive default (e.g. browser login)
 // while keeping non-interactive stdin (CI, pipes) working.
 func IsTerminal(r io.Reader) bool {
-	_, ok := terminalFd(r)
+	_, ok := TerminalFd(r)
 	return ok
 }
 
 // IsTerminalWriter reports whether w is an interactive terminal, e.g. for
 // gating pretty-printing so piped or redirected output isn't reformatted.
 func IsTerminalWriter(w io.Writer) bool {
-	_, ok := terminalFd(w)
+	_, ok := TerminalFd(w)
 	return ok
 }

--- a/cli/purr/cmd.go
+++ b/cli/purr/cmd.go
@@ -1,0 +1,215 @@
+// Package purr implements the `bitrise purr` easter egg: an animated ASCII
+// cat mascot with a rainbow-shimmer message.
+package purr
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"math"
+	"os"
+	"os/signal"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+	"golang.org/x/term"
+
+	"github.com/bitrise-io/bitrise/v2/cli/cmdutil"
+	"github.com/bitrise-io/bitrise/v2/internal/style"
+)
+
+// purrFrames are the cat-mascot ASCII frames cycled by `bitrise purr`. Each
+// frame has the same shape; only the body+tail row differs to suggest a
+// happily swinging tail. Keep all frames the same line count and column
+// width so the in-place redraw doesn't jiggle.
+var purrFrames = []string{
+	purrFrame("--==>>"),
+	purrFrame("~~==>>"),
+	purrFrame("__==>>"),
+	purrFrame("~~==>>"),
+}
+
+func purrFrame(tail string) string {
+	return fmt.Sprintf(`
+                  _______
+                 /  o  o  \
+                ;    \_/   ;
+                 \        /
+                  '------'
+                __|        |__
+               |   *  *  *  |%s
+               |______________|
+                  /\      /\
+                 '  '    '  '
+`, tail)
+}
+
+const purrMessage = "Purr Request is always here to help you!"
+
+// ANSI control sequences used to drive the in-place animation. Kept as
+// named constants because the bare escape codes are easy to misread.
+const (
+	ansiHideCursor = "\x1b[?25l"
+	ansiShowCursor = "\x1b[?25h"
+	ansiClearBelow = "\x1b[J"   // clear from cursor to end of screen
+	ansiCursorPrev = "\x1b[%dF" // CPL: move cursor up N lines, to column 0
+)
+
+// hueShiftPerFrame controls how fast the rainbow shimmer scrolls. 15° per
+// 250ms tick = one full spectrum every 6s, slow enough to read but fast
+// enough to be obviously alive.
+const hueShiftPerFrame = 15.0
+
+// NewCmd returns the `bitrise purr` command.
+func NewCmd() *cobra.Command {
+	var (
+		once     bool
+		duration time.Duration
+		interval time.Duration
+	)
+	c := &cobra.Command{
+		Use:    "purr",
+		Short:  "Visit Purr Request, the Bitrise CLI mascot",
+		Hidden: true,
+		Long: `Visit Purr Request — the rocket-powered cat that's always here to help you.
+
+The mascot animates with a swinging tail. The animation runs for --duration
+(default 8s) or until Ctrl-C, advancing one frame every --interval (default
+250ms); --once disables animation and prints a single frame. When stdout is
+not a terminal (piped output, log file) the command always prints once and
+exits regardless of --once.`,
+		Example: `  bitrise purr
+  bitrise purr --duration 30s
+  bitrise purr --interval 100ms
+  bitrise purr --once`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cmdutil.LogCommandParameters(cmd)
+			return runPurr(cmd.Context(), cmd.InOrStdin(), cmd.OutOrStdout(), once, duration, interval)
+		},
+	}
+	c.Flags().BoolVar(&once, "once", false, "print a single frame instead of animating")
+	c.Flags().DurationVar(&duration, "duration", 8*time.Second, "how long to animate before exiting")
+	c.Flags().DurationVar(&interval, "interval", 250*time.Millisecond, "delay between animation frames")
+	return c
+}
+
+func runPurr(ctx context.Context, in io.Reader, out io.Writer, once bool, duration, interval time.Duration) error {
+	s := style.New(out)
+
+	// Static path: piped output, --once, or stdout isn't a TTY. Rainbow
+	// auto-degrades to plain text on non-color writers.
+	if once || !cmdutil.IsTerminalWriter(out) {
+		if _, err := fmt.Fprint(out, purrFrames[0]); err != nil {
+			return err
+		}
+		_, err := fmt.Fprintln(out, s.Rainbow(purrMessage, 0))
+		return err
+	}
+
+	// Hide cursor during animation, restore even on early exit.
+	if _, err := fmt.Fprint(out, ansiHideCursor); err != nil {
+		return err
+	}
+	defer func() { _, _ = fmt.Fprint(out, ansiShowCursor) }()
+
+	// Stop cleanly on Ctrl-C.
+	ctx, cancel := signal.NotifyContext(ctx, os.Interrupt)
+	defer cancel()
+
+	// If stdin is a TTY, put it into raw mode and watch for a keypress so
+	// any key (including Ctrl-C, which raw mode delivers as a byte rather
+	// than a signal) ends the animation. The blocking Read will outlive
+	// runPurr when the timer or ctx fires first; that's fine for a short-
+	// lived CLI invocation since the OS reaps the goroutine on exit.
+	//
+	// term.MakeRaw also disables ONLCR on the shared tty device, so plain
+	// "\n" stops carriage-returning — without compensation each redrawn
+	// line stair-steps to the right. We wrap the output in a tiny "\n →
+	// \r\n" translator for the duration of the animation; cursor escape
+	// codes don't contain newlines so they pass through untouched.
+	keyPress := make(chan struct{})
+	if fd, ok := cmdutil.TerminalFd(in); ok {
+		if oldState, err := term.MakeRaw(fd); err == nil {
+			defer func() { _ = term.Restore(fd, oldState) }()
+			out = &crlfWriter{w: out}
+			go func() {
+				buf := make([]byte, 1)
+				_, _ = in.Read(buf)
+				close(keyPress)
+			}()
+		}
+	}
+
+	hue := 0.0
+
+	// Initial paint.
+	if _, err := fmt.Fprint(out, purrFrames[0]); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintln(out, s.Rainbow(purrMessage, hue)); err != nil {
+		return err
+	}
+
+	// One \n in the frame string + one from Fprintln(message) gives the
+	// total number of cursor-down moves we need to undo each tick.
+	height := strings.Count(purrFrames[0], "\n") + 1
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	deadline := time.NewTimer(duration)
+	defer deadline.Stop()
+
+	frame := 0
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-deadline.C:
+			return nil
+		case <-keyPress:
+			return nil
+		case <-ticker.C:
+			frame = (frame + 1) % len(purrFrames)
+			hue = math.Mod(hue+hueShiftPerFrame, 360)
+			// Move cursor back to the top of the frame, clear everything below,
+			// and redraw the frame + the (newly hue-shifted) rainbow message.
+			if _, err := fmt.Fprintf(out, ansiCursorPrev, height); err != nil {
+				return err
+			}
+			if _, err := fmt.Fprint(out, ansiClearBelow); err != nil {
+				return err
+			}
+			if _, err := fmt.Fprint(out, purrFrames[frame]); err != nil {
+				return err
+			}
+			if _, err := fmt.Fprintln(out, s.Rainbow(purrMessage, hue)); err != nil {
+				return err
+			}
+		}
+	}
+}
+
+// crlfWriter translates each "\n" byte in its input to "\r\n", forwarding
+// everything else unchanged. Used during the animation because raw-mode
+// stdin disables ONLCR on the shared tty, so the kernel no longer adds the
+// carriage-return for us. Bytes-from-p accounting matches the io.Writer
+// contract: a "\n" counts as 1 byte consumed even though 2 bytes were
+// emitted to the underlying writer.
+type crlfWriter struct{ w io.Writer }
+
+func (c *crlfWriter) Write(p []byte) (int, error) {
+	for i, b := range p {
+		var chunk []byte
+		if b == '\n' {
+			chunk = []byte{'\r', '\n'}
+		} else {
+			chunk = p[i : i+1]
+		}
+		if _, err := c.w.Write(chunk); err != nil {
+			return i, err
+		}
+	}
+	return len(p), nil
+}

--- a/cli/purr/cmd_test.go
+++ b/cli/purr/cmd_test.go
@@ -1,0 +1,107 @@
+package purr
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPurr_StaticToBuffer(t *testing.T) {
+	// *bytes.Buffer is never a TTY → the static path runs even without
+	// --once. Confirms that a non-TTY destination never animates and
+	// always emits ANSI-free output.
+	var buf bytes.Buffer
+	require.NoError(t, runPurr(t.Context(), nil, &buf, false, time.Second, time.Millisecond))
+	out := buf.String()
+	assert.NotContains(t, out, "\x1b[")
+	assert.Contains(t, out, purrMessage)
+	// Cat ear lines + message + leading blank = exactly 12 lines.
+	assert.Equal(t, 12, strings.Count(out, "\n"))
+}
+
+func TestPurr_OnceDoesntAnimate(t *testing.T) {
+	var buf bytes.Buffer
+	require.NoError(t, runPurr(t.Context(), nil, &buf, true, time.Hour, time.Microsecond))
+	// With once=true the function returns immediately after one paint; it
+	// must not block on the ticker even with a microsecond interval.
+	assert.Contains(t, buf.String(), "Purr Request")
+}
+
+func TestPurr_StaticMessageHasNoANSIOnBuffer(t *testing.T) {
+	// Even with the rainbow effect, output to *bytes.Buffer must remain
+	// ANSI-free — that's the contract that keeps log files / pipes / JSON
+	// output clean.
+	var buf bytes.Buffer
+	require.NoError(t, runPurr(t.Context(), nil, &buf, true, time.Second, time.Millisecond))
+	assert.NotContains(t, buf.String(), "\x1b[")
+}
+
+func TestCRLFWriter_TranslatesNewlines(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"hello", "hello"},
+		{"line1\nline2", "line1\r\nline2"},
+		{"a\nb\nc", "a\r\nb\r\nc"},
+		{"\n\n", "\r\n\r\n"},
+		// Already-CRLF should NOT be doubled — \r passes through, then \n becomes \r\n.
+		{"a\r\nb", "a\r\r\nb"},
+		// Cursor escape codes don't contain \n, must pass through untouched.
+		{"\x1b[5Fhello", "\x1b[5Fhello"},
+	}
+	for _, c := range cases {
+		var buf bytes.Buffer
+		w := &crlfWriter{w: &buf}
+		n, err := w.Write([]byte(c.in))
+		require.NoError(t, err)
+		assert.Equal(t, len(c.in), n, "Write(%q) return value per io.Writer contract", c.in)
+		assert.Equal(t, c.want, buf.String())
+	}
+}
+
+func TestPurrFrames_AllSameShape(t *testing.T) {
+	// Animation looks ugly if frames have different heights or the same
+	// content, so guard both invariants.
+	require.GreaterOrEqual(t, len(purrFrames), 2)
+	height := strings.Count(purrFrames[0], "\n")
+	for i, f := range purrFrames {
+		assert.Equal(t, height, strings.Count(f, "\n"), "frame[%d] height", i)
+	}
+	seen := make(map[string]bool)
+	distinct := 0
+	for _, f := range purrFrames {
+		if !seen[f] {
+			seen[f] = true
+			distinct++
+		}
+	}
+	assert.GreaterOrEqual(t, distinct, 2, "frames are all identical — animation has no motion")
+}
+
+func TestNewCmd_Flags(t *testing.T) {
+	cmd := NewCmd()
+	assert.True(t, cmd.Hidden)
+
+	once, err := cmd.Flags().GetBool("once")
+	require.NoError(t, err)
+	assert.False(t, once)
+
+	duration, err := cmd.Flags().GetDuration("duration")
+	require.NoError(t, err)
+	assert.Equal(t, 8*time.Second, duration)
+
+	interval, err := cmd.Flags().GetDuration("interval")
+	require.NoError(t, err)
+	assert.Equal(t, 250*time.Millisecond, interval)
+}
+
+func TestNewCmd_RunEUsesStaticPathOnBuffer(t *testing.T) {
+	cmd := NewCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	require.NoError(t, cmd.Flags().Set("once", "true"))
+	require.NoError(t, cmd.RunE(cmd, nil))
+	assert.Contains(t, out.String(), purrMessage)
+}

--- a/cli/root.go
+++ b/cli/root.go
@@ -13,6 +13,7 @@ import (
 	"github.com/bitrise-io/bitrise/v2/cli/config"
 	"github.com/bitrise-io/bitrise/v2/cli/local"
 	"github.com/bitrise-io/bitrise/v2/cli/plugin"
+	"github.com/bitrise-io/bitrise/v2/cli/purr"
 	"github.com/bitrise-io/bitrise/v2/cli/stack"
 	"github.com/bitrise-io/bitrise/v2/cli/step"
 	"github.com/bitrise-io/bitrise/v2/cli/user"
@@ -66,6 +67,7 @@ func newRootCommand() *cobra.Command {
 		updateCommand,
 		plugin.NewCmd(),
 		envmanCommand,
+		purr.NewCmd(),
 
 		// Deprecated, kept for backward compatibility but hidden (see local/trigger.go).
 		cmdutil.AsHidden(local.NewTriggerCommand()),

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,8 @@ require (
 	github.com/hashicorp/go-retryablehttp v0.7.8
 	github.com/hashicorp/go-version v1.9.0
 	github.com/heimdalr/dag v1.4.0
+	github.com/lucasb-eyer/go-colorful v1.3.0
+	github.com/muesli/termenv v0.16.0
 	github.com/ryanuber/go-glob v1.0.0
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
@@ -49,14 +51,12 @@ require (
 	github.com/containerd/errdefs/pkg v0.3.0 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
 	github.com/klauspost/cpuid/v2 v2.3.0 // indirect
-	github.com/lucasb-eyer/go-colorful v1.3.0 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-localereader v0.0.1 // indirect
 	github.com/mattn/go-runewidth v0.0.19 // indirect
 	github.com/moby/sys/atomicwriter v0.1.0 // indirect
 	github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
-	github.com/muesli/termenv v0.16.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	golang.org/x/text v0.38.0 // indirect

--- a/internal/style/style.go
+++ b/internal/style/style.go
@@ -31,9 +31,9 @@ var (
 	dimColor     = lipgloss.AdaptiveColor{Light: "240", Dark: "245"} // grey
 	successColor = lipgloss.AdaptiveColor{Light: "28", Dark: "42"}   // green
 	warnColor    = lipgloss.AdaptiveColor{Light: "136", Dark: "220"} // yellow / olive
-	failedColor  = lipgloss.AdaptiveColor{Light: "160", Dark: "203"} // red
-	runningColor = lipgloss.AdaptiveColor{Light: "25", Dark: "39"}   // blue
-	abortedColor = lipgloss.AdaptiveColor{Light: "166", Dark: "208"} // orange
+	failedColor  = lipgloss.AdaptiveColor{Light: "124", Dark: "196"} // red
+	runningColor = lipgloss.AdaptiveColor{Light: "27", Dark: "33"}   // blue
+	abortedColor = lipgloss.AdaptiveColor{Light: "166", Dark: "214"} // amber
 )
 
 // Styles bundles the semantic styles used across human renderers. It is
@@ -70,7 +70,7 @@ func New(w io.Writer) Styles {
 		Warn:    r.NewStyle().Foreground(warnColor),
 		Bold:    r.NewStyle().Bold(true),
 		Label:   r.NewStyle().Bold(true),
-		URL:     r.NewStyle().Foreground(runningColor).Underline(true),
+		URL:     r.NewStyle().Underline(true),
 		failed:  r.NewStyle().Foreground(failedColor),
 		running: r.NewStyle().Foreground(runningColor),
 		aborted: r.NewStyle().Foreground(abortedColor),

--- a/internal/style/style.go
+++ b/internal/style/style.go
@@ -3,18 +3,22 @@
 // must not leak into machine-readable output.
 //
 // This is a trimmed port of bitrise-cli's internal/output/style package:
-// only the styles and Table renderer actually consumed by a landed command
-// are included. Theme overrides, --no-color/--theme flags, and styles used
-// only by commands not yet ported (OAuth picker, etc.) are left out on
-// purpose — add them when a command that actually needs them lands, rather
-// than carrying dead code now.
+// only the styles, Table renderer, and Rainbow shimmer that ported commands
+// (`stack list`, `purr`) actually use are included. Theme overrides,
+// --no-color/--theme flags, and styles used only by commands not yet ported
+// (build status, OAuth picker, etc.) are left out on purpose — add them when
+// a command that actually needs them lands, rather than carrying dead code
+// now.
 package style
 
 import (
 	"io"
+	"math"
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
+	"github.com/lucasb-eyer/go-colorful"
+	"github.com/muesli/termenv"
 )
 
 // BrandColor is Bitrise's brand purple, used by the build-watch spinner.
@@ -36,6 +40,8 @@ var (
 // constructed per-writer so the writer's terminal capabilities (or lack
 // thereof) control whether ANSI is emitted.
 type Styles struct {
+	r *lipgloss.Renderer
+
 	Header  lipgloss.Style // table header rows
 	Dim     lipgloss.Style // de-emphasized text
 	Slug    lipgloss.Style // technical identifiers (dimmed)
@@ -56,6 +62,7 @@ type Styles struct {
 func New(w io.Writer) Styles {
 	r := lipgloss.NewRenderer(w)
 	return Styles{
+		r:       r,
 		Header:  r.NewStyle().Bold(true).Foreground(dimColor),
 		Dim:     r.NewStyle().Foreground(dimColor),
 		Slug:    r.NewStyle().Foreground(dimColor),
@@ -86,6 +93,65 @@ func (s Styles) BuildStatus(status string) lipgloss.Style {
 	default:
 		return s.Dim
 	}
+}
+
+// hasColor reports whether the styles will emit ANSI codes.
+func (s Styles) hasColor() bool {
+	return s.r.ColorProfile() != termenv.Ascii
+}
+
+// Rainbow returns msg with each visible rune colored along the HSV spectrum.
+// Whitespace stays unstyled. hueOffsetDeg shifts the start of the spectrum
+// (0-360); incrementing it across animation frames produces a smooth
+// shimmer. When color is disabled (NO_COLOR, or the writer isn't a TTY) the
+// plain string is returned unchanged.
+func (s Styles) Rainbow(msg string, hueOffsetDeg float64) string {
+	if !s.hasColor() {
+		return msg
+	}
+	runes := []rune(msg)
+	visibleCount := 0
+	for _, r := range runes {
+		if !isWhitespace(r) {
+			visibleCount++
+		}
+	}
+	if visibleCount == 0 {
+		return msg
+	}
+
+	// Each non-whitespace rune gets a slice of the spectrum. Saturation
+	// 0.85 / value 0.95 keeps the colors bright on dark terminals while
+	// staying just-barely-readable on light ones; the rainbow theme trades
+	// perfect contrast for visible variety.
+	const sat, val = 0.85, 0.95
+
+	var b strings.Builder
+	b.Grow(len(msg) * 12) // ANSI per-rune envelope is ~10-15 bytes
+
+	visible := 0
+	for _, r := range runes {
+		if isWhitespace(r) {
+			b.WriteRune(r)
+			continue
+		}
+		h := math.Mod(hueOffsetDeg+360.0*float64(visible)/float64(visibleCount), 360.0)
+		if h < 0 {
+			h += 360
+		}
+		hex := colorful.Hsv(h, sat, val).Hex()
+		b.WriteString(s.r.NewStyle().Foreground(lipgloss.Color(hex)).Render(string(r)))
+		visible++
+	}
+	return b.String()
+}
+
+func isWhitespace(r rune) bool {
+	switch r {
+	case ' ', '\t', '\n', '\r':
+		return true
+	}
+	return false
 }
 
 // CellStyler renders a single cell content string. Only called for data rows

--- a/internal/style/style_test.go
+++ b/internal/style/style_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 
 	"github.com/charmbracelet/lipgloss"
+
+	"github.com/muesli/termenv"
 )
 
 func TestNew_NonTTYWriterIsAnsiFree(t *testing.T) {
@@ -40,6 +42,33 @@ func TestBuildStatus_KnownAndUnknownValues(t *testing.T) {
 		if got := s.BuildStatus(status); got.String() != want.String() {
 			t.Errorf("BuildStatus(%q) = %q, want %q", status, got.String(), want.String())
 		}
+	}
+}
+
+func TestRainbow_NoColorReturnsPlain(t *testing.T) {
+	// On a non-TTY writer there's no color profile, so Rainbow must be a
+	// no-op: same string, no ANSI bytes.
+	var buf bytes.Buffer
+	s := New(&buf)
+	const msg = "Hello, world!"
+	got := s.Rainbow(msg, 0)
+	if got != msg {
+		t.Errorf("Rainbow on non-TTY = %q, want plain %q", got, msg)
+	}
+	if strings.Contains(got, "\x1b[") {
+		t.Errorf("Rainbow on non-TTY emitted ANSI: %q", got)
+	}
+}
+
+func TestRainbow_EmptyAndWhitespaceOnly(t *testing.T) {
+	var buf bytes.Buffer
+	s := New(&buf)
+	s.r.SetColorProfile(termenv.ANSI256) // force a color profile for this test
+	if got := s.Rainbow("", 0); got != "" {
+		t.Errorf("empty: got %q, want empty", got)
+	}
+	if got := s.Rainbow("   ", 0); got != "   " {
+		t.Errorf("whitespace-only: got %q, want %q", got, "   ")
 	}
 }
 


### PR DESCRIPTION
Migrated the easter egg command. All dependencies were already indirectly included so this doesn't increase size or complexity.