### PR TITLE
RDE 4 - infra: workspace resolution, TUI list picker

### DIFF
--- a/cli/app/view_test.go
+++ b/cli/app/view_test.go
@@ -47,6 +47,7 @@ func TestViewCmd_FlagFallback(t *testing.T) {
 }
 
 func TestViewCmd_RequiresAppSlug(t *testing.T) {
+	t.Setenv(cmdutil.EnvAppID, "")
 	t.Setenv(cmdutil.EnvAppIDLegacy, "")
 
 	cmd, _ := newTestViewCmd(t, "https://unused.test")

--- a/cli/auth/status_test.go
+++ b/cli/auth/status_test.go
@@ -14,6 +14,7 @@ import (
 
 func TestResolveTokenAndSource_NoToken(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("BITRISE_TOKEN", "") // an exported token would be a source, defeating the test
 
 	tok, source, err := resolveTokenAndSource()
 	require.NoError(t, err)
@@ -23,6 +24,7 @@ func TestResolveTokenAndSource_NoToken(t *testing.T) {
 
 func TestResolveTokenAndSource_EnvTakesPrecedence(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("BITRISE_TOKEN", "")
 	require.NoError(t, auth.Save(auth.Auth{Token: "file-token"}))
 	t.Setenv(auth.EnvToken, "env-token")
 
@@ -34,6 +36,7 @@ func TestResolveTokenAndSource_EnvTakesPrecedence(t *testing.T) {
 
 func TestResolveTokenAndSource_FallsBackToAuthFile(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("BITRISE_TOKEN", "")
 	require.NoError(t, auth.Save(auth.Auth{Token: "file-token"}))
 
 	tok, source, err := resolveTokenAndSource()
@@ -44,6 +47,7 @@ func TestResolveTokenAndSource_FallsBackToAuthFile(t *testing.T) {
 
 func TestResolveTokenAndSource_CorruptAuthFileReturnsError(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("BITRISE_TOKEN", "")
 	p, err := auth.Path()
 	require.NoError(t, err)
 	require.NoError(t, os.MkdirAll(filepath.Dir(p), 0o700))
@@ -57,6 +61,7 @@ func TestResolveTokenAndSource_CorruptAuthFileReturnsError(t *testing.T) {
 
 func TestCurrentStatus_NoToken(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("BITRISE_TOKEN", "")
 
 	s, err := currentStatus()
 	require.NoError(t, err)
@@ -67,6 +72,7 @@ func TestCurrentStatus_NoToken(t *testing.T) {
 
 func TestCurrentStatus_CorruptAuthFileReturnsError(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("BITRISE_TOKEN", "")
 	p, err := auth.Path()
 	require.NoError(t, err)
 	require.NoError(t, os.MkdirAll(filepath.Dir(p), 0o700))
@@ -78,6 +84,7 @@ func TestCurrentStatus_CorruptAuthFileReturnsError(t *testing.T) {
 
 func TestCurrentStatus_PastedToken(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("BITRISE_TOKEN", "")
 	require.NoError(t, auth.Save(auth.Auth{Token: "bitpat_x"}))
 
 	s, err := currentStatus()
@@ -90,6 +97,7 @@ func TestCurrentStatus_PastedToken(t *testing.T) {
 
 func TestCurrentStatus_OAuthManagedShowsExpiry(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("BITRISE_TOKEN", "")
 	expiry := time.Now().Add(time.Hour).Truncate(time.Second)
 	require.NoError(t, auth.Save(auth.Auth{
 		Token: "bitpat_x", TokenExpiry: expiry,
@@ -104,6 +112,7 @@ func TestCurrentStatus_OAuthManagedShowsExpiry(t *testing.T) {
 
 func TestCurrentStatus_EnvTokenSkipsOAuthDetails(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("BITRISE_TOKEN", "")
 	require.NoError(t, auth.Save(auth.Auth{
 		Token: "bitpat_x", TokenExpiry: time.Now().Add(time.Hour),
 		JWT: "jwt", JWTExpiry: time.Now().Add(time.Hour), RefreshToken: "refresh",

--- a/cli/build/abort_test.go
+++ b/cli/build/abort_test.go
@@ -41,6 +41,7 @@ func TestAbortCmd_HappyPath(t *testing.T) {
 }
 
 func TestAbortCmd_RequiresApp(t *testing.T) {
+	t.Setenv(cmdutil.EnvAppID, "")
 	t.Setenv(cmdutil.EnvAppIDLegacy, "")
 
 	cmd, _ := newTestAbortCmd(t, "https://unused.test")

--- a/cli/build/list_test.go
+++ b/cli/build/list_test.go
@@ -58,6 +58,7 @@ func TestListCmd_PrintsNextPageHint(t *testing.T) {
 }
 
 func TestListCmd_RequiresApp(t *testing.T) {
+	t.Setenv(cmdutil.EnvAppID, "")
 	t.Setenv(cmdutil.EnvAppIDLegacy, "")
 
 	cmd, _ := newTestListCmd(t, "https://unused.test")

--- a/cli/build/log_test.go
+++ b/cli/build/log_test.go
@@ -111,6 +111,7 @@ func TestLogCmd_StreamsArchivedLog(t *testing.T) {
 }
 
 func TestLogCmd_RequiresApp(t *testing.T) {
+	t.Setenv(cmdutil.EnvAppID, "")
 	t.Setenv(cmdutil.EnvAppIDLegacy, "")
 
 	cmd, _ := newTestLogCmd(t, "https://unused.test")

--- a/cli/build/trigger_test.go
+++ b/cli/build/trigger_test.go
@@ -187,6 +187,7 @@ func TestTriggerCmd_DefaultsBranchToMain(t *testing.T) {
 }
 
 func TestTriggerCmd_RequiresApp(t *testing.T) {
+	t.Setenv(cmdutil.EnvAppID, "")
 	t.Setenv(cmdutil.EnvAppIDLegacy, "")
 
 	cmd, _ := newTestTriggerCmd(t, "https://unused.test")

--- a/cli/build/view_test.go
+++ b/cli/build/view_test.go
@@ -34,6 +34,7 @@ func TestViewCmd_HappyPath(t *testing.T) {
 }
 
 func TestViewCmd_RequiresApp(t *testing.T) {
+	t.Setenv(cmdutil.EnvAppID, "")
 	t.Setenv(cmdutil.EnvAppIDLegacy, "")
 
 	cmd := newTestViewCmd(t, "https://unused.test")

--- a/cli/build/watch_test.go
+++ b/cli/build/watch_test.go
@@ -70,6 +70,7 @@ func TestWatchCmd_JSONFailedBuildExitsNonZero(t *testing.T) {
 }
 
 func TestWatchCmd_RequiresApp(t *testing.T) {
+	t.Setenv(cmdutil.EnvAppID, "")
 	t.Setenv(cmdutil.EnvAppIDLegacy, "")
 
 	cmd, _, _ := newTestWatchCmd(t, "https://unused.test")

--- a/cli/build/yml_test.go
+++ b/cli/build/yml_test.go
@@ -30,6 +30,7 @@ func TestYMLCmd_HappyPath(t *testing.T) {
 }
 
 func TestYMLCmd_RequiresApp(t *testing.T) {
+	t.Setenv(cmdutil.EnvAppID, "")
 	t.Setenv(cmdutil.EnvAppIDLegacy, "")
 
 	cmd, _ := newTestYMLCmd(t, "https://unused.test")

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -419,9 +419,7 @@ func Test_before_outputPrecedence(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Setenv("XDG_CONFIG_HOME", t.TempDir())
-			if tt.env != "" {
-				t.Setenv(cmdutil.EnvOutput, tt.env)
-			}
+			t.Setenv(cmdutil.EnvOutput, tt.env) // "" clears an exported one
 			if tt.configured != "" {
 				require.NoError(t, internalconfig.Save(internalconfig.Config{Output: tt.configured}))
 			}

--- a/cli/cmdtest/cmdtest.go
+++ b/cli/cmdtest/cmdtest.go
@@ -1,0 +1,97 @@
+// Package cmdtest is the shared test harness for rde command groups. It
+// replaces five near-duplicate per-package `run` helpers (one apiece for
+// session/template/savedinput/stack/machinetype in the reference
+// implementation) with a single Run, adapted to how this repo actually
+// resolves token/format/workspace: token from auth.yaml/BITRISE_TOKEN via
+// cmdutil.ResolveToken, format from a real --format flag, workspace from
+// flag/env/config layering — none of which live on a single flat struct the
+// way the reference's config.Resolved does.
+package cmdtest
+
+import (
+	"bytes"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+
+	"github.com/bitrise-io/bitrise/v2/analytics/analyticstest"
+	"github.com/bitrise-io/bitrise/v2/cli/cmdutil"
+	"github.com/bitrise-io/bitrise/v2/internal/auth"
+	"github.com/bitrise-io/bitrise/v2/internal/config"
+	"github.com/bitrise-io/bitrise/v2/output"
+)
+
+// RunIsolated sandboxes a package's tests with a temp XDG_CONFIG_HOME (so the
+// token-refresh path never touches a developer's real auth.yaml) and a no-op
+// analytics tracker (LogCommandParameters needs one set globally — see
+// cli/app/main_test.go). Use from a package TestMain:
+//
+//	func TestMain(m *testing.M) { os.Exit(cmdtest.RunIsolated(m)) }
+//
+// Every env var below reaches a command through a cli/cmdutil resolver rather
+// than through config.WithResolved, so a developer who exports one would get
+// different results than CI: an ambient BITRISE_WORKSPACE_ID alone silently
+// redirects every request a test asserts a path for.
+func RunIsolated(m *testing.M) int {
+	dir, err := os.MkdirTemp("", "bitrise-rde-test")
+	if err != nil {
+		panic(err)
+	}
+	defer func() { _ = os.RemoveAll(dir) }()
+	if err := os.Setenv("XDG_CONFIG_HOME", dir); err != nil {
+		panic(err)
+	}
+	for _, key := range []string{
+		"BITRISE_TOKEN",
+		cmdutil.EnvWorkspaceID,
+		cmdutil.EnvAppID,
+		cmdutil.EnvAppIDLegacy,
+		cmdutil.EnvOutput,
+		cmdutil.EnvTheme,
+	} {
+		if err := os.Unsetenv(key); err != nil {
+			panic(err)
+		}
+	}
+	cmdutil.SetTracker(analyticstest.NoOpTracker{})
+	return m.Run()
+}
+
+// Opts configures a single Run of cmd under test.
+type Opts struct {
+	Args               []string
+	RDEAPIBaseURL      string
+	DefaultWorkspaceID string
+	Format             string // "raw"/"json"/"yml"; empty leaves the command's own default
+	Stdin              string
+}
+
+// Run executes cmd with opts and returns its captured stdout/stderr.
+func Run(t *testing.T, cmd *cobra.Command, opts Opts) (stdout, stderr string, err error) {
+	t.Helper()
+	require.NoError(t, auth.Save(auth.Auth{Token: "test-token"}))
+
+	var out, errOut bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&errOut)
+	cmd.SetIn(strings.NewReader(opts.Stdin))
+
+	resolved := config.Resolve(config.Config{}, config.Config{}, config.Config{
+		RDEAPIBaseURL:      opts.RDEAPIBaseURL,
+		DefaultWorkspaceID: opts.DefaultWorkspaceID,
+	})
+	cmd.SetContext(config.WithResolved(t.Context(), resolved))
+
+	if opts.Format != "" {
+		if err := cmd.Flags().Set(output.FormatKey, opts.Format); err != nil {
+			t.Fatalf("set format flag: %v", err)
+		}
+	}
+
+	cmd.SetArgs(opts.Args)
+	err = cmd.Execute()
+	return out.String(), errOut.String(), err
+}

--- a/cli/cmdtest/cmdtest_test.go
+++ b/cli/cmdtest/cmdtest_test.go
@@ -1,0 +1,66 @@
+package cmdtest
+
+import (
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/bitrise-io/bitrise/v2/internal/config"
+	"github.com/bitrise-io/bitrise/v2/output"
+)
+
+func TestRun_WiresConfigFormatArgsAndStdin(t *testing.T) {
+	var resolved config.Resolved
+	cmd := &cobra.Command{
+		Use: "echo",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			resolved = config.FromContext(cmd.Context())
+			_, _ = fmt.Fprintln(cmd.OutOrStdout(), strings.Join(args, ","))
+			in, err := io.ReadAll(cmd.InOrStdin())
+			if err != nil {
+				return err
+			}
+			_, _ = fmt.Fprint(cmd.ErrOrStderr(), string(in))
+			return nil
+		},
+	}
+	cmd.Flags().StringP(output.FormatKey, "f", output.FormatRaw, "output format")
+
+	stdout, stderr, err := Run(t, cmd, Opts{
+		Args:               []string{"hello", "world"},
+		RDEAPIBaseURL:      "https://rde.example.test",
+		DefaultWorkspaceID: "test-ws",
+		Format:             output.FormatJSON,
+		Stdin:              "piped-in",
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "hello,world\n", stdout)
+	assert.Equal(t, "piped-in", stderr)
+	assert.Equal(t, "https://rde.example.test", resolved.RDEAPIBaseURL)
+	assert.Equal(t, "test-ws", resolved.DefaultWorkspaceID)
+
+	got, gerr := cmd.Flags().GetString(output.FormatKey)
+	require.NoError(t, gerr)
+	assert.Equal(t, output.FormatJSON, got)
+}
+
+func TestRun_EmptyFormatLeavesFlagDefault(t *testing.T) {
+	cmd := &cobra.Command{
+		Use:  "echo",
+		RunE: func(cmd *cobra.Command, args []string) error { return nil },
+	}
+	cmd.Flags().StringP(output.FormatKey, "f", output.FormatRaw, "output format")
+
+	_, _, err := Run(t, cmd, Opts{})
+	require.NoError(t, err)
+
+	got, gerr := cmd.Flags().GetString(output.FormatKey)
+	require.NoError(t, gerr)
+	assert.Equal(t, output.FormatRaw, got, "empty opts.Format must not touch the flag")
+}

--- a/cli/cmdtest/main_test.go
+++ b/cli/cmdtest/main_test.go
@@ -1,0 +1,10 @@
+package cmdtest
+
+import (
+	"os"
+	"testing"
+)
+
+func TestMain(m *testing.M) {
+	os.Exit(RunIsolated(m))
+}

--- a/cli/cmdutil/main_test.go
+++ b/cli/cmdutil/main_test.go
@@ -1,0 +1,20 @@
+package cmdutil
+
+import (
+	"os"
+	"testing"
+)
+
+// TestMain clears the ambient BITRISE_* inputs this package's resolvers read.
+// Without it a developer who exports one of them gets different results than
+// CI: an exported BITRISE_TOKEN, for instance, makes TestNewAPIClient_ErrNoToken
+// and TestNewAPIClient_FallsBackToAuthFile stop testing what they name. Tests
+// that want a value set use t.Setenv, which still wins.
+func TestMain(m *testing.M) {
+	for _, key := range []string{"BITRISE_TOKEN", EnvWorkspaceID, EnvAppID, EnvAppIDLegacy, EnvOutput, EnvTheme} {
+		if err := os.Unsetenv(key); err != nil {
+			panic(err)
+		}
+	}
+	os.Exit(m.Run())
+}

--- a/cli/cmdutil/picker/picker.go
+++ b/cli/cmdutil/picker/picker.go
@@ -1,0 +1,404 @@
+// Package picker is a small reusable arrow-key list selector built on
+// bubbletea. It renders an inline (non-alt-screen) menu — a highlighted cursor
+// you move with ↑/↓ (or j/k), Enter to confirm, Esc/q/Ctrl-C to cancel — and
+// returns the chosen index. The frame collapses to "" on exit so the caller's
+// own confirmation/log line is what stays in the scrollback.
+//
+// The picker is domain-agnostic: callers describe each row with an Item and map
+// any per-row status color onto a Tone, so the picker never has to know about a
+// caller's status vocabulary. Callers own the non-TTY fallback and the
+// single-item shortcut; Select always goes interactive.
+package picker
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/bitrise-io/bitrise/v2/internal/style"
+)
+
+// Tone is a semantic color hint for an item's status text. It decouples the
+// picker from any domain's status words: the caller maps its own statuses to a
+// Tone, and the picker maps Tone → the shared style bundle.
+type Tone int
+
+const (
+	ToneNone    Tone = iota // no status column
+	ToneSuccess             // green
+	ToneWarn                // amber
+	ToneDanger              // red
+	ToneDim                 // grey / de-emphasized
+)
+
+// Item is one row. Most items are selectable; set Divider to make a
+// non-selectable group header instead.
+type Item struct {
+	Title  string // primary text (e.g. an image name or a session title)
+	Desc   string // optional dim secondary text shown after the title
+	Status string // optional right-side status word ("" = none)
+	Tone   Tone   // color hint for Status
+	// Divider marks a non-selectable separator row — a group header. The cursor
+	// skips over it, Enter can't choose it, and it renders as a dim bold header
+	// rather than a normal row. Only Title is used; the other fields are ignored.
+	Divider bool
+}
+
+// Config controls a single Select call.
+type Config struct {
+	// Prompt heads the list, e.g. "Select an image".
+	Prompt string
+	// Note is an optional dim block rendered between the prompt and the rows,
+	// e.g. a key/value summary of what's being chosen. May span multiple lines;
+	// each line is rendered as-is (indent it yourself).
+	Note  string
+	Items []Item
+	// Cursor is the index highlighted on open (the press-Enter choice).
+	// Out-of-range values fall back to 0.
+	Cursor int
+	// DefaultIdx marks one row with a "(default)" badge (-1 = none).
+	DefaultIdx int
+	// Filter enables type-to-narrow substring filtering. When off, letter keys
+	// drive j/k navigation and q quits.
+	Filter bool
+	// In is the key source (os.Stdin); Out is where the menu renders (stderr).
+	In  io.Reader
+	Out io.Writer
+}
+
+// ErrCancelled is returned when the user backs out (Esc, q, Ctrl-C/SIGTERM,
+// EOF) or when there are no items to choose from. Callers translate it to their
+// own clean-exit sentinel.
+var ErrCancelled = errors.New("picker cancelled")
+
+// Select runs the interactive picker and returns the chosen index into
+// cfg.Items. It returns ErrCancelled if the user backs out (or cfg.Items is
+// empty), and a wrapped error if the bubbletea program itself fails. The caller
+// is responsible for the non-TTY fallback and the single-item shortcut — Select
+// always goes interactive. ctx cancellation yields ErrCancelled.
+func Select(ctx context.Context, cfg Config) (int, error) {
+	if len(cfg.Items) == 0 {
+		return 0, ErrCancelled
+	}
+	p := tea.NewProgram(newModel(cfg),
+		tea.WithContext(ctx),
+		tea.WithInput(cfg.In),   // os.Stdin
+		tea.WithOutput(cfg.Out), // stderr — keeps stdout clean (data discipline)
+	)
+	final, err := p.Run()
+	if err != nil {
+		// External cancel (trapped Ctrl-C / SIGTERM via WithContext) surfaces
+		// here; treat it as a clean backout like an in-program cancel.
+		if errors.Is(err, context.Canceled) || errors.Is(err, tea.ErrProgramKilled) {
+			return 0, ErrCancelled
+		}
+		return 0, fmt.Errorf("render picker: %w", err)
+	}
+	m, ok := final.(model)
+	if !ok {
+		return 0, fmt.Errorf("unexpected final model type %T", final)
+	}
+	if m.cancelled || m.chosen < 0 {
+		return 0, ErrCancelled
+	}
+	return m.chosen, nil
+}
+
+// model is the bubbletea state. cursor/offset index into the *filtered* view;
+// view holds the item indices currently shown.
+type model struct {
+	prompt   string
+	note     string
+	items    []Item
+	filterOn bool
+
+	view   []int  // item indices currently visible (filter applied)
+	cursor int    // index into view
+	offset int    // first visible view index (scroll window)
+	filter string // current filter text
+
+	defaultIdx int  // item index to badge "(default)" (-1 = none)
+	chosen     int  // chosen item index; -1 until Enter
+	cancelled  bool // user backed out
+	width      int
+	height     int
+
+	s           style.Styles
+	cursorStyle lipgloss.Style
+}
+
+func newModel(cfg Config) model {
+	view := make([]int, len(cfg.Items))
+	for i := range cfg.Items {
+		view[i] = i
+	}
+	cursor := cfg.Cursor
+	if cursor < 0 || cursor >= len(cfg.Items) {
+		cursor = 0
+	}
+	def := cfg.DefaultIdx
+	if def < 0 || def >= len(cfg.Items) {
+		def = -1
+	}
+	s := style.New(cfg.Out)
+	m := model{
+		prompt:      cfg.Prompt,
+		note:        cfg.Note,
+		items:       cfg.Items,
+		filterOn:    cfg.Filter,
+		view:        view,
+		cursor:      cursor,
+		defaultIdx:  def,
+		chosen:      -1,
+		width:       80,
+		s:           s,
+		cursorStyle: s.Brand.Bold(true),
+	}
+	m.cursor = m.selectableCursor(cursor) // never open the cursor on a divider
+	m.clampOffset()
+	return m
+}
+
+// selectableCursor returns a view index that lands on a selectable (non-divider)
+// row: it searches from want forward, then backward, so a group header is never
+// the highlighted row. Falls back to want when every visible row is a divider
+// (callers always include at least one selectable item, so this is defensive).
+func (m model) selectableCursor(want int) int {
+	if want < 0 || want >= len(m.view) {
+		want = 0
+	}
+	for i := want; i < len(m.view); i++ {
+		if !m.items[m.view[i]].Divider {
+			return i
+		}
+	}
+	for i := want - 1; i >= 0; i-- {
+		if !m.items[m.view[i]].Divider {
+			return i
+		}
+	}
+	return want
+}
+
+func (m model) Init() tea.Cmd { return nil }
+
+func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
+		m.height = msg.Height
+		m.clampOffset()
+		return m, nil
+
+	case tea.KeyMsg:
+		switch msg.Type {
+		case tea.KeyCtrlC, tea.KeyEsc:
+			m.cancelled = true
+			return m, tea.Quit
+		case tea.KeyUp:
+			m.move(-1)
+		case tea.KeyDown:
+			m.move(1)
+		case tea.KeyEnter:
+			if len(m.view) > 0 && !m.items[m.view[m.cursor]].Divider {
+				m.chosen = m.view[m.cursor]
+				return m, tea.Quit
+			}
+		case tea.KeyBackspace:
+			if m.filterOn && m.filter != "" {
+				r := []rune(m.filter)
+				m.filter = string(r[:len(r)-1])
+				m.applyFilter()
+			}
+		case tea.KeySpace:
+			if m.filterOn {
+				m.filter += " "
+				m.applyFilter()
+			}
+		case tea.KeyRunes:
+			if m.filterOn {
+				m.filter += string(msg.Runes)
+				m.applyFilter()
+				break
+			}
+			switch string(msg.Runes) {
+			case "k":
+				m.move(-1)
+			case "j":
+				m.move(1)
+			case "q":
+				m.cancelled = true
+				return m, tea.Quit
+			}
+		}
+		return m, nil
+	}
+	return m, nil
+}
+
+func (m model) View() string {
+	if m.chosen >= 0 || m.cancelled {
+		return "" // collapse — the caller prints the confirmation line
+	}
+
+	var b strings.Builder
+	b.WriteString(m.s.Bold.Render(m.prompt))
+	if m.filterOn && m.filter != "" {
+		b.WriteString("  ")
+		b.WriteString(m.s.Dim.Render("/" + m.filter))
+	}
+	b.WriteByte('\n')
+
+	if m.note != "" {
+		for _, line := range strings.Split(m.note, "\n") {
+			b.WriteString(m.s.Dim.Render(line))
+			b.WriteByte('\n')
+		}
+		b.WriteByte('\n') // blank line between the summary and the rows
+	}
+
+	if len(m.view) == 0 {
+		b.WriteString(m.s.Dim.Render("  no matches"))
+		b.WriteByte('\n')
+		b.WriteString(m.s.Dim.Render(m.hint()))
+		return b.String()
+	}
+
+	maxRows := m.visibleRows()
+	start := m.offset
+	end := start + maxRows
+	if end > len(m.view) {
+		end = len(m.view)
+	}
+	for vi := start; vi < end; vi++ {
+		itemIdx := m.view[vi]
+		it := m.items[itemIdx]
+		if it.Divider {
+			// A group header: flush-left, bold/dim, never carries the cursor.
+			b.WriteString(m.s.Header.Render(it.Title))
+			b.WriteByte('\n')
+			continue
+		}
+		marker := "  "
+		title := it.Title
+		if vi == m.cursor {
+			marker = m.cursorStyle.Render("›") + " "
+			title = m.cursorStyle.Render(title)
+		}
+		line := marker + title
+		if it.Desc != "" {
+			line += "  " + m.s.Dim.Render(it.Desc)
+		}
+		if itemIdx == m.defaultIdx {
+			line += "  " + m.s.Dim.Render("(default)")
+		}
+		if it.Status != "" {
+			line += "  " + m.toneStyle(it.Tone).Render("("+it.Status+")")
+		}
+		b.WriteString(line)
+		b.WriteByte('\n')
+	}
+	if len(m.view) > maxRows {
+		b.WriteString(m.s.Dim.Render(fmt.Sprintf("  … %d–%d of %d", start+1, end, len(m.view))))
+		b.WriteByte('\n')
+	}
+	b.WriteString(m.s.Dim.Render(m.hint()))
+	return b.String()
+}
+
+func (m model) hint() string {
+	if m.filterOn {
+		return "↑/↓ move · type to filter · enter select · esc cancel"
+	}
+	return "↑/↓ move · enter select · esc cancel"
+}
+
+func (m model) toneStyle(t Tone) lipgloss.Style {
+	switch t {
+	case ToneSuccess:
+		return m.s.Success
+	case ToneWarn:
+		return m.s.Warn
+	case ToneDanger:
+		return m.s.Failure
+	default:
+		return m.s.Dim
+	}
+}
+
+// move shifts the cursor within the filtered view (clamped, no wrap), skipping
+// over any divider rows, and keeps it inside the scroll window. When there's no
+// selectable row further in the given direction the cursor stays put.
+func (m *model) move(delta int) {
+	if len(m.view) == 0 || delta == 0 {
+		return
+	}
+	next := m.cursor
+	for {
+		next += delta
+		if next < 0 || next >= len(m.view) {
+			return // edge reached with only dividers beyond: stay put
+		}
+		if !m.items[m.view[next]].Divider {
+			m.cursor = next
+			m.clampOffset()
+			return
+		}
+	}
+}
+
+// applyFilter rebuilds the visible view from a case-insensitive substring match
+// over Title+Desc, then resets the cursor/window to the top match.
+func (m *model) applyFilter() {
+	q := strings.ToLower(strings.TrimSpace(m.filter))
+	view := make([]int, 0, len(m.items))
+	for i, it := range m.items {
+		if q == "" || strings.Contains(strings.ToLower(it.Title+" "+it.Desc), q) {
+			view = append(view, i)
+		}
+	}
+	m.view = view
+	m.cursor = m.selectableCursor(0)
+	m.offset = 0
+}
+
+// clampOffset scrolls the window so the cursor stays visible.
+func (m *model) clampOffset() {
+	if len(m.view) == 0 {
+		m.offset = 0
+		return
+	}
+	maxRows := m.visibleRows()
+	if m.cursor < m.offset {
+		m.offset = m.cursor
+	}
+	if m.cursor >= m.offset+maxRows {
+		m.offset = m.cursor - maxRows + 1
+	}
+	if m.offset < 0 {
+		m.offset = 0
+	}
+	if m.offset > len(m.view)-1 {
+		m.offset = len(m.view) - 1
+	}
+}
+
+// visibleRows is how many item rows fit, reserving lines for the prompt, the
+// "… N of M" window summary, and the footer hint. Falls back to a sane cap
+// before the first WindowSizeMsg (height unknown).
+func (m model) visibleRows() int {
+	const reserve = 3 // prompt + window summary + footer
+	const fallback = 12
+	if m.height <= 0 {
+		return fallback
+	}
+	if r := m.height - reserve; r >= 1 {
+		return r
+	}
+	return 1
+}

--- a/cli/cmdutil/picker/picker_test.go
+++ b/cli/cmdutil/picker/picker_test.go
@@ -1,0 +1,353 @@
+package picker
+
+import (
+	"bytes"
+	"reflect"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+// items builds n simple rows titled a, b, c, … for navigation tests.
+func threeItems() []Item {
+	return []Item{{Title: "alpha"}, {Title: "beta"}, {Title: "gamma"}}
+}
+
+// drive applies one message and returns the resulting model.
+func drive(m model, msg tea.Msg) model {
+	next, _ := m.Update(msg)
+	return next.(model)
+}
+
+func keyType(tt tea.KeyType) tea.KeyMsg { return tea.KeyMsg{Type: tt} }
+func runes(s string) tea.KeyMsg         { return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(s)} }
+
+// isQuit reports whether cmd is tea.Quit.
+func isQuit(cmd tea.Cmd) bool {
+	if cmd == nil {
+		return false
+	}
+	_, ok := cmd().(tea.QuitMsg)
+	return ok
+}
+
+func newTestModel(cfg Config) model {
+	if cfg.Out == nil {
+		cfg.Out = &bytes.Buffer{}
+	}
+	if cfg.Items == nil {
+		cfg.Items = threeItems()
+	}
+	return newModel(cfg)
+}
+
+func TestCursorStartsOnConfiguredIndex(t *testing.T) {
+	if m := newTestModel(Config{Cursor: 1}); m.cursor != 1 {
+		t.Errorf("cursor = %d, want 1", m.cursor)
+	}
+	// Out-of-range cursors clamp to 0.
+	if m := newTestModel(Config{Cursor: 99}); m.cursor != 0 {
+		t.Errorf("oob cursor = %d, want 0", m.cursor)
+	}
+	if m := newTestModel(Config{Cursor: -3}); m.cursor != 0 {
+		t.Errorf("negative cursor = %d, want 0", m.cursor)
+	}
+	// DefaultIdx out of range disables the badge (-1).
+	if m := newTestModel(Config{DefaultIdx: 99}); m.defaultIdx != -1 {
+		t.Errorf("oob defaultIdx = %d, want -1", m.defaultIdx)
+	}
+}
+
+func TestNavigationClamps(t *testing.T) {
+	m := newTestModel(Config{})
+	m = drive(m, keyType(tea.KeyDown))
+	m = drive(m, keyType(tea.KeyDown))
+	if m.cursor != 2 {
+		t.Fatalf("after 2×down cursor = %d, want 2", m.cursor)
+	}
+	// Can't move past the last row.
+	m = drive(m, keyType(tea.KeyDown))
+	if m.cursor != 2 {
+		t.Fatalf("down past end cursor = %d, want 2 (clamped)", m.cursor)
+	}
+	// j/k mirror the arrows when filtering is off.
+	m = drive(m, runes("k"))
+	if m.cursor != 1 {
+		t.Fatalf("after k cursor = %d, want 1", m.cursor)
+	}
+	m = drive(m, keyType(tea.KeyUp))
+	m = drive(m, keyType(tea.KeyUp))
+	if m.cursor != 0 {
+		t.Fatalf("up past start cursor = %d, want 0 (clamped)", m.cursor)
+	}
+}
+
+func TestEnterConfirmsAndQuits(t *testing.T) {
+	m := newTestModel(Config{Cursor: 1})
+	next, cmd := m.Update(keyType(tea.KeyEnter))
+	m = next.(model)
+	if m.chosen != 1 {
+		t.Errorf("chosen = %d, want 1", m.chosen)
+	}
+	if !isQuit(cmd) {
+		t.Error("expected Enter to issue tea.Quit")
+	}
+}
+
+func TestCancelKeys(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		msg  tea.KeyMsg
+	}{
+		{"esc", keyType(tea.KeyEsc)},
+		{"ctrl-c", keyType(tea.KeyCtrlC)},
+		{"q (filter off)", runes("q")},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			next, cmd := newTestModel(Config{}).Update(tc.msg)
+			m := next.(model)
+			if !m.cancelled {
+				t.Error("expected cancelled=true")
+			}
+			if m.chosen != -1 {
+				t.Errorf("chosen = %d, want -1", m.chosen)
+			}
+			if !isQuit(cmd) {
+				t.Error("expected tea.Quit")
+			}
+		})
+	}
+}
+
+func TestFilterNarrowsAndRestores(t *testing.T) {
+	m := newTestModel(Config{Filter: true})
+	// "al" matches only "alpha".
+	m = drive(m, runes("a"))
+	m = drive(m, runes("l"))
+	if len(m.view) != 1 || m.view[0] != 0 {
+		t.Fatalf("view after 'al' = %v, want [0]", m.view)
+	}
+	if m.cursor != 0 {
+		t.Fatalf("cursor after filter = %d, want 0", m.cursor)
+	}
+	// Enter selects the single match.
+	next, cmd := m.Update(keyType(tea.KeyEnter))
+	if got := next.(model).chosen; got != 0 {
+		t.Fatalf("chosen = %d, want 0", got)
+	}
+	if !isQuit(cmd) {
+		t.Error("expected tea.Quit on filtered Enter")
+	}
+	// Backspace widens the match again.
+	m = drive(m, keyType(tea.KeyBackspace)) // → "a", matches all three
+	if len(m.view) != 3 {
+		t.Fatalf("view after backspace = %v, want all 3", m.view)
+	}
+}
+
+func TestFilterEmptyResultIgnoresEnter(t *testing.T) {
+	m := newTestModel(Config{Filter: true})
+	m = drive(m, runes("z")) // matches nothing
+	if len(m.view) != 0 {
+		t.Fatalf("view = %v, want empty", m.view)
+	}
+	next, cmd := m.Update(keyType(tea.KeyEnter))
+	if got := next.(model).chosen; got != -1 {
+		t.Errorf("chosen = %d, want -1 (no-op on empty)", got)
+	}
+	if isQuit(cmd) {
+		t.Error("Enter on empty result should not quit")
+	}
+}
+
+func TestQTypesIntoFilterWhenFilterOn(t *testing.T) {
+	m := newTestModel(Config{Filter: true})
+	m = drive(m, runes("q"))
+	if m.cancelled {
+		t.Error("q should type into the filter, not cancel, when Filter is on")
+	}
+	if m.filter != "q" {
+		t.Errorf("filter = %q, want %q", m.filter, "q")
+	}
+}
+
+func TestViewContentAndCollapse(t *testing.T) {
+	m := newTestModel(Config{Prompt: "Select an image", Cursor: 1, DefaultIdx: 1})
+	v := m.View()
+	for _, want := range []string{"Select an image", "›", "(default)", "alpha", "beta"} {
+		if !strings.Contains(v, want) {
+			t.Errorf("View() missing %q in:\n%s", want, v)
+		}
+	}
+	// After confirming, the frame collapses so the caller's line is what shows.
+	m = drive(m, keyType(tea.KeyEnter))
+	if got := m.View(); got != "" {
+		t.Errorf("View() after confirm = %q, want empty", got)
+	}
+	// Same after cancelling.
+	c := drive(newTestModel(Config{}), keyType(tea.KeyEsc))
+	if got := c.View(); got != "" {
+		t.Errorf("View() after cancel = %q, want empty", got)
+	}
+}
+
+func TestViewRendersNote(t *testing.T) {
+	m := newTestModel(Config{
+		Prompt: "Last used for this project",
+		Note:   "  Image         Ubuntu 24.04\n  Machine type  g2.mac",
+		Items:  []Item{{Title: "Use this setup"}, {Title: "Change image"}},
+	})
+	v := m.View()
+	for _, want := range []string{"Image         Ubuntu 24.04", "Machine type  g2.mac", "Use this setup"} {
+		if !strings.Contains(v, want) {
+			t.Errorf("View() missing note/row %q in:\n%s", want, v)
+		}
+	}
+}
+
+func TestStatusRendersInView(t *testing.T) {
+	m := newTestModel(Config{Items: []Item{
+		{Title: "sess-1", Desc: "[main] 2h ago", Status: "running", Tone: ToneSuccess},
+	}})
+	v := m.View()
+	for _, want := range []string{"sess-1", "[main] 2h ago", "(running)"} {
+		if !strings.Contains(v, want) {
+			t.Errorf("View() missing %q in:\n%s", want, v)
+		}
+	}
+}
+
+func TestToneStyleMapping(t *testing.T) {
+	m := newTestModel(Config{})
+	for _, tc := range []struct {
+		tone Tone
+		want lipgloss.Style
+	}{
+		{ToneSuccess, m.s.Success},
+		{ToneWarn, m.s.Warn},
+		{ToneDanger, m.s.Failure},
+		{ToneDim, m.s.Dim},
+		{ToneNone, m.s.Dim},
+	} {
+		if !reflect.DeepEqual(m.toneStyle(tc.tone), tc.want) {
+			t.Errorf("toneStyle(%v) mapped to the wrong style", tc.tone)
+		}
+	}
+	// Distinct tones must map to distinct styles, else coloring is meaningless.
+	if reflect.DeepEqual(m.s.Success, m.s.Failure) {
+		t.Error("Success and Failure styles should differ")
+	}
+}
+
+func TestViewportWindowsLongList(t *testing.T) {
+	items := make([]Item, 30)
+	for i := range items {
+		items[i] = Item{Title: string(rune('a' + i%26))}
+	}
+	m := newTestModel(Config{Items: items})
+	m = drive(m, tea.WindowSizeMsg{Width: 80, Height: 10}) // visibleRows = 10-3 = 7
+	if got := m.visibleRows(); got != 7 {
+		t.Fatalf("visibleRows = %d, want 7", got)
+	}
+	for i := 0; i < 10; i++ {
+		m = drive(m, keyType(tea.KeyDown))
+	}
+	if m.cursor != 10 {
+		t.Fatalf("cursor = %d, want 10", m.cursor)
+	}
+	// Window scrolled to keep the cursor visible: offset = cursor-maxRows+1.
+	if m.offset != 4 {
+		t.Fatalf("offset = %d, want 4", m.offset)
+	}
+	if v := m.View(); !strings.Contains(v, "of 30") {
+		t.Errorf("View() should show the windowed summary, got:\n%s", v)
+	}
+}
+
+// dividerItems builds a grouped list: [G1 divider, alpha, beta, G2 divider, gamma].
+func dividerItems() []Item {
+	return []Item{
+		{Title: "G1", Divider: true},
+		{Title: "alpha"},
+		{Title: "beta"},
+		{Title: "G2", Divider: true},
+		{Title: "gamma"},
+	}
+}
+
+func TestCursorOpensOffDivider(t *testing.T) {
+	// Cursor 0 is a divider → it advances to the first selectable row (index 1).
+	if m := newTestModel(Config{Items: dividerItems(), Cursor: 0}); m.cursor != 1 {
+		t.Errorf("cursor = %d, want 1 (first selectable, not the divider)", m.cursor)
+	}
+	// A cursor already on a selectable row is left alone.
+	if m := newTestModel(Config{Items: dividerItems(), Cursor: 2}); m.cursor != 2 {
+		t.Errorf("cursor = %d, want 2", m.cursor)
+	}
+}
+
+func TestNavigationSkipsDividers(t *testing.T) {
+	m := newTestModel(Config{Items: dividerItems()}) // opens on 1 (alpha)
+	m = drive(m, keyType(tea.KeyDown))               // → 2 (beta)
+	if m.cursor != 2 {
+		t.Fatalf("after down cursor = %d, want 2 (beta)", m.cursor)
+	}
+	m = drive(m, keyType(tea.KeyDown)) // skips the G2 divider → 4 (gamma)
+	if m.cursor != 4 {
+		t.Fatalf("after down cursor = %d, want 4 (gamma, divider skipped)", m.cursor)
+	}
+	m = drive(m, keyType(tea.KeyDown)) // at the last row: stays put
+	if m.cursor != 4 {
+		t.Fatalf("down past end cursor = %d, want 4", m.cursor)
+	}
+	m = drive(m, keyType(tea.KeyUp)) // skips G2 back up → 2 (beta)
+	if m.cursor != 2 {
+		t.Fatalf("after up cursor = %d, want 2 (beta)", m.cursor)
+	}
+	m = drive(m, keyType(tea.KeyUp)) // → 1 (alpha)
+	m = drive(m, keyType(tea.KeyUp)) // top selectable; G1 divider above → stays at 1
+	if m.cursor != 1 {
+		t.Fatalf("up past top cursor = %d, want 1 (alpha)", m.cursor)
+	}
+}
+
+func TestEnterIgnoresDivider(t *testing.T) {
+	// Force the cursor onto a divider (navigation never does this) and confirm
+	// Enter is a no-op — the frame stays open and nothing is chosen.
+	m := newTestModel(Config{Items: dividerItems()})
+	m.cursor = 0 // the G1 divider
+	next, cmd := m.Update(keyType(tea.KeyEnter))
+	got := next.(model)
+	if got.chosen != -1 {
+		t.Errorf("chosen = %d, want -1 (divider not selectable)", got.chosen)
+	}
+	if isQuit(cmd) {
+		t.Error("Enter on a divider should not quit")
+	}
+}
+
+func TestDividerRendersAsHeaderWithoutCursor(t *testing.T) {
+	m := newTestModel(Config{Items: dividerItems()}) // cursor on alpha (index 1)
+	lines := strings.Split(m.View(), "\n")
+	var g1 string
+	for _, ln := range lines {
+		if strings.Contains(ln, "G1") {
+			g1 = ln
+		}
+	}
+	if g1 == "" {
+		t.Fatalf("View() missing the G1 divider:\n%s", m.View())
+	}
+	if strings.Contains(g1, "›") {
+		t.Errorf("divider line should not carry the cursor marker: %q", g1)
+	}
+}
+
+func TestSelectEmptyItemsCancels(t *testing.T) {
+	_, err := Select(t.Context(), Config{Items: nil, Out: &bytes.Buffer{}})
+	if err != ErrCancelled {
+		t.Errorf("Select(empty) err = %v, want ErrCancelled", err)
+	}
+}

--- a/cli/cmdutil/workspace.go
+++ b/cli/cmdutil/workspace.go
@@ -1,11 +1,17 @@
 package cmdutil
 
 import (
+	"errors"
+	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
 
+	"github.com/bitrise-io/bitrise/v2/cli/cmdutil/picker"
+	"github.com/bitrise-io/bitrise/v2/internal/bitriseapi"
 	"github.com/bitrise-io/bitrise/v2/internal/config"
+	"github.com/bitrise-io/bitrise/v2/internal/workspace"
+	"github.com/bitrise-io/bitrise/v2/output"
 )
 
 // FlagWorkspace is the workspace a command acts on.
@@ -14,8 +20,9 @@ const FlagWorkspace = "workspace"
 // EnvWorkspaceID supplies the workspace when --workspace isn't passed. Bitrise
 // auto-injects it into every build, naming the workspace that owns the app the
 // build runs for, so a bare command inside a build acts on that workspace. Same
-// intentional ambient targeting as EnvAppIDLegacy.
-const EnvWorkspaceID = "BITRISE_WORKSPACE_ID"
+// intentional ambient targeting as EnvAppIDLegacy. Defined in internal/workspace
+// because the shared sole-workspace error names it.
+const EnvWorkspaceID = workspace.EnvWorkspaceID
 
 // DefaultWorkspaceSlug returns the workspace configured as the default —
 // BITRISE_WORKSPACE_ID, then the default_workspace_id config key — or "" when
@@ -27,4 +34,101 @@ func DefaultWorkspaceSlug(cmd *cobra.Command) string {
 		return v
 	}
 	return config.FromContext(cmd.Context()).DefaultWorkspaceID
+}
+
+// ResolveWorkspaceID returns the workspace ID for this command: --workspace,
+// then DefaultWorkspaceSlug (BITRISE_WORKSPACE_ID / default_workspace_id),
+// then one GET /organizations call — a sole workspace auto-detects (with a
+// stderr breadcrumb), 2+ workspaces show an interactive picker on a TTY or a
+// friendly sorted error otherwise. Zero workspaces always errors.
+func ResolveWorkspaceID(cmd *cobra.Command) (string, error) {
+	if v, _ := cmd.Flags().GetString(FlagWorkspace); v != "" {
+		return v, nil
+	}
+	if v := DefaultWorkspaceSlug(cmd); v != "" {
+		return v, nil
+	}
+	client, err := NewAPIClient(cmd)
+	if err != nil {
+		return "", err
+	}
+	orgs, err := client.Organizations(cmd.Context())
+	if err != nil {
+		return "", fmt.Errorf("list workspaces: %w", err)
+	}
+	if len(orgs) > 1 && interactiveWorkspacePicker(cmd) {
+		return pickWorkspace(cmd, orgs)
+	}
+	ws, err := workspace.Sole(orgs)
+	if err != nil {
+		return "", err
+	}
+	if !IsQuiet(cmd) && output.Format == output.FormatRaw {
+		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Using your only workspace: %s\n", workspaceLabel(ws))
+		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Set it permanently to skip this lookup: bitrise config set %s %s\n", config.KeyDefaultWorkspaceID, ws.Slug)
+	}
+	return ws.Slug, nil
+}
+
+// interactiveWorkspacePicker reports whether the workspace picker can run: it
+// reads keys from stdin and draws to stderr, so both must be a terminal, and it
+// only makes sense for raw/human output (json/yml callers want the
+// deterministic error, not a prompt).
+func interactiveWorkspacePicker(cmd *cobra.Command) bool {
+	return output.Format == output.FormatRaw &&
+		IsTerminal(os.Stdin) &&
+		IsTerminalWriter(cmd.ErrOrStderr())
+}
+
+// pickWorkspace shows the interactive workspace picker for orgs (assumed 2+)
+// and returns the chosen workspace ID for this command only. It prints the
+// command that pins the choice as the default so the next run skips the
+// prompt. A backout (Esc/q/Ctrl-C) prints "Cancelled." and returns an error
+// that aborts the command without cobra's redundant "Error:" line.
+func pickWorkspace(cmd *cobra.Command, orgs []bitriseapi.Organization) (string, error) {
+	sorted := workspace.Sort(orgs)
+	items := make([]picker.Item, len(sorted))
+	for i, o := range sorted {
+		items[i] = picker.Item{Title: workspaceName(o), Desc: o.Slug}
+	}
+	idx, err := picker.Select(cmd.Context(), picker.Config{
+		Prompt:     "Select a workspace",
+		Items:      items,
+		Cursor:     0,
+		DefaultIdx: -1,
+		In:         os.Stdin,
+		Out:        cmd.ErrOrStderr(),
+	})
+	if errors.Is(err, picker.ErrCancelled) {
+		_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "Cancelled.")
+		SilenceRootErrors(cmd)
+		return "", errors.New("workspace selection cancelled")
+	}
+	if err != nil {
+		return "", err
+	}
+	ws := sorted[idx]
+	if !IsQuiet(cmd) {
+		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Using workspace: %s\n", workspaceLabel(ws))
+		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Set it permanently to skip this prompt: bitrise config set %s %s\n", config.KeyDefaultWorkspaceID, ws.Slug)
+	}
+	return ws.Slug, nil
+}
+
+// workspaceLabel renders a workspace for a human breadcrumb as "name (slug)",
+// falling back to the bare slug when the API omitted a name.
+func workspaceLabel(ws bitriseapi.Organization) string {
+	if ws.Name != "" {
+		return fmt.Sprintf("%s (%s)", ws.Name, ws.Slug)
+	}
+	return ws.Slug
+}
+
+// workspaceName returns the workspace's display name, falling back to its
+// slug when the API omitted a name — used as the picker row's primary text.
+func workspaceName(ws bitriseapi.Organization) string {
+	if ws.Name != "" {
+		return ws.Name
+	}
+	return ws.Slug
 }

--- a/cli/cmdutil/workspace_test.go
+++ b/cli/cmdutil/workspace_test.go
@@ -1,12 +1,18 @@
 package cmdutil
 
 import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
+	"github.com/bitrise-io/bitrise/v2/internal/auth"
 	"github.com/bitrise-io/bitrise/v2/internal/config"
+	"github.com/bitrise-io/bitrise/v2/output"
 )
 
 // A bare command has a nil Context(), which must read as "no default set"
@@ -37,4 +43,130 @@ func TestDefaultWorkspaceSlug_EnvWinsOverConfig(t *testing.T) {
 	)))
 
 	assert.Equal(t, "env-ws", DefaultWorkspaceSlug(cmd))
+}
+
+func TestResolveWorkspaceID_FlagWins(t *testing.T) {
+	cmd := newTestWorkspaceCmd(t)
+	require.NoError(t, cmd.Flags().Set(FlagWorkspace, "flag-ws"))
+
+	ws, err := ResolveWorkspaceID(cmd)
+	require.NoError(t, err)
+	assert.Equal(t, "flag-ws", ws)
+}
+
+func TestResolveWorkspaceID_FallsBackToDefaultWorkspaceSlug(t *testing.T) {
+	t.Setenv(EnvWorkspaceID, "env-ws")
+	cmd := newTestWorkspaceCmd(t)
+
+	ws, err := ResolveWorkspaceID(cmd)
+	require.NoError(t, err)
+	assert.Equal(t, "env-ws", ws)
+}
+
+func TestResolveWorkspaceID_SoleWorkspaceAutoDetect(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"data":[{"slug":"only-ws","name":"Only Workspace"}]}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	cmd, errOut := newTestWorkspaceCmdWithServer(t, srv.URL)
+
+	ws, err := ResolveWorkspaceID(cmd)
+	require.NoError(t, err)
+	assert.Equal(t, "only-ws", ws)
+	assert.Contains(t, errOut.String(), "Using your only workspace: Only Workspace (only-ws)")
+	assert.Contains(t, errOut.String(), "Set it permanently to skip this lookup: bitrise config set default_workspace_id only-ws")
+}
+
+func TestResolveWorkspaceID_SoleWorkspaceBreadcrumbSuppressedByQuiet(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"data":[{"slug":"only-ws"}]}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	cmd, errOut := newTestWorkspaceCmdWithServer(t, srv.URL)
+	require.NoError(t, cmd.PersistentFlags().Set(FlagQuiet, "true"))
+
+	ws, err := ResolveWorkspaceID(cmd)
+	require.NoError(t, err)
+	assert.Equal(t, "only-ws", ws)
+	assert.Empty(t, errOut.String())
+}
+
+func TestResolveWorkspaceID_SoleWorkspaceBreadcrumbSuppressedByFormat(t *testing.T) {
+	for _, format := range []string{output.FormatJSON, output.FormatYML} {
+		t.Run(format, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				_, _ = w.Write([]byte(`{"data":[{"slug":"only-ws"}]}`))
+			}))
+			t.Cleanup(srv.Close)
+
+			output.Format = format
+			t.Cleanup(func() { output.Format = output.FormatRaw })
+
+			cmd, errOut := newTestWorkspaceCmdWithServer(t, srv.URL)
+
+			ws, err := ResolveWorkspaceID(cmd)
+			require.NoError(t, err)
+			assert.Equal(t, "only-ws", ws)
+			assert.Empty(t, errOut.String())
+		})
+	}
+}
+
+func TestResolveWorkspaceID_AmbiguousWorkspaceFriendlyError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"data":[{"slug":"b-ws","name":"Bravo"},{"slug":"a-ws","name":"Alpha"}]}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	cmd, _ := newTestWorkspaceCmdWithServer(t, srv.URL)
+
+	// Non-interactive with 2+ workspaces surfaces workspace.Sole's error
+	// rather than prompting; its wording and ordering are pinned in
+	// internal/workspace.
+	_, err := ResolveWorkspaceID(cmd)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "multiple workspaces available")
+}
+
+func TestResolveWorkspaceID_NoWorkspaces(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"data":[]}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	cmd, _ := newTestWorkspaceCmdWithServer(t, srv.URL)
+
+	_, err := ResolveWorkspaceID(cmd)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no workspaces found")
+}
+
+// newTestWorkspaceCmd builds a bare command with --workspace and the root
+// --quiet flag registered, its stderr captured (never a terminal, so
+// ResolveWorkspaceID never mistakes the test process for an interactive one).
+func newTestWorkspaceCmd(t *testing.T) *cobra.Command {
+	t.Helper()
+	cmd := &cobra.Command{Use: "test"}
+	cmd.Flags().String(FlagWorkspace, "", "workspace")
+	cmd.PersistentFlags().Bool(FlagQuiet, false, "quiet")
+	cmd.SetErr(&bytes.Buffer{})
+	return cmd
+}
+
+// newTestWorkspaceCmdWithServer is newTestWorkspaceCmd wired to a stub
+// /organizations server, with its captured stderr returned separately.
+func newTestWorkspaceCmdWithServer(t *testing.T, apiBaseURL string) (*cobra.Command, *bytes.Buffer) {
+	t.Helper()
+	t.Setenv(EnvWorkspaceID, "")
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	require.NoError(t, auth.Save(auth.Auth{Token: "test-token"}))
+
+	cmd := newTestWorkspaceCmd(t)
+	errOut := &bytes.Buffer{}
+	cmd.SetErr(errOut)
+	resolved := config.Resolve(config.Config{}, config.Config{}, config.Config{APIBaseURL: apiBaseURL})
+	cmd.SetContext(config.WithResolved(t.Context(), resolved))
+	return cmd, errOut
 }

--- a/cli/stack/list_test.go
+++ b/cli/stack/list_test.go
@@ -164,6 +164,7 @@ func TestListCmd_RejectsPositionalArgs(t *testing.T) {
 func newTestListCmd(t *testing.T, apiBaseURL string) (*cobra.Command, *bytes.Buffer) {
 	t.Helper()
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("BITRISE_TOKEN", "") // an exported token would outrank the fixture in cmdutil.ResolveToken
 	require.NoError(t, auth.Save(auth.Auth{Token: "test-token"}))
 
 	cmd := NewListCommand()

--- a/cli/yml/get_test.go
+++ b/cli/yml/get_test.go
@@ -16,6 +16,7 @@ import (
 )
 
 func TestGetCmd_RequiresApp(t *testing.T) {
+	t.Setenv(cmdutil.EnvAppID, "")
 	t.Setenv(cmdutil.EnvAppIDLegacy, "")
 
 	cmd, _ := newTestGetCmd(t, "http://unused.test")
@@ -83,6 +84,7 @@ func TestGetCmd_JSONOutput(t *testing.T) {
 func newTestGetCmd(t *testing.T, apiBaseURL string) (*cobra.Command, *bytes.Buffer) {
 	t.Helper()
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("BITRISE_TOKEN", "") // an exported token would outrank the fixture in cmdutil.ResolveToken
 	require.NoError(t, auth.Save(auth.Auth{Token: "test-token"}))
 
 	cmd := NewGetCommand()

--- a/cli/yml/update_test.go
+++ b/cli/yml/update_test.go
@@ -18,6 +18,7 @@ import (
 )
 
 func TestUpdateCmd_RequiresApp(t *testing.T) {
+	t.Setenv(cmdutil.EnvAppID, "")
 	t.Setenv(cmdutil.EnvAppIDLegacy, "")
 
 	cmd, _ := newTestUpdateCmd(t, "http://unused.test", "")
@@ -53,6 +54,7 @@ func TestUpdateCmd_EmptyContent(t *testing.T) {
 func newTestUpdateCmd(t *testing.T, apiBaseURL, stdin string) (*cobra.Command, *bytes.Buffer) {
 	t.Helper()
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("BITRISE_TOKEN", "") // an exported token would outrank the fixture in cmdutil.ResolveToken
 	require.NoError(t, auth.Save(auth.Auth{Token: "test-token"}))
 
 	cmd := NewUpdateCommand()

--- a/cli/yml/validate_test.go
+++ b/cli/yml/validate_test.go
@@ -36,7 +36,9 @@ func TestValidateConfig_NoToken_UsesLocal(t *testing.T) {
 		_, _ = w.Write([]byte(`{"errors":[],"warnings":[]}`))
 	})
 	cmd := &cobra.Command{}
-	t.Setenv("XDG_CONFIG_HOME", t.TempDir()) // no auth.yaml written -> no token
+	// No auth.yaml written and no exported token, so no token resolves.
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("BITRISE_TOKEN", "")
 	resolved := config.Resolve(config.Config{}, config.Config{}, config.Config{APIBaseURL: srv.URL})
 	cmd.SetContext(config.WithResolved(t.Context(), resolved))
 
@@ -59,6 +61,7 @@ func TestValidateConfig_CorruptAuthFile_FallsBackWithWarning(t *testing.T) {
 		_, _ = w.Write([]byte(`{"errors":[],"warnings":[]}`))
 	})
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("BITRISE_TOKEN", "") // an exported token would outrank the fixture in cmdutil.ResolveToken
 	p, err := auth.Path()
 	require.NoError(t, err)
 	require.NoError(t, os.MkdirAll(filepath.Dir(p), 0o700))
@@ -234,6 +237,7 @@ func newValidateFakeServer(t *testing.T, handler http.HandlerFunc) *httptest.Ser
 func newTestValidateCommand(t *testing.T, handler http.HandlerFunc) (*cobra.Command, *bytes.Buffer) {
 	t.Helper()
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("BITRISE_TOKEN", "") // an exported token would outrank the fixture in cmdutil.ResolveToken
 	require.NoError(t, auth.Save(auth.Auth{Token: "test-token"}))
 
 	apiBaseURL := newValidateFakeServer(t, handler).URL
@@ -252,6 +256,7 @@ func newTestValidateCommand(t *testing.T, handler http.HandlerFunc) (*cobra.Comm
 func newTestValidateCmd(t *testing.T, handler http.HandlerFunc) *cobra.Command {
 	t.Helper()
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("BITRISE_TOKEN", "") // an exported token would outrank the fixture in cmdutil.ResolveToken
 	require.NoError(t, auth.Save(auth.Auth{Token: "test-token"}))
 
 	apiBaseURL := newValidateFakeServer(t, handler).URL

--- a/internal/app/create.go
+++ b/internal/app/create.go
@@ -12,6 +12,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/bitrise-io/bitrise/v2/internal/bitriseapi"
+	"github.com/bitrise-io/bitrise/v2/internal/workspace"
 )
 
 // DefaultStackID is the stack used by Create when opts.StackID is empty. Any
@@ -169,24 +170,18 @@ func (s *Service) Create(ctx context.Context, opts CreateOptions) (CreateResult,
 }
 
 // autoDetectOrg fetches the user's workspaces and returns the slug when
-// there's exactly one. 0 or 2+ workspaces produce a friendly error.
+// there's exactly one. 0 or 2+ workspaces produce a friendly error — the same
+// one every other command gives, via internal/workspace.
 func (s *Service) autoDetectOrg(ctx context.Context) (string, error) {
 	orgs, err := s.client.Organizations(ctx)
 	if err != nil {
 		return "", fmt.Errorf("list workspaces: %w", err)
 	}
-	switch len(orgs) {
-	case 0:
-		return "", errors.New("no workspaces found for this account — create one in the Bitrise dashboard, or pass --workspace")
-	case 1:
-		return orgs[0].Slug, nil
-	default:
-		names := make([]string, 0, len(orgs))
-		for _, o := range orgs {
-			names = append(names, fmt.Sprintf("  %s (%s)", o.Slug, o.Name))
-		}
-		return "", fmt.Errorf("multiple workspaces available — pass --workspace. Available:\n%s", strings.Join(names, "\n"))
+	org, err := workspace.Sole(orgs)
+	if err != nil {
+		return "", err
 	}
+	return org.Slug, nil
 }
 
 // resolveProvider validates an explicit --provider value, or returns

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -35,6 +35,7 @@ type Config struct {
 	LastPluginUpdateChecks map[string]time.Time `yaml:"last_plugin_update_checks,omitempty"`
 	APIBaseURL             string               `yaml:"api_base_url,omitempty"`
 	WebBaseURL             string               `yaml:"web_base_url,omitempty"`
+	RDEAPIBaseURL          string               `yaml:"rde_api_base_url,omitempty"`
 	AppID                  string               `yaml:"app_id,omitempty"`
 	DefaultWorkspaceID     string               `yaml:"default_workspace_id,omitempty"`
 	Output                 string               `yaml:"output,omitempty"`

--- a/internal/config/resolve.go
+++ b/internal/config/resolve.go
@@ -12,8 +12,8 @@ import (
 //  3. Global config file (~/.config/bitrise/cli/config.yml)
 //  4. Zero value
 //
-// APIBaseURL/WebBaseURL are the exception: they skip the per-directory layer
-// (see below) — everything else follows the order above.
+// APIBaseURL/WebBaseURL/RDEAPIBaseURL are the exception: they skip the
+// per-directory layer (see below) — everything else follows the order above.
 //
 // Resolved embeds Config (rather than being an identical, separately-typed
 // copy of its fields) so a new field only needs adding once — but it stays a
@@ -56,6 +56,10 @@ func Resolve(legacyCfg, dirCfg, globalCfg Config) Resolved {
 		// global > default — no dirCfg, see the doc comment above.
 		APIBaseURL: FirstNonEmptyString(legacyCfg.APIBaseURL, globalCfg.APIBaseURL, DefaultAPIBaseURL),
 		WebBaseURL: FirstNonEmptyString(legacyCfg.WebBaseURL, globalCfg.WebBaseURL, DefaultWebBaseURL),
+		// No default yet — the rde_api_base_url config key (and its default)
+		// land in a later PR; this merges the raw field so the test harness can
+		// route a value through Resolve today.
+		RDEAPIBaseURL: FirstNonEmptyString(legacyCfg.RDEAPIBaseURL, globalCfg.RDEAPIBaseURL),
 		// legacyCfg.AppID is likewise always empty, and there's no sensible
 		// default app — effectively dir > global > unset. Both of these DO
 		// honor dirCfg, unlike the two URLs above: they name which app and

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -1,0 +1,75 @@
+// Package workspace holds the rules for picking a workspace when the user
+// didn't name one. It is a leaf package so both the CLI layer
+// (cli/cmdutil.ResolveWorkspaceID) and a domain service (internal/app's app
+// creation) can share one definition — and one error message — without
+// internal/* depending on cli/*.
+package workspace
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/bitrise-io/bitrise/v2/internal/bitriseapi"
+	"github.com/bitrise-io/bitrise/v2/internal/config"
+)
+
+// EnvWorkspaceID supplies the workspace when --workspace isn't passed. Bitrise
+// sets it in every build. It lives here rather than beside the other env-var
+// constants in cli/cmdutil because Sole's guidance message names it, and
+// internal/* must not import cli/*; cli/cmdutil re-exports it.
+const EnvWorkspaceID = "BITRISE_WORKSPACE_ID"
+
+// Sole returns the user's workspace when they have exactly one. With zero or
+// 2+ workspaces it returns a friendly error, since no default can be picked
+// unambiguously. This is the single definition of the "exactly one workspace"
+// rule and its guidance message.
+func Sole(orgs []bitriseapi.Organization) (bitriseapi.Organization, error) {
+	switch len(orgs) {
+	case 0:
+		return bitriseapi.Organization{}, errors.New("no workspaces found for this account — create one in the Bitrise dashboard, or pass --workspace")
+	case 1:
+		return orgs[0], nil
+	default:
+		return bitriseapi.Organization{}, fmt.Errorf("multiple workspaces available — pass --workspace, set %s, or run 'bitrise config set %s <id>'. Available:\n%s",
+			EnvWorkspaceID, config.KeyDefaultWorkspaceID, List(orgs))
+	}
+}
+
+// Sort returns a copy of orgs sorted for human display: named workspaces
+// first, alphabetically by name (case-insensitive), then any the API returned
+// without a name, by slug. It's the single source of ordering for both the
+// multiple-workspaces error list and the interactive picker, so the two stay
+// in sync.
+func Sort(orgs []bitriseapi.Organization) []bitriseapi.Organization {
+	sorted := append([]bitriseapi.Organization(nil), orgs...)
+	sort.Slice(sorted, func(i, j int) bool {
+		ni, nj := sorted[i].Name, sorted[j].Name
+		if (ni == "") != (nj == "") {
+			return ni != "" // named workspaces first
+		}
+		if !strings.EqualFold(ni, nj) {
+			return strings.ToLower(ni) < strings.ToLower(nj)
+		}
+		return sorted[i].Slug < sorted[j].Slug
+	})
+	return sorted
+}
+
+// List renders workspaces one per indented line as "name (slug)", sorted by
+// name so a user can scan for the one they recognize and copy its slug.
+// Workspaces the API returned without a name fall back to the bare slug and
+// sort last.
+func List(orgs []bitriseapi.Organization) string {
+	sorted := Sort(orgs)
+	lines := make([]string, len(sorted))
+	for i, o := range sorted {
+		if o.Name != "" {
+			lines[i] = fmt.Sprintf("  %s (%s)", o.Name, o.Slug)
+		} else {
+			lines[i] = "  " + o.Slug
+		}
+	}
+	return strings.Join(lines, "\n")
+}

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -1,0 +1,64 @@
+package workspace
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/bitrise-io/bitrise/v2/internal/bitriseapi"
+)
+
+func TestSole(t *testing.T) {
+	t.Run("exactly one is returned", func(t *testing.T) {
+		got, err := Sole([]bitriseapi.Organization{{Slug: "only-ws", Name: "Only"}})
+		require.NoError(t, err)
+		assert.Equal(t, "only-ws", got.Slug)
+	})
+
+	t.Run("none is an error naming the way out", func(t *testing.T) {
+		_, err := Sole(nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no workspaces found")
+		assert.Contains(t, err.Error(), "--workspace")
+	})
+
+	t.Run("several lists them sorted, with both ways to pin one", func(t *testing.T) {
+		_, err := Sole([]bitriseapi.Organization{
+			{Slug: "b-ws", Name: "Bravo"},
+			{Slug: "a-ws", Name: "Alpha"},
+		})
+		require.Error(t, err)
+		msg := err.Error()
+		assert.Contains(t, msg, "multiple workspaces available")
+		assert.Contains(t, msg, EnvWorkspaceID)
+		assert.Contains(t, msg, "bitrise config set default_workspace_id")
+		assert.Less(t, strings.Index(msg, "Alpha"), strings.Index(msg, "Bravo"))
+	})
+}
+
+func TestSort_NamedFirstThenCaseInsensitiveByName(t *testing.T) {
+	orgs := []bitriseapi.Organization{
+		{Slug: "z-ws"},
+		{Slug: "c-ws", Name: "charlie"},
+		{Slug: "a-ws"},
+		{Slug: "b-ws", Name: "Bravo"},
+	}
+	got := Sort(orgs)
+
+	var slugs []string
+	for _, o := range got {
+		slugs = append(slugs, o.Slug)
+	}
+	assert.Equal(t, []string{"b-ws", "c-ws", "a-ws", "z-ws"}, slugs)
+	assert.Equal(t, "z-ws", orgs[0].Slug, "Sort must not reorder its argument")
+}
+
+func TestList_RendersNameSlugAndFallsBackToSlug(t *testing.T) {
+	got := List([]bitriseapi.Organization{
+		{Slug: "nameless"},
+		{Slug: "a-ws", Name: "Alpha"},
+	})
+	assert.Equal(t, "  Alpha (a-ws)\n  nameless", got)
+}


### PR DESCRIPTION
- Env support cleanup (accept new and legacy app slug)
- Workspace resolution (autoselect if only one is accessible, resolve name to slug, show interactive list when multiple available).
- Test harness for running RDE commands in isolation (`cmdtest`)

_This is PR 4 of 15, splitting the changes into reviewable chunks. PRs 1-4 are just infrastructure._