### PR TITLE
Apply env size limit overrides to envman's config file for step subprocesses

### DIFF
--- a/cli/env_var_limit_override_test.go
+++ b/cli/env_var_limit_override_test.go
@@ -116,3 +116,40 @@ func TestApplyEnvVarLimitOverrides(t *testing.T) {
 		})
 	}
 }
+
+// TestApplyEnvVarLimitOverridesReachesConfigFile proves the resolved limit is
+// written to envman's config file, so it reaches an envman binary that reads
+// only the file and ignores the process env var overrides.
+func TestApplyEnvVarLimitOverridesReachesConfigFile(t *testing.T) {
+	runner := WorkflowRunner{logger: log.NewLogger(log.GetGlobalLoggerOpts())}
+	key := envman.EnvListBytesLimitInKBEnvKey
+
+	origHome := os.Getenv("HOME")
+	t.Cleanup(func() { require.NoError(t, os.Setenv("HOME", origHome)) })
+	require.NoError(t, os.Setenv("HOME", t.TempDir()))
+	for _, k := range []string{key, envman.EnvBytesLimitInKBEnvKey} {
+		require.NoError(t, os.Unsetenv(k))
+		t.Cleanup(func() { require.NoError(t, os.Unsetenv(k)) })
+	}
+
+	overrides := runner.applyEnvVarLimitOverrides([]envmanModels.EnvironmentItemModel{{key: "1024"}})
+	require.NotNil(t, overrides.EnvListBytesLimitInKB)
+	require.Equal(t, 1024, *overrides.EnvListBytesLimitInKB)
+	require.Nil(t, overrides.EnvBytesLimitInKB)
+
+	restore, err := envman.SetConfigLimits(overrides)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, restore()) })
+
+	// Clear the process env override so GetConfigs can only read the file.
+	require.NoError(t, os.Unsetenv(key))
+
+	configs, err := envman.GetConfigs()
+	require.NoError(t, err)
+	require.Equal(t, 1024, configs.EnvListBytesLimitInKB)
+
+	require.NoError(t, restore())
+	configs, err = envman.GetConfigs()
+	require.NoError(t, err)
+	require.Equal(t, 256, configs.EnvListBytesLimitInKB, "restore should revert the file to the default")
+}

