### PR TITLE
RDE 1 - infra: command and style helpers

### DIFF
--- a/cli/auth/login.go
+++ b/cli/auth/login.go
@@ -117,7 +117,7 @@ logout' to clear).`,
 // stdin is a terminal. The prompt is only reachable via an explicit
 // --with-token, since a bare interactive `auth login` defaults to OAuth.
 func runTokenLogin(cmd *cobra.Command) error {
-	tok, err := cmdutil.ReadTokenInput(cmd.InOrStdin(), cmd.ErrOrStderr(), "Token: ", false)
+	tok, err := cmdutil.ReadSecretInput(cmd.InOrStdin(), cmd.ErrOrStderr(), "Token: ", false)
 	if err != nil {
 		return err
 	}

--- a/cli/cmdutil/cobraargs.go
+++ b/cli/cmdutil/cobraargs.go
@@ -1,0 +1,49 @@
+package cmdutil
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+// RequireArgs returns an Args validator that names exactly which positional
+// argument(s) are missing, instead of cobra's generic "accepts N arg(s), received M".
+func RequireArgs(names ...string) cobra.PositionalArgs {
+	return func(cmd *cobra.Command, args []string) error {
+		if len(args) >= len(names) {
+			return nil
+		}
+		missing := names[len(args):]
+		var msg string
+		if len(missing) == 1 {
+			msg = fmt.Sprintf("missing argument: %s", missing[0])
+		} else {
+			msg = fmt.Sprintf("missing arguments: %s", strings.Join(missing, " "))
+		}
+		return fmt.Errorf("%s\nRun '%s --help' for usage", msg, cmd.CommandPath())
+	}
+}
+
+// DelegateToList forwards a bare parent invocation to its "list" subcommand,
+// propagating the parent's context so resolved config is available.
+func DelegateToList(cmd *cobra.Command, args []string) error {
+	for _, sub := range cmd.Commands() {
+		if sub.Name() == "list" {
+			sub.SetContext(cmd.Context())
+			return sub.RunE(sub, args)
+		}
+	}
+	return cmd.Help()
+}
+
+// SilenceRootErrors prevents cobra from printing a returned error to stderr by
+// setting SilenceErrors on both the command and its root. Use this when the
+// command has already printed its own error summary and the automatic
+// "Error: ..." line would be redundant.
+func SilenceRootErrors(cmd *cobra.Command) {
+	cmd.SilenceErrors = true
+	if root := cmd.Root(); root != nil {
+		root.SilenceErrors = true
+	}
+}

--- a/cli/cmdutil/cobraargs_test.go
+++ b/cli/cmdutil/cobraargs_test.go
@@ -1,0 +1,76 @@
+package cmdutil
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestRequireArgs(t *testing.T) {
+	cmd := &cobra.Command{Use: "view"}
+
+	for _, tc := range []struct {
+		name    string
+		names   []string
+		args    []string
+		wantErr string
+	}{
+		{"no names required", nil, nil, ""},
+		{"single missing", []string{"SESSION_ID"}, nil, "missing argument: SESSION_ID"},
+		{"one of two missing", []string{"SESSION_ID", "KEY"}, []string{"sess-1"}, "missing argument: KEY"},
+		{"two missing", []string{"SESSION_ID", "KEY"}, nil, "missing arguments: SESSION_ID KEY"},
+		{"all provided", []string{"SESSION_ID", "KEY"}, []string{"sess-1", "key-1"}, ""},
+		{"extra args are fine", []string{"SESSION_ID"}, []string{"sess-1", "extra"}, ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := RequireArgs(tc.names...)(cmd, tc.args)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("expected no error, got %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.HasPrefix(err.Error(), tc.wantErr) {
+				t.Fatalf("error = %v, want prefix %q", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestDelegateToList_ForwardsArgsAndContext(t *testing.T) {
+	type ctxKey struct{}
+	ctx := context.WithValue(context.Background(), ctxKey{}, "resolved-config")
+
+	var gotArgs []string
+	var gotCtx context.Context
+	list := &cobra.Command{
+		Use: "list",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			gotArgs = args
+			gotCtx = cmd.Context()
+			return nil
+		},
+	}
+	parent := &cobra.Command{Use: "session"}
+	parent.AddCommand(list)
+	parent.SetContext(ctx)
+
+	if err := DelegateToList(parent, []string{"a", "b"}); err != nil {
+		t.Fatalf("DelegateToList: %v", err)
+	}
+	if len(gotArgs) != 2 || gotArgs[0] != "a" || gotArgs[1] != "b" {
+		t.Errorf("args not forwarded, got %v", gotArgs)
+	}
+	if gotCtx == nil || gotCtx.Value(ctxKey{}) != "resolved-config" {
+		t.Errorf("context not propagated to list subcommand")
+	}
+}
+
+func TestDelegateToList_NoListSubcommandFallsBackToHelp(t *testing.T) {
+	parent := &cobra.Command{Use: "session"}
+	if err := DelegateToList(parent, nil); err != nil {
+		t.Errorf("expected no error falling back to Help, got %v", err)
+	}
+}

--- a/cli/cmdutil/errwriter.go
+++ b/cli/cmdutil/errwriter.go
@@ -1,0 +1,32 @@
+package cmdutil
+
+import (
+	"fmt"
+	"io"
+)
+
+// ErrWriter wraps an io.Writer and captures the first write error so callers
+// can chain writes and check once at the end.
+type ErrWriter struct {
+	w   io.Writer
+	Err error
+}
+
+// NewErrWriter returns an ErrWriter backed by w.
+func NewErrWriter(w io.Writer) *ErrWriter { return &ErrWriter{w: w} }
+
+// F writes a formatted string, skipping if a previous write already failed.
+func (ew *ErrWriter) F(format string, a ...any) {
+	if ew.Err != nil {
+		return
+	}
+	_, ew.Err = fmt.Fprintf(ew.w, format, a...)
+}
+
+// Ln writes args followed by a newline, skipping if a previous write failed.
+func (ew *ErrWriter) Ln(a ...any) {
+	if ew.Err != nil {
+		return
+	}
+	_, ew.Err = fmt.Fprintln(ew.w, a...)
+}

--- a/cli/cmdutil/errwriter_test.go
+++ b/cli/cmdutil/errwriter_test.go
@@ -1,0 +1,58 @@
+package cmdutil
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+)
+
+func TestErrWriter_FAndLn(t *testing.T) {
+	var buf bytes.Buffer
+	ew := NewErrWriter(&buf)
+	ew.F("count: %d", 3)
+	ew.Ln("a", "b")
+	if ew.Err != nil {
+		t.Fatalf("unexpected error: %v", ew.Err)
+	}
+	want := "count: 3a b\n"
+	if buf.String() != want {
+		t.Errorf("buf = %q, want %q", buf.String(), want)
+	}
+}
+
+func TestErrWriter_StopsAfterFirstError(t *testing.T) {
+	w := &failAfterWriter{failOn: 2}
+	ew := NewErrWriter(w)
+
+	ew.Ln("first") // write 1: succeeds
+	if ew.Err != nil {
+		t.Fatalf("unexpected error after first write: %v", ew.Err)
+	}
+	ew.Ln("second") // write 2: fails
+	firstErr := ew.Err
+	if firstErr == nil {
+		t.Fatal("expected an error after the second write")
+	}
+	ew.Ln("third") // must be a no-op
+	ew.F("fourth")
+	if ew.Err != firstErr {
+		t.Errorf("Err changed after failure: got %v, want %v", ew.Err, firstErr)
+	}
+	if w.calls != 2 {
+		t.Errorf("writer called %d times, want 2 (chain should stop after the first error)", w.calls)
+	}
+}
+
+// failAfterWriter fails starting from its failOn-th Write call (1-indexed).
+type failAfterWriter struct {
+	calls  int
+	failOn int
+}
+
+func (w *failAfterWriter) Write(p []byte) (int, error) {
+	w.calls++
+	if w.calls >= w.failOn {
+		return 0, errors.New("write failed")
+	}
+	return len(p), nil
+}

--- a/cli/cmdutil/openvnc.go
+++ b/cli/cmdutil/openvnc.go
@@ -1,0 +1,48 @@
+package cmdutil
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"runtime"
+	"strings"
+)
+
+// OpenVNCURL invokes the OS's default URL handler for a vnc:// URL:
+//
+//   - macOS:    open
+//   - Windows:  cmd /c start
+//   - other:    xdg-open
+//
+// Errors carry the handler's combined output so a missing xdg-open or a
+// malformed URL is debuggable without rerunning under strace.
+//
+// The vnc:// prefix is verified before shelling out. The URL is built from
+// backend-provided host/port plus URL-escaped credentials, but the call can be
+// triggered by a remote signal (the rde claude host bridge), so the prefix
+// check is the trust boundary that keeps a non-vnc argument from reaching the
+// OS handler.
+func OpenVNCURL(ctx context.Context, url string) error {
+	if !strings.HasPrefix(url, "vnc://") {
+		return fmt.Errorf("refusing to open non-vnc URL %q", url)
+	}
+	var cmd *exec.Cmd
+	switch runtime.GOOS {
+	case "darwin":
+		cmd = exec.CommandContext(ctx, "open", url)
+	case "windows":
+		// `cmd /c start "" url` — the empty "" is `start`'s window-title
+		// placeholder, without it `start` treats the URL as the title.
+		cmd = exec.CommandContext(ctx, "cmd", "/c", "start", "", url)
+	default:
+		cmd = exec.CommandContext(ctx, "xdg-open", url)
+	}
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		if len(out) > 0 {
+			return fmt.Errorf("%w: %s", err, string(out))
+		}
+		return err
+	}
+	return nil
+}

--- a/cli/cmdutil/osdisplay.go
+++ b/cli/cmdutil/osdisplay.go
@@ -1,0 +1,17 @@
+package cmdutil
+
+// OSDisplayName maps a backend OS token to a human-friendly display name
+// (e.g. "macos" → "macOS", "linux" → "Linux"); unknown values pass through
+// unchanged. Shared by the RDE stack list and the `rde claude` stack picker so
+// the capitalization stays consistent. This is display-only — the raw token is
+// still what `--output json` and the wire carry.
+func OSDisplayName(os string) string {
+	switch os {
+	case "macos":
+		return "macOS"
+	case "linux":
+		return "Linux"
+	default:
+		return os
+	}
+}

--- a/cli/cmdutil/osdisplay_test.go
+++ b/cli/cmdutil/osdisplay_test.go
@@ -1,0 +1,16 @@
+package cmdutil
+
+import "testing"
+
+func TestOSDisplayName(t *testing.T) {
+	for in, want := range map[string]string{
+		"macos":   "macOS",
+		"linux":   "Linux",
+		"windows": "windows", // unknown → unchanged
+		"":        "",
+	} {
+		if got := OSDisplayName(in); got != want {
+			t.Errorf("OSDisplayName(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/cli/cmdutil/secret.go
+++ b/cli/cmdutil/secret.go
@@ -9,15 +9,15 @@ import (
 	"golang.org/x/term"
 )
 
-// ReadTokenInput reads a token from in, trimming all surrounding whitespace
+// ReadSecretInput reads a secret from in, trimming all surrounding whitespace
 // (tokens are forgiving of shell copy/paste artifacts). When fromStdin is
 // true, or in isn't a terminal, it reads a line directly; otherwise it
 // prompts and reads a masked line.
-func ReadTokenInput(in io.Reader, stderr io.Writer, prompt string, fromStdin bool) (string, error) {
+func ReadSecretInput(in io.Reader, stderr io.Writer, prompt string, fromStdin bool) (string, error) {
 	return readSecretInput(in, stderr, prompt, fromStdin, strings.TrimSpace)
 }
 
-// ReadPasswordInput reads a password from in the same way as ReadTokenInput,
+// ReadPasswordInput reads a password from in the same way as ReadSecretInput,
 // but trims only a trailing line terminator — a leading/trailing space can
 // be a deliberate part of a password and must not be silently stripped.
 func ReadPasswordInput(in io.Reader, stderr io.Writer, prompt string, fromStdin bool) (string, error) {

--- a/cli/cmdutil/secret_test.go
+++ b/cli/cmdutil/secret_test.go
@@ -6,13 +6,13 @@ import (
 	"testing"
 )
 
-func TestReadTokenInput_NonTerminalReadsLine(t *testing.T) {
+func TestReadSecretInput_NonTerminalReadsLine(t *testing.T) {
 	in := strings.NewReader("  a-token-value  \nrest\n")
 	var stderr bytes.Buffer
 
-	got, err := ReadTokenInput(in, &stderr, "Token: ", false)
+	got, err := ReadSecretInput(in, &stderr, "Token: ", false)
 	if err != nil {
-		t.Fatalf("ReadTokenInput: %v", err)
+		t.Fatalf("ReadSecretInput: %v", err)
 	}
 	if got != "a-token-value" {
 		t.Fatalf("got %q, want %q", got, "a-token-value")
@@ -22,22 +22,22 @@ func TestReadTokenInput_NonTerminalReadsLine(t *testing.T) {
 	}
 }
 
-func TestReadTokenInput_EOFWithoutNewline(t *testing.T) {
+func TestReadSecretInput_EOFWithoutNewline(t *testing.T) {
 	in := strings.NewReader("no-trailing-newline")
-	got, err := ReadTokenInput(in, &bytes.Buffer{}, "", true)
+	got, err := ReadSecretInput(in, &bytes.Buffer{}, "", true)
 	if err != nil {
-		t.Fatalf("ReadTokenInput: %v", err)
+		t.Fatalf("ReadSecretInput: %v", err)
 	}
 	if got != "no-trailing-newline" {
 		t.Fatalf("got %q", got)
 	}
 }
 
-func TestReadTokenInput_StillFullyTrims(t *testing.T) {
+func TestReadSecretInput_StillFullyTrims(t *testing.T) {
 	in := strings.NewReader("  tok  \n")
-	got, err := ReadTokenInput(in, &bytes.Buffer{}, "", false)
+	got, err := ReadSecretInput(in, &bytes.Buffer{}, "", false)
 	if err != nil {
-		t.Fatalf("ReadTokenInput: %v", err)
+		t.Fatalf("ReadSecretInput: %v", err)
 	}
 	if got != "tok" {
 		t.Fatalf("got %q, want %q", got, "tok")

--- a/cli/cmdutil/shell.go
+++ b/cli/cmdutil/shell.go
@@ -1,0 +1,44 @@
+package cmdutil
+
+import "strings"
+
+// JoinShellArgs joins argv into a single shell-safe command string by
+// POSIX-quoting each argument. Without quoting, `bash -c 'echo a; pwd'`
+// would arrive at the remote as three space-separated tokens and the `;`
+// would be reinterpreted by the remote shell, dropping `echo a`.
+func JoinShellArgs(args []string) string {
+	q := make([]string, len(args))
+	for i, a := range args {
+		q[i] = ShellQuote(a)
+	}
+	return strings.Join(q, " ")
+}
+
+// ShellQuote wraps s in POSIX single-quotes, escaping any embedded single
+// quotes with the standard `'\”` sequence. Strings made entirely of
+// shell-safe characters are returned as-is to keep readable commands
+// readable in logs.
+func ShellQuote(s string) string {
+	if s == "" {
+		return "''"
+	}
+	safe := true
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch {
+		case c >= 'a' && c <= 'z',
+			c >= 'A' && c <= 'Z',
+			c >= '0' && c <= '9',
+			c == '_', c == '-', c == '.', c == '/', c == ':', c == '=', c == ',', c == '@', c == '+', c == '%':
+		default:
+			safe = false
+		}
+		if !safe {
+			break
+		}
+	}
+	if safe {
+		return s
+	}
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}

--- a/cli/cmdutil/shell_test.go
+++ b/cli/cmdutil/shell_test.go
@@ -1,0 +1,26 @@
+package cmdutil
+
+import "testing"
+
+func TestJoinShellArgs(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		args []string
+		want string
+	}{
+		{"empty", nil, ""},
+		{"safe argv passes through", []string{"ls", "-la", "/opt"}, "ls -la /opt"},
+		{"semicolon is quoted", []string{"bash", "-c", "echo a; pwd"}, "bash -c 'echo a; pwd'"},
+		{"spaces inside arg", []string{"echo", "hello world"}, "echo 'hello world'"},
+		{"embedded single quote", []string{"echo", "it's"}, `echo 'it'\''s'`},
+		{"dollar var stays inside quotes", []string{"bash", "-c", "echo $HOME"}, "bash -c 'echo $HOME'"},
+		{"empty arg becomes ''", []string{"printf", "%s", ""}, "printf %s ''"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := JoinShellArgs(tc.args)
+			if got != tc.want {
+				t.Errorf("JoinShellArgs(%q) = %q, want %q", tc.args, got, tc.want)
+			}
+		})
+	}
+}

--- a/cli/cmdutil/terminal.go
+++ b/cli/cmdutil/terminal.go
@@ -8,7 +8,8 @@ import (
 )
 
 // TerminalFd reports whether stream is an *os.File backed by a TTY. fd is
-// only meaningful when isTerminal is true.
+// only meaningful when isTerminal is true. A nil stream safely fails the
+// type assertion below and reports false.
 func TerminalFd(stream any) (fd int, isTerminal bool) {
 	f, ok := stream.(*os.File)
 	if !ok {

--- a/internal/style/style.go
+++ b/internal/style/style.go
@@ -2,16 +2,15 @@
 // renderers. JSON/YML output never goes through this package — ANSI codes
 // must not leak into machine-readable output.
 //
-// This is a trimmed port of bitrise-cli's internal/output/style package:
-// only the styles, Table renderer, and Rainbow shimmer that ported commands
-// (`stack list`, `purr`) actually use are included. Theme overrides,
-// --no-color/--theme flags, and styles used only by commands not yet ported
-// (build status, OAuth picker, etc.) are left out on purpose — add them when
-// a command that actually needs them lands, rather than carrying dead code
-// now.
+// Each renderer constructs Styles via New(writer), scoped to that writer's
+// color profile: non-TTY writers (pipes, *bytes.Buffer) automatically
+// produce ANSI-free output. NO_COLOR and FORCE_COLOR are honored
+// automatically by the underlying termenv detection; Configure adds
+// explicit overrides for a --no-color / --theme flag pair.
 package style
 
 import (
+	"fmt"
 	"io"
 	"math"
 	"strings"
@@ -20,6 +19,55 @@ import (
 	"github.com/lucasb-eyer/go-colorful"
 	"github.com/muesli/termenv"
 )
+
+// Theme controls which side of an AdaptiveColor pair New picks. Auto leaves
+// the choice to lipgloss (which queries the terminal background via OSC 11).
+// Dark/Light force the corresponding side. None disables ANSI altogether.
+type Theme string
+
+const (
+	ThemeAuto  Theme = "auto"
+	ThemeDark  Theme = "dark"
+	ThemeLight Theme = "light"
+	ThemeNone  Theme = "none"
+)
+
+// Themes is the registered list of theme values, used for validation, help
+// text, and shell completion.
+var Themes = []string{string(ThemeAuto), string(ThemeDark), string(ThemeLight), string(ThemeNone)}
+
+// ParseTheme validates a user-supplied --theme value. Empty resolves to Auto
+// so callers can pass cmd flag values directly.
+func ParseTheme(s string) (Theme, error) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "", string(ThemeAuto):
+		return ThemeAuto, nil
+	case string(ThemeDark):
+		return ThemeDark, nil
+	case string(ThemeLight):
+		return ThemeLight, nil
+	case string(ThemeNone):
+		return ThemeNone, nil
+	default:
+		return "", fmt.Errorf("unknown theme %q (expected: %s)", s, strings.Join(Themes, ", "))
+	}
+}
+
+// forceNoColor and forcedTheme are set by Configure and override every
+// Styles bundle constructed by New afterward. Configure is called once from
+// persistentPreRun before any subcommand's RunE, so concurrent New calls
+// during a single command run see a stable value.
+var (
+	forceNoColor bool
+	forcedTheme  = ThemeAuto
+)
+
+// Configure applies process-wide style settings. Call once from the cmd
+// layer's persistentPreRun, after parsing the --no-color and --theme flags.
+func Configure(noColor bool, theme Theme) {
+	forceNoColor = noColor
+	forcedTheme = theme
+}
 
 // BrandColor is Bitrise's brand purple, used by the build-watch spinner.
 const BrandColor = lipgloss.Color("#7B61FF")
@@ -46,32 +94,46 @@ type Styles struct {
 	Dim     lipgloss.Style // de-emphasized text
 	Slug    lipgloss.Style // technical identifiers (dimmed)
 	Success lipgloss.Style // success indicators
+	Failure lipgloss.Style // failure indicators
 	Warn    lipgloss.Style // warnings
 	Bold    lipgloss.Style // emphasis
 	Label   lipgloss.Style // field labels in key/value dumps
 	URL     lipgloss.Style // links
+	Brand   lipgloss.Style // brand-purple accent (picker cursor, etc.)
 
-	failed  lipgloss.Style
 	running lipgloss.Style
 	aborted lipgloss.Style
 }
 
 // New returns a Styles bundle for the given writer. ANSI escape codes are
-// emitted only if w is detected as a color-capable TTY (NO_COLOR is honored
-// automatically by the underlying termenv detection).
+// emitted only if w is detected as a color-capable TTY, --no-color is not in
+// effect, and --theme is not "none". The theme (when not Auto) overrides the
+// renderer's auto-detected light/dark background, forcing AdaptiveColor
+// pairs to pick the requested side.
 func New(w io.Writer) Styles {
 	r := lipgloss.NewRenderer(w)
+	if forceNoColor || forcedTheme == ThemeNone {
+		r.SetColorProfile(termenv.Ascii)
+	} else {
+		switch forcedTheme {
+		case ThemeDark:
+			r.SetHasDarkBackground(true)
+		case ThemeLight:
+			r.SetHasDarkBackground(false)
+		}
+	}
 	return Styles{
 		r:       r,
 		Header:  r.NewStyle().Bold(true).Foreground(dimColor),
 		Dim:     r.NewStyle().Foreground(dimColor),
 		Slug:    r.NewStyle().Foreground(dimColor),
 		Success: r.NewStyle().Foreground(successColor),
+		Failure: r.NewStyle().Foreground(failedColor),
 		Warn:    r.NewStyle().Foreground(warnColor),
 		Bold:    r.NewStyle().Bold(true),
 		Label:   r.NewStyle().Bold(true),
 		URL:     r.NewStyle().Underline(true),
-		failed:  r.NewStyle().Foreground(failedColor),
+		Brand:   r.NewStyle().Foreground(BrandColor),
 		running: r.NewStyle().Foreground(runningColor),
 		aborted: r.NewStyle().Foreground(abortedColor),
 	}
@@ -85,7 +147,7 @@ func (s Styles) BuildStatus(status string) lipgloss.Style {
 	case "success":
 		return s.Success
 	case "failed":
-		return s.failed
+		return s.Failure
 	case "in-progress":
 		return s.running
 	case "aborted", "aborted-with-success":
@@ -95,8 +157,8 @@ func (s Styles) BuildStatus(status string) lipgloss.Style {
 	}
 }
 
-// hasColor reports whether the styles will emit ANSI codes.
-func (s Styles) hasColor() bool {
+// HasColor reports whether the styles will emit ANSI codes.
+func (s Styles) HasColor() bool {
 	return s.r.ColorProfile() != termenv.Ascii
 }
 
@@ -106,7 +168,7 @@ func (s Styles) hasColor() bool {
 // shimmer. When color is disabled (NO_COLOR, or the writer isn't a TTY) the
 // plain string is returned unchanged.
 func (s Styles) Rainbow(msg string, hueOffsetDeg float64) string {
-	if !s.hasColor() {
+	if !s.HasColor() {
 		return msg
 	}
 	runes := []rune(msg)

--- a/internal/style/style_test.go
+++ b/internal/style/style_test.go
@@ -16,6 +16,9 @@ func TestNew_NonTTYWriterIsAnsiFree(t *testing.T) {
 	// invariant that keeps tests, pipes, and JSON output ANSI-free.
 	var buf bytes.Buffer
 	s := New(&buf)
+	if s.HasColor() {
+		t.Fatal("Styles built for *bytes.Buffer should not emit color")
+	}
 	for _, in := range []string{"hello", "Build:", "success"} {
 		if got := s.Header.Render(in); got != in {
 			t.Errorf("Header.Render(%q) = %q, want plain", in, got)
@@ -23,6 +26,71 @@ func TestNew_NonTTYWriterIsAnsiFree(t *testing.T) {
 		if got := s.Success.Render(in); got != in {
 			t.Errorf("Success.Render(%q) = %q, want plain", in, got)
 		}
+		if got := s.Brand.Render(in); got != in {
+			t.Errorf("Brand.Render(%q) = %q, want plain", in, got)
+		}
+		if got := s.Failure.Render(in); got != in {
+			t.Errorf("Failure.Render(%q) = %q, want plain", in, got)
+		}
+	}
+}
+
+func TestConfigure_NoColorForcesAscii(t *testing.T) {
+	t.Cleanup(func() { Configure(false, ThemeAuto) })
+	Configure(true, ThemeAuto)
+
+	var buf bytes.Buffer
+	s := New(&buf)
+	if s.HasColor() {
+		t.Fatal("Configure(true, _) should force no color")
+	}
+	if got := s.Success.Render("✓"); strings.Contains(got, "\x1b[") {
+		t.Errorf("expected ANSI-free output, got %q", got)
+	}
+}
+
+func TestConfigure_ThemeNoneForcesAscii(t *testing.T) {
+	t.Cleanup(func() { Configure(false, ThemeAuto) })
+	Configure(false, ThemeNone)
+
+	var buf bytes.Buffer
+	s := New(&buf)
+	if s.HasColor() {
+		t.Fatal("Configure(_, ThemeNone) should force no color")
+	}
+}
+
+func TestParseTheme(t *testing.T) {
+	cases := []struct {
+		in      string
+		want    Theme
+		wantErr bool
+	}{
+		{"", ThemeAuto, false},
+		{"auto", ThemeAuto, false},
+		{"AUTO", ThemeAuto, false},
+		{"  dark  ", ThemeDark, false},
+		{"light", ThemeLight, false},
+		{"none", ThemeNone, false},
+		{"neon", "", true},
+		{"system", "", true},
+	}
+	for _, c := range cases {
+		t.Run(c.in, func(t *testing.T) {
+			got, err := ParseTheme(c.in)
+			if c.wantErr {
+				if err == nil {
+					t.Fatalf("ParseTheme(%q): expected error, got %q", c.in, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ParseTheme(%q): unexpected error: %v", c.in, err)
+			}
+			if got != c.want {
+				t.Errorf("ParseTheme(%q) = %q, want %q", c.in, got, c.want)
+			}
+		})
 	}
 }
 
@@ -32,7 +100,7 @@ func TestBuildStatus_KnownAndUnknownValues(t *testing.T) {
 
 	cases := map[string]lipgloss.Style{
 		"success":               s.Success,
-		"failed":                s.failed,
+		"failed":                s.Failure,
 		"in-progress":           s.running,
 		"aborted":               s.aborted,
 		"aborted-with-success":  s.aborted,


### PR DESCRIPTION
- add the missing parts to `internal/style`: theme & colour support
- cmd helpers: terminal methods, VNC, cobra validation, error handling

_This is PR #1 of 15, splitting the changes into reviewable chunks. PRs 1-4 are just infrastructure._