### PR TITLE
RDE 3 - infra: global command flag handling

### DIFF
--- a/cli/build/watch_tui.go
+++ b/cli/build/watch_tui.go
@@ -24,7 +24,7 @@ func runWatchTUI(cmd *cobra.Command, svc *internalbuild.Service, b internalbuild
 	ctx, cancel := context.WithCancel(cmd.Context())
 	defer cancel()
 
-	m := newWaitModel(b)
+	m := newWaitModel(b, style.New(cmd.OutOrStdout()))
 	p := tea.NewProgram(m, tea.WithContext(ctx), tea.WithOutput(cmd.OutOrStdout()))
 
 	doneCh := make(chan struct{})
@@ -113,10 +113,12 @@ type waitModel struct {
 	urlStyle   lipgloss.Style
 }
 
-func newWaitModel(b internalbuild.Build) waitModel {
+// newWaitModel builds the TUI model from s, the Styles bundle scoped to the
+// program's output writer, so --no-color and --theme reach the status bar.
+func newWaitModel(b internalbuild.Build, s style.Styles) waitModel {
 	sp := spinner.New()
 	sp.Spinner = spinner.Dot
-	sp.Style = lipgloss.NewStyle().Foreground(style.BrandColor)
+	sp.Style = s.Brand
 	started := b.TriggeredAt
 	if started.IsZero() {
 		started = time.Now()
@@ -126,9 +128,9 @@ func newWaitModel(b internalbuild.Build) waitModel {
 		spinner:    sp,
 		startedAt:  started,
 		width:      80,
-		labelStyle: lipgloss.NewStyle().Bold(true),
-		dimStyle:   lipgloss.NewStyle().Foreground(lipgloss.Color("245")),
-		urlStyle:   lipgloss.NewStyle().Foreground(style.BrandColor).Underline(true),
+		labelStyle: s.Bold,
+		dimStyle:   s.Dim,
+		urlStyle:   s.Brand.Underline(true),
 	}
 }
 

--- a/cli/build/watch_tui_test.go
+++ b/cli/build/watch_tui_test.go
@@ -1,12 +1,14 @@
 package build
 
 import (
+	"io"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	internalbuild "github.com/bitrise-io/bitrise/v2/internal/build"
+	"github.com/bitrise-io/bitrise/v2/internal/style"
 )
 
 // The TUI used to print each log line with tea.Batch, which bubbletea runs
@@ -16,7 +18,7 @@ import (
 // flight, and lines arriving during a print buffer until it completes.
 
 func TestWaitModel_SerializesLogOutputSingleFlight(t *testing.T) {
-	m := newWaitModel(internalbuild.Build{BuildNumber: 1})
+	m := newWaitModel(internalbuild.Build{BuildNumber: 1}, style.New(io.Discard))
 
 	// First chunk with two complete lines starts exactly one print and
 	// drains the lines into that in-flight block.
@@ -48,7 +50,7 @@ func TestWaitModel_SerializesLogOutputSingleFlight(t *testing.T) {
 }
 
 func TestWaitModel_HoldsPartialLineUntilNewline(t *testing.T) {
-	m := newWaitModel(internalbuild.Build{})
+	m := newWaitModel(internalbuild.Build{}, style.New(io.Discard))
 
 	// A chunk without a trailing newline isn't a complete line yet, so
 	// nothing prints.
@@ -67,7 +69,7 @@ func TestWaitModel_HoldsPartialLineUntilNewline(t *testing.T) {
 }
 
 func TestWaitModel_FinalFlushEmitsTrailingPartialAndQuits(t *testing.T) {
-	m := newWaitModel(internalbuild.Build{})
+	m := newWaitModel(internalbuild.Build{}, style.New(io.Discard))
 
 	// A trailing partial line (a build's last line often has no newline).
 	next, _ := m.Update(logChunkMsg("ExitCode: 0"))
@@ -82,7 +84,7 @@ func TestWaitModel_FinalFlushEmitsTrailingPartialAndQuits(t *testing.T) {
 }
 
 func TestWaitModel_WaitsForInFlightPrintBeforeQuitting(t *testing.T) {
-	m := newWaitModel(internalbuild.Build{})
+	m := newWaitModel(internalbuild.Build{}, style.New(io.Discard))
 
 	// Start a print.
 	next, _ := m.Update(logChunkMsg("line\n"))

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -11,7 +11,9 @@ import (
 	"github.com/bitrise-io/bitrise/v2/cli/cmdutil"
 	"github.com/bitrise-io/bitrise/v2/configs"
 	"github.com/bitrise-io/bitrise/v2/internal/config"
+	"github.com/bitrise-io/bitrise/v2/internal/style"
 	"github.com/bitrise-io/bitrise/v2/log"
+	"github.com/bitrise-io/bitrise/v2/output"
 	"github.com/bitrise-io/bitrise/v2/plugins"
 	"github.com/spf13/cobra"
 )
@@ -50,7 +52,7 @@ func Run() {
 	// envman is a passthrough command: it must receive its args verbatim, so it
 	// is dispatched before cobra to keep the global flags (which precede the
 	// command) from being forwarded into the passthrough.
-	if envmanArgs, isEnvman := envmanPassthrough(rawArgs); isEnvman {
+	if envmanArgs, isEnvman := envmanPassthrough(rootCmd, rawArgs); isEnvman {
 		runEnvman(rootCmd, rawArgs, envmanArgs)
 		return
 	}
@@ -217,6 +219,27 @@ func before(cmd *cobra.Command, _ []string) error {
 		ctx = context.Background()
 	}
 	cmd.SetContext(config.WithResolved(ctx, resolved))
+
+	// Seed the output-format and theme defaults once per invocation. Root
+	// flag beats the env var, which beats the config key — matching every
+	// other resolver in cli/cmdutil (webbase.go, app.go, workspace.go).
+	// resolved.Output/Theme already carry per-directory over global.
+	flagOutput, _ := root.PersistentFlags().GetString(cmdutil.FlagOutput)
+	rawOutput := config.FirstNonEmptyString(flagOutput, os.Getenv(cmdutil.EnvOutput), resolved.Output, output.FormatRaw)
+	format, err := output.ParseFormat(rawOutput)
+	if err != nil {
+		return err
+	}
+	output.SetDefault(format)
+
+	flagTheme, _ := root.PersistentFlags().GetString(cmdutil.FlagTheme)
+	rawTheme := config.FirstNonEmptyString(flagTheme, os.Getenv(cmdutil.EnvTheme), resolved.Theme)
+	theme, err := style.ParseTheme(rawTheme)
+	if err != nil {
+		return err
+	}
+	noColor, _ := root.PersistentFlags().GetBool(cmdutil.FlagNoColor)
+	style.Configure(noColor, theme)
 
 	return nil
 }

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -440,9 +440,11 @@ func Test_before_outputPrecedence(t *testing.T) {
 // Test_ymlMergeOutputFlag_ShadowsGlobalOutputFlag guards the shorthand
 // collision called out in the master rde-migration plan: yml merge's own
 // --output/-o (an output directory) must keep working unchanged once the
-// root gains a persistent --output/-o (an output format) — cobra's flag
-// merge order (local flags are registered before parent persistent flags are
-// merged in) makes the local one win, with no panic on the shared shorthand.
+// root gains a persistent --output/-o (an output format). pflag's AddFlagSet
+// dedups on the long name only, so the root's --output is skipped for this
+// command and its -o never reaches AddFlag. The shared long name is what makes
+// this safe: a local -o under a different long name would panic there on the
+// shorthand collision.
 func Test_ymlMergeOutputFlag_ShadowsGlobalOutputFlag(t *testing.T) {
 	root := newRootCommand()
 
@@ -468,4 +470,29 @@ func Test_ymlMergeOutputFlag_ShadowsGlobalOutputFlag(t *testing.T) {
 
 	rootOutput, _ := root.PersistentFlags().GetString(cmdutil.FlagOutput)
 	assert.Equal(t, "", rootOutput, "the global --output flag must be untouched by yml merge's local -o")
+}
+
+// Test_flagShorthands_doNotCollideAcrossTree walks every command and forces the
+// flag merge that would panic on a shorthand collision — pflag's AddFlagSet
+// skips a parent flag only when the long name matches, so a local -o/-q under a
+// different long name blows up. InitDefaultHelpFlag is included because it adds
+// --help/-h without checking whether -h is taken (unlike InitDefaultVersionFlag,
+// which falls back to no shorthand), and because cobra only inits it for the one
+// command being executed — a collision in a rarely-run subcommand would
+// otherwise surface as a runtime panic instead of a test failure.
+func Test_flagShorthands_doNotCollideAcrossTree(t *testing.T) {
+	visitCommands(newRootCommand(), func(cmd *cobra.Command) {
+		require.NotPanics(t, func() {
+			cmd.InitDefaultHelpFlag()
+			cmd.InitDefaultVersionFlag()
+			cmd.Flags()
+		}, "flag shorthand collision in %q", cmd.CommandPath())
+	})
+}
+
+func visitCommands(cmd *cobra.Command, fn func(*cobra.Command)) {
+	fn(cmd)
+	for _, sub := range cmd.Commands() {
+		visitCommands(sub, fn)
+	}
 }

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -3,9 +3,14 @@ package cli
 import (
 	"testing"
 
-	"github.com/bitrise-io/bitrise/v2/cli/cmdutil"
-	"github.com/bitrise-io/bitrise/v2/log"
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/bitrise-io/bitrise/v2/cli/cmdutil"
+	internalconfig "github.com/bitrise-io/bitrise/v2/internal/config"
+	"github.com/bitrise-io/bitrise/v2/log"
+	"github.com/bitrise-io/bitrise/v2/output"
 )
 
 func Test_loggerParameters(t *testing.T) {
@@ -134,6 +139,60 @@ func Test_detectPlugin(t *testing.T) {
 			args:       []string{},
 			wantPlugin: false,
 		},
+		{
+			// A value-taking global flag written with a space must not have its
+			// value ("json") mistaken for the plugin/command token.
+			name:       "leading value flag with space syntax is skipped",
+			args:       []string{"--output", "json", ":analytics"},
+			wantName:   "analytics",
+			wantArgs:   []string{},
+			wantPlugin: true,
+		},
+		{
+			name:       "leading value flag with equals syntax is skipped",
+			args:       []string{"--output=json", ":analytics", "--flag"},
+			wantName:   "analytics",
+			wantArgs:   []string{"--flag"},
+			wantPlugin: true,
+		},
+		{
+			name:       "leading theme flag with space syntax is skipped",
+			args:       []string{"--theme", "dark", ":analytics"},
+			wantName:   "analytics",
+			wantArgs:   []string{},
+			wantPlugin: true,
+		},
+		{
+			name:       "leading value shorthand with space syntax is skipped",
+			args:       []string{"-o", "json", ":analytics"},
+			wantName:   "analytics",
+			wantArgs:   []string{},
+			wantPlugin: true,
+		},
+		{
+			name:       "leading value shorthand with attached value is skipped",
+			args:       []string{"-ojson", ":analytics", "--flag"},
+			wantName:   "analytics",
+			wantArgs:   []string{"--flag"},
+			wantPlugin: true,
+		},
+		{
+			name:       "leading bool shorthand cluster is skipped",
+			args:       []string{"-q", ":analytics"},
+			wantName:   "analytics",
+			wantArgs:   []string{},
+			wantPlugin: true,
+		},
+		{
+			// A cluster is all-or-nothing: -x is not a bitrise global, so -qx
+			// is not consumed as one. plugins.ParseArgs then scans past it to
+			// the ":" token, so the plugin still runs — without the flag.
+			name:       "shorthand cluster with an unknown letter is not a global",
+			args:       []string{"-qx", ":analytics"},
+			wantName:   "analytics",
+			wantArgs:   []string{},
+			wantPlugin: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -184,10 +243,30 @@ func Test_envmanPassthrough(t *testing.T) {
 			args:      []string{"--ci"},
 			wantMatch: false,
 		},
+		{
+			name:      "leading value flag with space syntax is skipped",
+			args:      []string{"--output", "json", "envman", "add"},
+			wantArgs:  []string{"add"},
+			wantMatch: true,
+		},
+		{
+			// Shorthands are the spelling users reach for, and forwarding one
+			// into envman makes it reject a flag bitrise owns.
+			name:      "leading value shorthand with space syntax is skipped",
+			args:      []string{"-o", "json", "envman", "add"},
+			wantArgs:  []string{"add"},
+			wantMatch: true,
+		},
+		{
+			name:      "leading bool shorthand is skipped",
+			args:      []string{"-q", "envman", "add"},
+			wantArgs:  []string{"add"},
+			wantMatch: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			args, isEnvman := envmanPassthrough(tt.args)
+			args, isEnvman := envmanPassthrough(newRootCommand(), tt.args)
 			assert.Equal(t, tt.wantMatch, isEnvman)
 			if tt.wantMatch {
 				assert.Equal(t, tt.wantArgs, args)
@@ -198,11 +277,14 @@ func Test_envmanPassthrough(t *testing.T) {
 
 func Test_applyGlobalFlagsFromArgs_onlyLeadingApplied(t *testing.T) {
 	tests := []struct {
-		name      string
-		args      []string
-		wantDebug bool
-		wantCI    bool
-		wantPR    bool
+		name       string
+		args       []string
+		wantDebug  bool
+		wantCI     bool
+		wantPR     bool
+		wantQuiet  bool
+		wantOutput string
+		wantTheme  string
 	}{
 		{
 			// A plugin's own --debug after the command token must not set bitrise's
@@ -229,6 +311,55 @@ func Test_applyGlobalFlagsFromArgs_onlyLeadingApplied(t *testing.T) {
 			args:   []string{"envman", "--pr"},
 			wantPR: false,
 		},
+		{
+			name:       "leading value flag with space syntax sets the value, not \"true\"",
+			args:       []string{"--output", "json", ":plugin"},
+			wantOutput: "json",
+		},
+		{
+			name:       "leading value flag with equals syntax",
+			args:       []string{"--output=yml", ":plugin"},
+			wantOutput: "yml",
+		},
+		{
+			name:      "leading theme flag with space syntax",
+			args:      []string{"--theme", "dark", ":plugin"},
+			wantTheme: "dark",
+		},
+		{
+			// A plugin's own --output after the command token must not set
+			// bitrise's persistent --output flag.
+			name:       "value flag after the command token is not applied to bitrise",
+			args:       []string{":plugin", "--output", "json"},
+			wantOutput: "",
+		},
+		{
+			name:       "value shorthand with space syntax",
+			args:       []string{"-o", "json", ":plugin"},
+			wantOutput: "json",
+		},
+		{
+			name:       "value shorthand with attached value",
+			args:       []string{"-oyml", ":plugin"},
+			wantOutput: "yml",
+		},
+		{
+			name:       "value shorthand with equals syntax",
+			args:       []string{"-o=json", ":plugin"},
+			wantOutput: "json",
+		},
+		{
+			name:      "bool shorthand",
+			args:      []string{"--debug", ":plugin"},
+			wantDebug: true,
+		},
+		{
+			// A cluster ending in a value flag sets every flag in it.
+			name:       "shorthand cluster of a bool and a value flag",
+			args:       []string{"-qo", "json", ":plugin"},
+			wantQuiet:  true,
+			wantOutput: "json",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -238,9 +369,15 @@ func Test_applyGlobalFlagsFromArgs_onlyLeadingApplied(t *testing.T) {
 			debug, _ := root.PersistentFlags().GetBool(cmdutil.DebugModeKey)
 			ci, _ := root.PersistentFlags().GetBool(cmdutil.CIKey)
 			pr, _ := root.PersistentFlags().GetBool(cmdutil.PRKey)
+			quiet, _ := root.PersistentFlags().GetBool(cmdutil.FlagQuiet)
+			outputVal, _ := root.PersistentFlags().GetString(cmdutil.FlagOutput)
+			themeVal, _ := root.PersistentFlags().GetString(cmdutil.FlagTheme)
 			assert.Equal(t, tt.wantDebug, debug, "debug")
 			assert.Equal(t, tt.wantCI, ci, "ci")
 			assert.Equal(t, tt.wantPR, pr, "pr")
+			assert.Equal(t, tt.wantQuiet, quiet, "quiet")
+			assert.Equal(t, tt.wantOutput, outputVal, "output")
+			assert.Equal(t, tt.wantTheme, themeVal, "theme")
 		})
 	}
 }
@@ -256,4 +393,79 @@ func Test_before_calledWithoutExecute_doesNotPanic(t *testing.T) {
 		err := before(root, nil)
 		assert.NoError(t, err)
 	})
+}
+
+// Test_before_outputPrecedence pins the precedence documented in
+// cli/config/cmd.go: root flag > $BITRISE_OUTPUT > the "output" config key >
+// raw — env above config, matching every other resolver in cli/cmdutil.
+func Test_before_outputPrecedence(t *testing.T) {
+	t.Cleanup(func() {
+		output.SetDefault(output.FormatRaw)
+		require.NoError(t, output.ConfigureOutputFormat(output.FormatRaw))
+	})
+
+	tests := []struct {
+		name       string
+		rootFlag   string
+		configured string
+		env        string
+		want       string
+	}{
+		{name: "root flag wins over env and config", rootFlag: "raw", configured: "json", env: "yml", want: "raw"},
+		{name: "env wins over config key when no flag", configured: "json", env: "yml", want: "yml"},
+		{name: "config key used when neither flag nor env set", configured: "json", want: "json"},
+		{name: "raw default when nothing set", want: "raw"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+			if tt.env != "" {
+				t.Setenv(cmdutil.EnvOutput, tt.env)
+			}
+			if tt.configured != "" {
+				require.NoError(t, internalconfig.Save(internalconfig.Config{Output: tt.configured}))
+			}
+
+			root := newRootCommand()
+			if tt.rootFlag != "" {
+				require.NoError(t, root.PersistentFlags().Set(cmdutil.FlagOutput, tt.rootFlag))
+			}
+			require.NoError(t, before(root, nil))
+			require.NoError(t, output.ConfigureOutputFormat(""))
+			assert.Equal(t, tt.want, output.Format)
+		})
+	}
+}
+
+// Test_ymlMergeOutputFlag_ShadowsGlobalOutputFlag guards the shorthand
+// collision called out in the master rde-migration plan: yml merge's own
+// --output/-o (an output directory) must keep working unchanged once the
+// root gains a persistent --output/-o (an output format) — cobra's flag
+// merge order (local flags are registered before parent persistent flags are
+// merged in) makes the local one win, with no panic on the shared shorthand.
+func Test_ymlMergeOutputFlag_ShadowsGlobalOutputFlag(t *testing.T) {
+	root := newRootCommand()
+
+	var mergeCmd *cobra.Command
+	for _, c := range root.Commands() {
+		if c.Name() == "yml" {
+			for _, sub := range c.Commands() {
+				if sub.Name() == "merge" {
+					mergeCmd = sub
+				}
+			}
+		}
+	}
+	require.NotNil(t, mergeCmd, "yml merge command must be registered")
+
+	require.NotPanics(t, func() {
+		require.NoError(t, mergeCmd.ParseFlags([]string{"-o", "/tmp/merged"}))
+	})
+
+	got, err := mergeCmd.Flags().GetString("output")
+	require.NoError(t, err)
+	assert.Equal(t, "/tmp/merged", got, "-o must resolve to yml merge's own output-directory flag")
+
+	rootOutput, _ := root.PersistentFlags().GetString(cmdutil.FlagOutput)
+	assert.Equal(t, "", rootOutput, "the global --output flag must be untouched by yml merge's local -o")
 }

--- a/cli/cmdutil/args.go
+++ b/cli/cmdutil/args.go
@@ -1,9 +1,11 @@
 package cmdutil
 
 import (
+	"slices"
 	"strings"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 // CommandTokenIndex returns the index of the first argument that is not a global
@@ -11,18 +13,20 @@ import (
 // configure bitrise; everything from it onward belongs to the command (and, for
 // plugins and envman, is forwarded verbatim), so it must not be scanned for or
 // stripped of global flags.
-func CommandTokenIndex(args []string, globalFlagNames []string) int {
-	for i, a := range args {
-		isGlobalFlag := false
-		for _, name := range globalFlagNames {
-			if IsFlag(name, a) {
-				isGlobalFlag = true
-				break
-			}
-		}
-		if !isGlobalFlag {
+//
+// fs is the root's persistent flag set. It supplies each global's shorthand and
+// whether it takes a value, so this scanner accepts the same spellings cobra
+// would: a bare "--output"/"-o" is followed by its value, not by the
+// command/plugin token, and that value must be skipped rather than mistaken
+// for it.
+func CommandTokenIndex(fs *pflag.FlagSet, args []string, globalFlagNames []string) int {
+	i := 0
+	for i < len(args) {
+		_, consumed := matchGlobalFlags(fs, args[i:], globalFlagNames)
+		if consumed == 0 {
 			return i
 		}
+		i += consumed
 	}
 	return len(args)
 }
@@ -31,15 +35,89 @@ func CommandTokenIndex(args []string, globalFlagNames []string) int {
 // paths, where cobra does not parse them. Only the leading args (before the
 // command token) are bitrise globals; anything after belongs to the passthrough.
 func ApplyGlobalFlagsFromArgs(root *cobra.Command, args []string, globalFlagNames []string) {
-	for _, a := range args[:CommandTokenIndex(args, globalFlagNames)] {
-		for _, name := range globalFlagNames {
-			switch {
-			case a == "--"+name:
-				_ = root.PersistentFlags().Set(name, "true")
-			case strings.HasPrefix(a, "--"+name+"="):
-				_ = root.PersistentFlags().Set(name, strings.TrimPrefix(a, "--"+name+"="))
-			}
+	fs := root.PersistentFlags()
+	boundary := CommandTokenIndex(fs, args, globalFlagNames)
+	for i := 0; i < boundary; {
+		assignments, consumed := matchGlobalFlags(fs, args[i:boundary], globalFlagNames)
+		if consumed == 0 {
+			break // unreachable within the boundary, but keeps the loop well-defined
 		}
+		for _, a := range assignments {
+			_ = fs.Set(a.name, a.value)
+		}
+		i += consumed
+	}
+}
+
+type globalFlagAssignment struct{ name, value string }
+
+// matchGlobalFlags reports the assignments args[0] makes — plus, for a value
+// flag written with a space, args[1] — and how many leading tokens of args that
+// consumed. consumed is 0 when args[0] does not name a global flag at all, in
+// which case the assignments are meaningless. A shorthand cluster ("-qo json")
+// assigns more than one flag, hence the slice.
+func matchGlobalFlags(fs *pflag.FlagSet, args, globalFlagNames []string) ([]globalFlagAssignment, int) {
+	arg := args[0]
+
+	if strings.HasPrefix(arg, "--") {
+		name, value, hasValue := strings.Cut(strings.TrimPrefix(arg, "--"), "=")
+		if !slices.Contains(globalFlagNames, name) {
+			return nil, 0
+		}
+		f := fs.Lookup(name)
+		if f == nil {
+			return nil, 0
+		}
+		return assignOne(f, value, hasValue, args)
+	}
+
+	if !strings.HasPrefix(arg, "-") || arg == "-" {
+		return nil, 0
+	}
+
+	// Shorthand form. Every character has to name a global flag, since a
+	// cluster is all-or-nothing: "-qx" is not two bitrise globals, so the
+	// whole token belongs to the command.
+	rest := strings.TrimPrefix(arg, "-")
+	var out []globalFlagAssignment
+	for i := 0; i < len(rest); i++ {
+		f := fs.ShorthandLookup(string(rest[i]))
+		if f == nil || !slices.Contains(globalFlagNames, f.Name) {
+			return nil, 0
+		}
+		tail := rest[i+1:]
+		if f.NoOptDefVal == "" {
+			// A value flag ends the cluster: it swallows the rest of the token
+			// ("-o=json", "-ojson") or, when the token ends here, the next
+			// argument.
+			value, hasValue := strings.CutPrefix(tail, "=")
+			if !hasValue {
+				value, hasValue = tail, tail != ""
+			}
+			assigned, consumed := assignOne(f, value, hasValue, args)
+			return append(out, assigned...), consumed
+		}
+		if value, hasValue := strings.CutPrefix(tail, "="); hasValue {
+			return append(out, globalFlagAssignment{f.Name, value}), 1
+		}
+		out = append(out, globalFlagAssignment{f.Name, f.NoOptDefVal})
+	}
+	return out, 1
+}
+
+// assignOne resolves a single flag's value: an attached one when hasValue, the
+// flag's no-argument default when it has one (bools), otherwise the following
+// argument.
+func assignOne(f *pflag.Flag, value string, hasValue bool, args []string) ([]globalFlagAssignment, int) {
+	switch {
+	case hasValue:
+		return []globalFlagAssignment{{f.Name, value}}, 1
+	case f.NoOptDefVal != "":
+		return []globalFlagAssignment{{f.Name, f.NoOptDefVal}}, 1
+	case len(args) > 1:
+		return []globalFlagAssignment{{f.Name, args[1]}}, 2
+	default:
+		return []globalFlagAssignment{{f.Name, ""}}, 1
 	}
 }
 

--- a/cli/cmdutil/flags.go
+++ b/cli/cmdutil/flags.go
@@ -3,7 +3,7 @@ package cmdutil
 import (
 	"github.com/bitrise-io/bitrise/v2/configs"
 	"github.com/spf13/pflag"
-) // Flags ...
+)
 
 const (
 	CollectionPathEnvKey = "STEPMAN_COLLECTION"
@@ -43,7 +43,7 @@ const (
 // GlobalFlagNames lists the persistent flags that configure bitrise itself.
 // They are recognised on the plugin/envman dispatch paths and reported to
 // analytics, so the list is shared rather than repeated at each use site.
-var GlobalFlagNames = []string{DebugModeKey, CIKey, PRKey}
+var GlobalFlagNames = []string{DebugModeKey, CIKey, PRKey, FlagQuiet, FlagNoColor, FlagOutput, FlagTheme}
 
 // AddConfigAndInventoryFlags ...
 func AddConfigAndInventoryFlags(fs *pflag.FlagSet) {

--- a/cli/cmdutil/globalflags.go
+++ b/cli/cmdutil/globalflags.go
@@ -1,0 +1,32 @@
+package cmdutil
+
+import "github.com/spf13/cobra"
+
+// FlagOutput is the root-persistent output format flag (raw|json|yml, plus
+// the human alias for raw). Per-command --format flags (FormatKey) take
+// precedence over it when set.
+const FlagOutput = "output"
+
+// FlagQuiet suppresses non-error diagnostic messages. Only rde commands act
+// on it for now (see IsQuiet).
+const FlagQuiet = "quiet"
+
+// FlagNoColor disables ANSI colors regardless of terminal detection.
+const FlagNoColor = "no-color"
+
+// FlagTheme selects the color theme (see internal/style.Themes).
+const FlagTheme = "theme"
+
+// EnvOutput overrides the output format when neither --output nor the
+// "output" config key is set.
+const EnvOutput = "BITRISE_OUTPUT"
+
+// EnvTheme overrides the color theme when neither --theme nor the "theme"
+// config key is set.
+const EnvTheme = "BITRISE_CLI_THEME"
+
+// IsQuiet reports whether the persistent --quiet flag was set.
+func IsQuiet(cmd *cobra.Command) bool {
+	q, _ := cmd.Root().PersistentFlags().GetBool(FlagQuiet)
+	return q
+}

--- a/cli/cmdutil/globalflags_test.go
+++ b/cli/cmdutil/globalflags_test.go
@@ -1,0 +1,21 @@
+package cmdutil
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsQuiet(t *testing.T) {
+	root := &cobra.Command{Use: "root"}
+	root.PersistentFlags().BoolP(FlagQuiet, "q", false, "quiet")
+	child := &cobra.Command{Use: "child"}
+	root.AddCommand(child)
+
+	assert.False(t, IsQuiet(child), "unset defaults to false")
+
+	require.NoError(t, root.PersistentFlags().Set(FlagQuiet, "true"))
+	assert.True(t, IsQuiet(child), "reads the flag off the root, not the child")
+}

--- a/cli/config/cmd.go
+++ b/cli/config/cmd.go
@@ -42,11 +42,20 @@ inside a build a command with no --app/--workspace acts on the app the build
 runs for and the workspace owning it. Pass the flag explicitly to target
 anything else.
 
+output resolves as: --output flag > $%s > output config key (per-directory
+file then global file) > built-in default (raw). theme resolves the same way,
+via --theme and $%s (default: auto). Both honor the per-directory file, like
+app_id/default_workspace_id above — neither is a credential or a URL. Note
+--output only affects commands that share the raw/json/yml format vocabulary:
+'yml validate', 'local workflow-list' and 'plugin list/info' keep their own
+--format flag.
+
 'get'/'set'/'unset'/'list' only read and write the global file — per-dir
 files must be edited by hand.
 
 To manage your access token, use 'bitrise auth login/logout/status'.`,
 			strings.Join(internalconfig.Keys, ", "), cmdutil.EnvWebBaseURL,
+			cmdutil.EnvOutput, cmdutil.EnvTheme,
 		),
 		RunE: cmdutil.RequireKnownSubcommand,
 	}

--- a/cli/config/list_test.go
+++ b/cli/config/list_test.go
@@ -22,6 +22,8 @@ func TestListCmd_Empty(t *testing.T) {
 	assert.Contains(t, got, "web_base_url: (unset)")
 	assert.Contains(t, got, "app_id: (unset)")
 	assert.Contains(t, got, "default_workspace_id: (unset)")
+	assert.Contains(t, got, "output: (unset)")
+	assert.Contains(t, got, "theme: (unset)")
 }
 
 func TestListCmd_ShowsSavedValues(t *testing.T) {
@@ -35,6 +37,8 @@ func TestListCmd_ShowsSavedValues(t *testing.T) {
 	assert.Contains(t, out.String(), "web_base_url: (unset)")
 	assert.Contains(t, out.String(), "app_id: (unset)")
 	assert.Contains(t, out.String(), "default_workspace_id: (unset)")
+	assert.Contains(t, out.String(), "output: (unset)")
+	assert.Contains(t, out.String(), "theme: (unset)")
 }
 
 func TestListCmd_JSONFormat(t *testing.T) {
@@ -50,6 +54,8 @@ func TestListCmd_JSONFormat(t *testing.T) {
 	assert.Contains(t, out, `"web_base_url": ""`, "unset keys must still be enumerated, not omitted")
 	assert.Contains(t, out, `"app_id": ""`)
 	assert.Contains(t, out, `"default_workspace_id": ""`)
+	assert.Contains(t, out, `"output": ""`)
+	assert.Contains(t, out, `"theme": ""`)
 }
 
 func TestListCmd_YMLFormat(t *testing.T) {
@@ -65,6 +71,8 @@ func TestListCmd_YMLFormat(t *testing.T) {
 	assert.Contains(t, out, `web_base_url: ""`)
 	assert.Contains(t, out, `app_id: ""`)
 	assert.Contains(t, out, `default_workspace_id: ""`)
+	assert.Contains(t, out, `output: ""`)
+	assert.Contains(t, out, `theme: ""`)
 }
 
 func TestListCmd_RejectsPositionalArgs(t *testing.T) {

--- a/cli/envman.go
+++ b/cli/envman.go
@@ -31,8 +31,8 @@ var envmanCommand = &cobra.Command{
 // envmanPassthrough reports whether the invocation targets the envman command
 // (the first non-global-flag token is "envman") and, if so, returns the args
 // that follow it, to be forwarded verbatim.
-func envmanPassthrough(rawArgs []string) ([]string, bool) {
-	i := cmdutil.CommandTokenIndex(rawArgs, cmdutil.GlobalFlagNames)
+func envmanPassthrough(root *cobra.Command, rawArgs []string) ([]string, bool) {
+	i := cmdutil.CommandTokenIndex(root.PersistentFlags(), rawArgs, cmdutil.GlobalFlagNames)
 	if i < len(rawArgs) && rawArgs[i] == envmanCommand.Name() {
 		return rawArgs[i+1:], true
 	}

--- a/cli/plugin_dispatch.go
+++ b/cli/plugin_dispatch.go
@@ -14,7 +14,7 @@ import (
 // non-global-flag token is not a known command (or "help"), so e.g.
 // `bitrise run a:b` stays a run invocation rather than being treated as a plugin.
 func detectPlugin(root *cobra.Command, rawArgs []string) (string, []string, bool) {
-	i := cmdutil.CommandTokenIndex(rawArgs, cmdutil.GlobalFlagNames)
+	i := cmdutil.CommandTokenIndex(root.PersistentFlags(), rawArgs, cmdutil.GlobalFlagNames)
 	if i == len(rawArgs) {
 		return "", nil, false
 	}

--- a/cli/root.go
+++ b/cli/root.go
@@ -2,8 +2,10 @@ package cli
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/bitrise-io/bitrise/v2/cli/api"
 	"github.com/bitrise-io/bitrise/v2/cli/app"
@@ -19,6 +21,8 @@ import (
 	"github.com/bitrise-io/bitrise/v2/cli/user"
 	"github.com/bitrise-io/bitrise/v2/cli/yml"
 	"github.com/bitrise-io/bitrise/v2/configs"
+	"github.com/bitrise-io/bitrise/v2/internal/style"
+	"github.com/bitrise-io/bitrise/v2/output"
 	"github.com/bitrise-io/bitrise/v2/version"
 	"github.com/spf13/cobra"
 )
@@ -50,6 +54,25 @@ func newRootCommand() *cobra.Command {
 	rootCmd.PersistentFlags().Bool(cmdutil.PRKey, false, "If true bitrise runs in pull request mode.")
 	cmdutil.SetFlagEnvVar(rootCmd.PersistentFlags(), cmdutil.DebugModeKey, configs.DebugModeEnvKey)
 	cmdutil.SetFlagEnvVar(rootCmd.PersistentFlags(), cmdutil.CIKey, configs.CIModeEnvKey)
+
+	// --output does not reach the local commands that predate this vocabulary
+	// (yml validate, local workflow-list, plugin list/info); they keep their
+	// own --format.
+	rootCmd.PersistentFlags().StringP(cmdutil.FlagOutput, "o", "",
+		fmt.Sprintf("Output format for commands that support it. Accepted: %s (default), %s, %s (alias %q).", output.FormatRaw, output.FormatJSON, output.FormatYML, "human"))
+	rootCmd.PersistentFlags().BoolP(cmdutil.FlagQuiet, "q", false, "Suppress non-error diagnostic messages.")
+	rootCmd.PersistentFlags().Bool(cmdutil.FlagNoColor, false, "Disable ANSI colors (the NO_COLOR env var is also honored).")
+	rootCmd.PersistentFlags().String(cmdutil.FlagTheme, "",
+		fmt.Sprintf("Color theme. Accepted: %s.", strings.Join(style.Themes, ", ")))
+	cmdutil.SetFlagEnvVar(rootCmd.PersistentFlags(), cmdutil.FlagOutput, cmdutil.EnvOutput)
+	cmdutil.SetFlagEnvVar(rootCmd.PersistentFlags(), cmdutil.FlagTheme, cmdutil.EnvTheme)
+
+	_ = rootCmd.RegisterFlagCompletionFunc(cmdutil.FlagOutput, func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+		return []string{output.FormatRaw, output.FormatJSON, output.FormatYML, "human"}, cobra.ShellCompDirectiveNoFileComp
+	})
+	_ = rootCmd.RegisterFlagCompletionFunc(cmdutil.FlagTheme, func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+		return style.Themes, cobra.ShellCompDirectiveNoFileComp
+	})
 
 	rootCmd.AddCommand(
 		local.NewCmd(),

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -37,6 +37,8 @@ type Config struct {
 	WebBaseURL             string               `yaml:"web_base_url,omitempty"`
 	AppID                  string               `yaml:"app_id,omitempty"`
 	DefaultWorkspaceID     string               `yaml:"default_workspace_id,omitempty"`
+	Output                 string               `yaml:"output,omitempty"`
+	Theme                  string               `yaml:"theme,omitempty"`
 }
 
 // DirFileName is the file looked up in the working directory and its

--- a/internal/config/keys.go
+++ b/internal/config/keys.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 
 	"github.com/bitrise-io/bitrise/v2/internal/baseurl"
+	"github.com/bitrise-io/bitrise/v2/internal/style"
+	"github.com/bitrise-io/bitrise/v2/output"
 )
 
 const (
@@ -12,13 +14,15 @@ const (
 	KeyWebBaseURL         = "web_base_url"
 	KeyAppID              = "app_id"
 	KeyDefaultWorkspaceID = "default_workspace_id"
+	KeyOutput             = "output"
+	KeyTheme              = "theme"
 )
 
 // Keys is the subset of Config's fields exposed to `bitrise config
 // get/set/unset` — SetupVersion/LastCLIUpdateCheck/LastPluginUpdateChecks are
 // deliberately excluded: the CLI writes those itself, they aren't user
 // settings.
-var Keys = []string{KeyAPIBaseURL, KeyWebBaseURL, KeyAppID, KeyDefaultWorkspaceID}
+var Keys = []string{KeyAPIBaseURL, KeyWebBaseURL, KeyAppID, KeyDefaultWorkspaceID, KeyOutput, KeyTheme}
 
 // URLKeys is the subset of Keys whose value Set validates as an absolute
 // https URL (see validateURL) rather than accepting it as a plain
@@ -37,6 +41,10 @@ func (c *Config) Get(key string) (string, error) {
 		return c.AppID, nil
 	case KeyDefaultWorkspaceID:
 		return c.DefaultWorkspaceID, nil
+	case KeyOutput:
+		return c.Output, nil
+	case KeyTheme:
+		return c.Theme, nil
 	default:
 		return "", unknownKeyErr(key)
 	}
@@ -68,6 +76,20 @@ func (c *Config) Set(key, value string) error {
 	case KeyDefaultWorkspaceID:
 		// A workspace slug; same reasoning as KeyAppID.
 		next.DefaultWorkspaceID = value
+	case KeyOutput:
+		if value != "" {
+			if _, err := output.ParseFormat(value); err != nil {
+				return err
+			}
+		}
+		next.Output = value
+	case KeyTheme:
+		if value != "" {
+			if _, err := style.ParseTheme(value); err != nil {
+				return err
+			}
+		}
+		next.Theme = value
 	default:
 		return unknownKeyErr(key)
 	}

--- a/internal/config/keys_test.go
+++ b/internal/config/keys_test.go
@@ -84,3 +84,43 @@ func TestConfig_Set_AllowsPlainHTTPForLoopback(t *testing.T) {
 		require.NoError(t, c.Set(KeyAPIBaseURL, host), host)
 	}
 }
+
+func TestConfig_Set_Output(t *testing.T) {
+	var c Config
+	require.NoError(t, c.Set(KeyOutput, "json"))
+	v, err := c.Get(KeyOutput)
+	require.NoError(t, err)
+	assert.Equal(t, "json", v, "stored unnormalized — re-parsed downstream, not rewritten here")
+
+	require.NoError(t, c.Unset(KeyOutput))
+	v, err = c.Get(KeyOutput)
+	require.NoError(t, err)
+	assert.Equal(t, "", v)
+}
+
+func TestConfig_Set_Output_InvalidLeavesConfigUntouched(t *testing.T) {
+	c := Config{Output: "json"}
+	err := c.Set(KeyOutput, "not-a-format")
+	assert.ErrorContains(t, err, `invalid output format`)
+	assert.Equal(t, "json", c.Output)
+}
+
+func TestConfig_Set_Theme(t *testing.T) {
+	var c Config
+	require.NoError(t, c.Set(KeyTheme, "dark"))
+	v, err := c.Get(KeyTheme)
+	require.NoError(t, err)
+	assert.Equal(t, "dark", v)
+
+	require.NoError(t, c.Unset(KeyTheme))
+	v, err = c.Get(KeyTheme)
+	require.NoError(t, err)
+	assert.Equal(t, "", v)
+}
+
+func TestConfig_Set_Theme_InvalidLeavesConfigUntouched(t *testing.T) {
+	c := Config{Theme: "dark"}
+	err := c.Set(KeyTheme, "not-a-theme")
+	assert.ErrorContains(t, err, `unknown theme`)
+	assert.Equal(t, "dark", c.Theme)
+}

--- a/internal/config/resolve.go
+++ b/internal/config/resolve.go
@@ -63,6 +63,11 @@ func Resolve(legacyCfg, dirCfg, globalCfg Config) Resolved {
 		// file should be able to pin, and neither is a credential.
 		AppID:              FirstNonEmptyString(legacyCfg.AppID, dirCfg.AppID, globalCfg.AppID),
 		DefaultWorkspaceID: FirstNonEmptyString(legacyCfg.DefaultWorkspaceID, dirCfg.DefaultWorkspaceID, globalCfg.DefaultWorkspaceID),
+		// Output/Theme are neither credentials nor URLs, so — like AppID/
+		// DefaultWorkspaceID above — they honor dirCfg: a repo may reasonably
+		// pin its own output format or color theme.
+		Output: FirstNonEmptyString(legacyCfg.Output, dirCfg.Output, globalCfg.Output),
+		Theme:  FirstNonEmptyString(legacyCfg.Theme, dirCfg.Theme, globalCfg.Theme),
 	}}
 }
 

--- a/internal/config/resolve_test.go
+++ b/internal/config/resolve_test.go
@@ -92,6 +92,38 @@ func TestResolve_DefaultWorkspaceIDPrecedence(t *testing.T) {
 	assert.Equal(t, "dir-ws", r.DefaultWorkspaceID)
 }
 
+func TestResolve_OutputPrecedence(t *testing.T) {
+	dir := Config{Output: "json"}
+	global := Config{Output: "yml"}
+
+	// no layer set: stays unset — the raw/auto default is applied downstream
+	// by output.ParseFormat/style.ParseTheme, not here
+	r := Resolve(Config{}, Config{}, Config{})
+	assert.Equal(t, "", r.Output)
+
+	// global only
+	r = Resolve(Config{}, Config{}, global)
+	assert.Equal(t, "yml", r.Output)
+
+	// dir overrides global — not a credential or a URL, same treatment as AppID
+	r = Resolve(Config{}, dir, global)
+	assert.Equal(t, "json", r.Output)
+}
+
+func TestResolve_ThemePrecedence(t *testing.T) {
+	dir := Config{Theme: "dark"}
+	global := Config{Theme: "light"}
+
+	r := Resolve(Config{}, Config{}, Config{})
+	assert.Equal(t, "", r.Theme)
+
+	r = Resolve(Config{}, Config{}, global)
+	assert.Equal(t, "light", r.Theme)
+
+	r = Resolve(Config{}, dir, global)
+	assert.Equal(t, "dark", r.Theme)
+}
+
 // TestResolve_LayerPrecedence covers the three fields sharing the generic
 // legacy > dir > global precedence (SetupVersion, LastCLIUpdateCheck,
 // LastPluginUpdateChecks) in one pass, each via a different underlying


### PR DESCRIPTION
Global flag handling improvements: `output`, `theme`, `quiet` etc. registered

_This is PR 3 of 15, splitting the changes into reviewable chunks. PRs 1-4 are just infrastructure._