### PR TITLE
Better toolsetup GitHub token error message

### DIFF
--- a/toolprovider/mise/install.go
+++ b/toolprovider/mise/install.go
@@ -3,6 +3,7 @@ package mise
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/bitrise-io/bitrise/v2/log"
 	"github.com/bitrise-io/bitrise/v2/toolprovider/mise/execenv"
@@ -105,11 +106,29 @@ func (m *MiseToolProvider) installToolVersion(toolName provider.ToolID, concrete
 		log.Printf("[TOOLPROVIDER] mise install output for %s:\n%s", versionString, output)
 	}
 	if err != nil {
+		cause := fmt.Sprintf("mise install %s: %s", versionString, err)
+		rawOutput := string(output)
+		var recommendation string
+
+		if strings.Contains(strings.ToLower(err.Error()), "rate limit exceeded") {
+			// The mise output (which is what makes this recognizable as a rate limit error) is embedded in err,
+			// not in output: RunMiseWithTimeoutAndEnvs() only returns command output separately on success.
+			cause = fmt.Sprintf("GitHub API rate limit exceeded while installing %s", toolName)
+			rawOutput = err.Error()
+			recommendation = fmt.Sprintf(
+				"GitHub's public API allows only a small number of requests per hour without a token. "+
+					"Add one of %s as a secret to raise the limit and avoid this error. "+
+					"See the raw output below for details.",
+				strings.Join(KnownGitHubTokenEnvVars, ", "),
+			)
+		}
+
 		return provider.ToolInstallError{
 			ToolName:         toolName,
 			RequestedVersion: concreteVersion,
-			Cause:            fmt.Sprintf("mise install %s: %s", versionString, err),
-			RawOutput:        string(output),
+			Cause:            cause,
+			RawOutput:        rawOutput,
+			Recommendation:   recommendation,
 		}
 	}
 	return nil

--- a/toolprovider/mise/install_test.go
+++ b/toolprovider/mise/install_test.go
@@ -215,6 +215,75 @@ func TestCanBeInstalledWithNix(t *testing.T) {
 	}
 }
 