--- a/cli/run.go
+++ b/cli/run.go
@@ -265,7 +265,16 @@ func (r WorkflowRunner) runWorkflows() (models.BuildRunResultsModel, error) {
 	environments := append(r.config.Secrets, r.config.Config.App.Environments...)
 
 	// Envman setup
-	r.applyEnvVarLimitOverrides(environments)
+	limitOverrides := r.applyEnvVarLimitOverrides(environments)
+	if restore, err := envman.SetConfigLimits(limitOverrides); err != nil {
+		r.logger.Warnf("Failed to write envman env size limit config, steps may still hit the default limit: %s", err)
+	} else {
+		defer func() {
+			if err := restore(); err != nil {
+				r.logger.Warnf("Failed to restore envman env size limit config: %s", err)
+			}
+		}()
+	}
 
 	if err := os.Setenv(configs.EnvstorePathEnvKey, configs.OutputEnvstorePath); err != nil {
 		return models.BuildRunResultsModel{}, fmt.Errorf("failed to set %s env: %w", configs.EnvstorePathEnvKey, err)
@@ -381,22 +390,27 @@ func (r WorkflowRunner) runWorkflows() (models.BuildRunResultsModel, error) {
 // Precedence is process env < secret < app env; the highest-precedence valid
 // value wins. Invalid values are skipped as they are considered, so a malformed
 // higher-precedence value never discards a valid lower-precedence one.
-func (r WorkflowRunner) applyEnvVarLimitOverrides(environments []envmanModels.EnvironmentItemModel) {
+//
+// The resolved limits are returned so the caller can also write them to envman's
+// config file, which reaches an `envman` binary invoked by a step (to export
+// outputs) that cannot read the process env var overrides.
+func (r WorkflowRunner) applyEnvVarLimitOverrides(environments []envmanModels.EnvironmentItemModel) envman.ConfigLimitOverrides {
 	targets := map[string]struct{}{
 		envman.EnvBytesLimitInKBEnvKey:     {},
 		envman.EnvListBytesLimitInKBEnvKey: {},
 	}
-	resolved := map[string]string{}
+	resolved := map[string]int{}
 
 	consider := func(key, value string) {
 		if _, ok := targets[key]; !ok || value == "" {
 			return
 		}
-		if limit, err := strconv.Atoi(value); err != nil || limit < 0 {
+		limit, err := strconv.Atoi(value)
+		if err != nil || limit < 0 {
 			r.logger.Warnf("Ignoring invalid %s value %q: must be a non-negative integer", key, value)
 			return
 		}
-		resolved[key] = value
+		resolved[key] = limit
 	}
 
 	for key := range targets {
@@ -410,11 +424,20 @@ func (r WorkflowRunner) applyEnvVarLimitOverrides(environments []envmanModels.En
 		consider(key, value)
 	}
 
-	for key, value := range resolved {
-		if err := os.Setenv(key, value); err != nil {
+	overrides := envman.ConfigLimitOverrides{}
+	for key, limit := range resolved {
+		limit := limit
+		switch key {
+		case envman.EnvBytesLimitInKBEnvKey:
+			overrides.EnvBytesLimitInKB = &limit
+		case envman.EnvListBytesLimitInKBEnvKey:
+			overrides.EnvListBytesLimitInKB = &limit
+		}
+		if err := os.Setenv(key, strconv.Itoa(limit)); err != nil {
 			r.logger.Warnf("Failed to set %s: %s", key, err)
 		}
 	}
+	return overrides
 }
 
 func processArgs(cmd *cobra.Command, args []string) (*RunConfig, error) {

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	al.essio.dev/pkg/shellescape v1.6.0
 	github.com/Masterminds/semver/v3 v3.4.0
 	github.com/bitrise-io/colorstring v0.0.0-20180614154802-a8cd70115192
-	github.com/bitrise-io/envman/v2 v2.7.0
+	github.com/bitrise-io/envman/v2 v2.7.1-0.20260824140817-e80c577643e7
 	github.com/bitrise-io/go-steputils/v2 v2.0.0-alpha.44
 	github.com/bitrise-io/go-utils v1.0.15
 	github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.36

--- a/go.sum
+++ b/go.sum
@@ -18,8 +18,8 @@ github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPd
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/bitrise-io/colorstring v0.0.0-20180614154802-a8cd70115192 h1:vSHYT6kCL/iOT9BVuUPm0tVcbW57r5zldLWg0aB7qbQ=
 github.com/bitrise-io/colorstring v0.0.0-20180614154802-a8cd70115192/go.mod h1:CIHVcxZUvsG99XUJV6JlR7okNsMMGY81jMvPC20W+O0=
-github.com/bitrise-io/envman/v2 v2.7.0 h1:6C/a6jXAJ0RRPQ3sdxbdm417W86Y/74xUQ3ifE0C/D4=
-github.com/bitrise-io/envman/v2 v2.7.0/go.mod h1:FuWPjEk053wT3POPxj8IuyeVv7chbh20o3s2zcIXLvw=
+github.com/bitrise-io/envman/v2 v2.7.1-0.20260824140817-e80c577643e7 h1:/kZTSipEj4yv2/JCGfGKY/I8OsYnZseaOmV+KVaedNM=
+github.com/bitrise-io/envman/v2 v2.7.1-0.20260824140817-e80c577643e7/go.mod h1:FuWPjEk053wT3POPxj8IuyeVv7chbh20o3s2zcIXLvw=
 github.com/bitrise-io/go-steputils/v2 v2.0.0-alpha.44 h1:EXclFI+XfxxcsRZlly3WsYJwph/6BwJdhF7JZ9bde2M=
 github.com/bitrise-io/go-steputils/v2 v2.0.0-alpha.44/go.mod h1:i72XgHIZPEZtPPQLWy2cP86MaImo37nlQRhX1HCKi7Q=
 github.com/bitrise-io/go-utils v1.0.15 h1:KRQjNiPrkxBRM6G5fQy05v0p0r8wycWfKVb+Ko+Vtg0=

--- a/vendor/github.com/bitrise-io/envman/v2/envman/configs.go
+++ b/vendor/github.com/bitrise-io/envman/v2/envman/configs.go
@@ -30,6 +30,22 @@ type ConfigsModel struct {
 	EnvListBytesLimitInKB int `json:"env_list_bytes_limit_in_kb,omitempty"`
 }
 
+// ConfigLimitOverrides selects which env size limits to write to the config
+// file. A nil field is left unchanged; a non-nil field is written as-is,
+// including 0, which disables that check.
+type ConfigLimitOverrides struct {
+	EnvBytesLimitInKB     *int
+	EnvListBytesLimitInKB *int
+}
+
+// configsFile mirrors the on-disk config, using pointers so an unset field is
+// omitted and a 0 is written explicitly (unlike ConfigsModel, whose omitempty
+// int fields would drop a 0 and fall back to the default).
+type configsFile struct {
+	EnvBytesLimitInKB     *int `json:"env_bytes_limit_in_kb,omitempty"`
+	EnvListBytesLimitInKB *int `json:"env_list_bytes_limit_in_kb,omitempty"`
+}
+
 func getEnvmanConfigsDirPath() string {
 	return path.Join(pathutil.UserHomeDir(), ".envman")
 }
@@ -74,12 +90,7 @@ func GetConfigs() (ConfigsModel, error) {
 			return ConfigsModel{}, err
 		}
 
-		type ConfigsFileMode struct {
-			EnvBytesLimitInKB     *int `json:"env_bytes_limit_in_kb,omitempty"`
-			EnvListBytesLimitInKB *int `json:"env_list_bytes_limit_in_kb,omitempty"`
-		}
-
-		var userConfigs ConfigsFileMode
+		var userConfigs configsFile
 		if err := json.Unmarshal(bytes, &userConfigs); err != nil {
 			return ConfigsModel{}, err
 		}
@@ -100,6 +111,67 @@ func GetConfigs() (ConfigsModel, error) {
 	}
 
 	return configs, nil
+}
+
+// SetConfigLimits merges the given limits into the config file, creating it if
+// needed, and returns a restore function that reverts the file to its previous
+// state (its original content, or its absence).
+//
+// Unlike the process env var overrides, this reaches an `envman` binary that
+// predates env var support (e.g. one invoked by a step to export outputs),
+// since reading configs.json is the older, always-present mechanism.
+func SetConfigLimits(overrides ConfigLimitOverrides) (restore func() error, err error) {
+	if overrides.EnvBytesLimitInKB == nil && overrides.EnvListBytesLimitInKB == nil {
+		return func() error { return nil }, nil
+	}
+
+	configPth := getEnvmanConfigsFilePath()
+
+	existed, err := pathutil.IsPathExists(configPth)
+	if err != nil {
+		return nil, err
+	}
+
+	var merged configsFile
+	var originalBytes []byte
+	if existed {
+		originalBytes, err = fileutil.ReadBytesFromFile(configPth)
+		if err != nil {
+			return nil, err
+		}
+		if err := json.Unmarshal(originalBytes, &merged); err != nil {
+			return nil, err
+		}
+	}
+
+	if overrides.EnvBytesLimitInKB != nil {
+		merged.EnvBytesLimitInKB = overrides.EnvBytesLimitInKB
+	}
+	if overrides.EnvListBytesLimitInKB != nil {
+		merged.EnvListBytesLimitInKB = overrides.EnvListBytesLimitInKB
+	}
+
+	mergedBytes, err := json.Marshal(merged)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := ensureEnvmanConfigDirExists(); err != nil {
+		return nil, err
+	}
+	if err := fileutil.WriteBytesToFile(configPth, mergedBytes); err != nil {
+		return nil, err
+	}
+
+	return func() error {
+		if !existed {
+			if err := os.Remove(configPth); err != nil && !os.IsNotExist(err) {
+				return err
+			}
+			return nil
+		}
+		return fileutil.WriteBytesToFile(configPth, originalBytes)
+	}, nil
 }
 
 // envLimitOverride reads a limit from a process env var, treating a value of 0

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -41,7 +41,7 @@ github.com/ProtonMail/go-crypto/openpgp/x448
 # github.com/bitrise-io/colorstring v0.0.0-20180614154802-a8cd70115192
 ## explicit
 github.com/bitrise-io/colorstring
-# github.com/bitrise-io/envman/v2 v2.7.0
+# github.com/bitrise-io/envman/v2 v2.7.1-0.20260824140817-e80c577643e7
 ## explicit; go 1.25
 github.com/bitrise-io/envman/v2/cli
 github.com/bitrise-io/envman/v2/env


### PR DESCRIPTION
> Draft: depends on envman PR https://github.com/bitrise-io/envman/pull/256. The dep is temporarily pinned to that branch build; it will be re-pinned to a tagged envman release before merge.

## Why

The previous change let a build raise envman's env size limits, but only for envman used as a **Go module** (the CLI's own in-process usage), via process env var overrides. Steps export their outputs through the `envman` **binary** on the build machine (e.g. xcode-test), and that binary cannot be updated yet, so it ignores the env var overrides. As a result a build that raised its limit could still fail when a step exports a large output.

The binary does read `~/.envman/configs.json` (the older, always-present mechanism). This change writes the resolved limits there too.

## What

- `applyEnvVarLimitOverrides` now returns the resolved limits as an `envman.ConfigLimitOverrides`.
- `runWorkflows` passes them to `envman.SetConfigLimits`, which merges them into `~/.envman/configs.json` before the run and returns a `restore` that reverts the file afterward (deferred), so a reused agent or dev machine does not leak a raised limit.
- The process env var `os.Setenv` is kept, so the CLI's in-process envman and any updated binary still prefer the env var.
- Writing is non-fatal: on failure the CLI's in-process limit still applies via the env var.

## Testing

- `TestApplyEnvVarLimitOverridesReachesConfigFile`: the resolved limit, written via `SetConfigLimits`, is read back by `GetConfigs` with the process env cleared, proving it reaches a file-only reader; restore reverts to the default.
- Existing `TestApplyEnvVarLimitOverrides` (env var + precedence) and env-ordering tests still pass.
- Manual e2e: with the limit set in `app.envs`, a script step reads `~/.envman/configs.json` and sees `{"env_list_bytes_limit_in_kb":777}` during the run; the file is removed after the run.

## Scope

Temporary in spirit: once the build-machine `envman` reaches the version with env var support, the config-file write becomes redundant with the env var, though it is a harmless fallback.