+func TestInstallToolVersion(t *testing.T) {
+	tests := []struct {
+		name            string
+		toolName        provider.ToolID
+		concreteVersion string
+		mockErr         error
+		wantCause       string
+		wantRecommend   string
+		wantRawOutput   string
+	}{
+		{
+			name:            "success",
+			toolName:        "node",
+			concreteVersion: "18.20.0",
+			mockErr:         nil,
+		},
+		{
+			name:            "generic failure has no GitHub recommendation",
+			toolName:        "node",
+			concreteVersion: "18.20.0",
+			mockErr:         errors.New("exit status 1\nsome unrelated mise error"),
+			wantCause:       "mise install node@18.20.0: exit status 1\nsome unrelated mise error",
+			wantRecommend:   "",
+		},
+		{
+			name:            "GitHub rate limit error",
+			toolName:        "tuist",
+			concreteVersion: "4.70.0",
+			mockErr:         errors.New("exit status 1\nmise ERROR Failed to install aqua:tuist/tuist@4.70.0: HTTP status client error (403 rate limit exceeded) for url (https://api.github.com/repos/tuist/tuist/releases/tags/4.70.0)"),
+			wantCause:       "GitHub API rate limit exceeded while installing tuist",
+			wantRecommend:   "GITHUB_TOKEN, GH_TOKEN, GITHUB_API_TOKEN, MISE_GITHUB_TOKEN, MISE_GITHUB_ENTERPRISE_TOKEN",
+			wantRawOutput:   "exit status 1\nmise ERROR Failed to install aqua:tuist/tuist@4.70.0: HTTP status client error (403 rate limit exceeded) for url (https://api.github.com/repos/tuist/tuist/releases/tags/4.70.0)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fake := newFakeExecEnv()
+			versionString := miseVersionString(tt.toolName, tt.concreteVersion)
+			cmdKey := fmt.Sprintf("install --yes %s", versionString)
+			if tt.mockErr != nil {
+				fake.setError(cmdKey, tt.mockErr)
+			} else {
+				fake.setResponse(cmdKey, "")
+			}
+
+			p := &MiseToolProvider{ExecEnv: fake}
+			err := p.installToolVersion(tt.toolName, tt.concreteVersion)
+
+			if tt.mockErr == nil {
+				require.NoError(t, err)
+				return
+			}
+
+			var toolErr provider.ToolInstallError
+			require.ErrorAs(t, err, &toolErr)
+			require.Equal(t, tt.wantCause, toolErr.Cause)
+			if tt.wantRecommend == "" {
+				require.Empty(t, toolErr.Recommendation)
+			} else {
+				require.Contains(t, toolErr.Recommendation, tt.wantRecommend)
+			}
+			if tt.wantRawOutput != "" {
+				require.Equal(t, tt.wantRawOutput, toolErr.RawOutput)
+			}
+		})
+	}
+}
+
 func TestInstallRequest(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/toolprovider/mise/mise.go
+++ b/toolprovider/mise/mise.go
@@ -3,6 +3,7 @@ package mise
 import (
 	"errors"
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
 
@@ -40,6 +41,14 @@ var miseStableChecksums = map[string]string{
 	"linux-arm64": "6e0362723bddec3b25923a6c7c447c3f10eba4bf6e3db6973e175fa0a60ab974",
 	"macos-x64":   "a6f6f320b547dec3eff321e301fa05268dfc73a620d35ec3292603fbab1c4c29",
 	"macos-arm64": "9d6e2bfea3e00ffb566ad1a369914cb029c32a28eb4b699e8655cf3c3d4ef87e",
+}
+
+var KnownGitHubTokenEnvVars = []string{
+	"GITHUB_TOKEN",
+	"GH_TOKEN",
+	"GITHUB_API_TOKEN",
+	"MISE_GITHUB_TOKEN",
+	"MISE_GITHUB_ENTERPRISE_TOKEN",
 }
 
 type MiseToolProvider struct {
@@ -83,9 +92,7 @@ func NewToolProvider(installDir string, dataDir string, useFastInstall, silent b
 		// so verification fails for any such version (e.g. 3.11.4).
 		"MISE_PYTHON_GITHUB_ATTESTATIONS": "false",
 	}
-	for k, v := range extraEnvs {
-		miseEnvs[k] = v
-	}
+	maps.Copy(miseEnvs, extraEnvs)
 
 	return &MiseToolProvider{
 		ExecEnv:        execenv.NewMiseExecEnv(installDir, miseEnvs),

--- a/toolprovider/run.go
+++ b/toolprovider/run.go
@@ -24,19 +24,10 @@ type toolSetupResult struct {
 	startTime time.Time
 }
 
-// knownGitHubTokenEnvVars lists the env var names that users possibly set as a valid GitHub API token.
-var knownGitHubTokenEnvVars = []string{
-	"GITHUB_TOKEN",
-	"GH_TOKEN",
-	"GITHUB_API_TOKEN",
-	"MISE_GITHUB_TOKEN",
-	"MISE_GITHUB_ENTERPRISE_TOKEN",
-}
-
 // findGitHubTokenEnv returns the first known GitHub token env var found in envs,
-// checked in priority order defined by knownGitHubTokenEnvVars.
+// checked in priority order defined by mise.KnownGitHubTokenEnvVars.
 func findGitHubTokenEnv(envs map[string]string) (name, value string, found bool) {
-	for _, n := range knownGitHubTokenEnvVars {
+	for _, n := range mise.KnownGitHubTokenEnvVars {
 		if v, ok := envs[n]; ok {
 			return n, v, true
 		}


### PR DESCRIPTION
### Checklist
- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-io/bitrise/blob/master/.github/CONTRIBUTING.md)
- [ ] `README.md` is updated with the changes (if needed)
- [ ] I've run `go mod tidy` both in root and in `integrationtests/` if any dependencies have changed.

### Version
Requires a *PATCH* [version update](https://semver.org/)

### Context

Tool installation failures caused by GitHub API rate limiting are very common, and our error message is not that helpful in terms of next steps:

```
Installing missing tools
• tuist 4.70.0...
⨯ install tuist 4.70.0
  • Cause: mise install tuist@4.70.0: exit status 1
mise tuist@4.70.0    [1/3] install
mise WARN  GitHub rate limit exceeded. Resets at 2026-07-15 11:00:25 +00:00
mise WARN  [tuist/tuist] failed to fetch version tags, URL may be incorrect: HTTP status client error (403 rate limit exceeded) for url (https://api.github.com/repos/tuist/tuist/releases)
mise WARN  GitHub rate limit exceeded. Resets at 2026-07-15 11:00:25 +00:00
mise WARN  GitHub rate limit exceeded. Resets at 2026-07-15 11:00:25 +00:00
mise ERROR Failed to install aqua:tuist/tuist@4.70.0: HTTP status client error (403 rate limit exceeded) for url (https://api.github.com/repos/tuist/tuist/releases/tags/4.70.0): HTTP status client error (403 rate limit exceeded) for url (https://api.github.com/repos/tuist/tuist/releases/tags/v4.70.0)
mise ERROR Run with --verbose or MISE_VERBOSE=1 for more information


failed to run workflow: set up tools: see error details above
```

### Changes

Detect GitHub API rate limit errors in mise's install output and surface a clear `Cause` plus an actionable `Recommendation` pointing at the known token env vars, with the raw mise output preserved for debugging.

### Investigation details

Initially considered differentiating the recommendation message based on whether a GitHub token was already configured, but dropped it: the only reliable signal for "token configured" is the `extraEnvs` passed into the mise provider, which is intentionally `nil` for CLI-invoked runs (the token is already in the shell env in that case), so the check was unreliable and wasn't worth the extra complexity. A single recommendation message plus the raw mise output covers both cases.
