### PR TITLE
RDE 11 - rde session lifecycle commands

### DIFF
--- a/cli/rde/session/cmd.go
+++ b/cli/rde/session/cmd.go
@@ -24,6 +24,12 @@ the command errors and lists the candidate IDs to pick from.`,
 		newViewCmd(),
 		newNotificationsCmd(),
 		newDiffCmd(),
+		newCreateCmd(),
+		newUpdateCmd(),
+		newRestoreCmd(),
+		newTerminateCmd(),
+		newDeleteCmd(),
+		newDeleteTerminatedCmd(),
 	)
 	return c
 }

--- a/cli/rde/session/create.go
+++ b/cli/rde/session/create.go
@@ -1,0 +1,252 @@
+package session
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/bitrise-io/bitrise/v2/cli/cmdutil"
+	internalrde "github.com/bitrise-io/bitrise/v2/internal/rde"
+	"github.com/bitrise-io/bitrise/v2/internal/style"
+	"github.com/bitrise-io/bitrise/v2/output"
+)
+
+func newCreateCmd() *cobra.Command {
+	var (
+		description          string
+		templateID           string
+		stack                string
+		machineType          string
+		inputs               []string
+		secretInputs         []string
+		savedInputs          []string
+		labels               []string
+		featureFlags         []string
+		cluster              string
+		aiPrompt             string
+		autoTerminateMinutes int
+		setAutoTerminate     bool
+		mapSavedInputs       bool
+		wait                 bool
+		waitTimeout          time.Duration
+		format               string
+	)
+
+	c := &cobra.Command{
+		Use:   "create NAME",
+		Short: "Create a new RDE session",
+		Long: `Create a new RDE session, either from a template or from a bare
+stack + machine type (a template-less session, with no warmup/startup scripts
+or other template configuration).
+
+NAME is a human-readable label for the session; you can use it in place of the
+session ID in later commands (view, terminate, …) as long as it stays unique.
+
+Pass --template to create the session from a template (by ID or name). To
+create a session without a template, omit --template and pass both --stack and
+--machine-type instead. --stack / --machine-type may also be given alongside
+--template to override the template's defaults for this session.
+
+Provide session input values via --input (one --input per key), --secret-input
+(value stored as secret-at-rest), or --saved-input (reference an existing saved
+input by ID). Use --map-saved-inputs to auto-fill any session input key that
+matches a saved input the user already has.
+
+For secret values, prefer storing them once with 'rde saved-input create
+--value-stdin --secret' and referencing them by ID via --saved-input. A value
+passed inline with --secret-input ends up in your shell history and in the
+process arguments (readable by other users via 'ps'); marking it secret only
+governs how the backend stores the value, not how it reaches the CLI.
+
+Attach arbitrary key=value metadata with --label (repeatable); labels come
+back on 'session view' and in 'session list --format json', and sessions
+can be filtered by them with 'rde session list --label-selector key=value'.
+
+Example values:
+  --input key=value
+  --saved-input session-key=SAVED_INPUT_ID   # secret stored ahead of time
+  --secret-input api-key=VALUE               # inline; avoid for real secrets`,
+		Example: `  bitrise rde session create dev --template TEMPLATE_ID
+  bitrise rde session create dev --template TEMPLATE_ID --input repo=my-app
+  # Template-less: pick a stack and machine type directly.
+  bitrise rde session create dev --stack osx-xcode-16.0.x-edge --machine-type g2.mac.m2pro.6c-14g
+  # Keep secrets off the command line: store once, then reference by ID.
+  echo -n "ghp_xxx" | bitrise rde saved-input create --key gh-token --value-stdin --secret
+  bitrise rde session create dev --template TEMPLATE_ID --saved-input gh-token=SAVED_INPUT_ID
+  bitrise rde session create dev --template TEMPLATE_ID --map-saved-inputs`,
+		Args: cmdutil.RequireArgs("NAME"),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cmdutil.LogCommandParameters(cmd)
+
+			if err := output.ConfigureOutputFormat(format); err != nil {
+				return fmt.Errorf("failed to configure output format: %w", err)
+			}
+
+			name := args[0]
+			if name == "" {
+				return fmt.Errorf("NAME must not be empty")
+			}
+			// A session needs either a template or, for a template-less
+			// session, an explicit stack + machine type. (stack/machine type
+			// may also accompany a template to override its defaults.)
+			if templateID == "" && (stack == "" || machineType == "") {
+				return fmt.Errorf("provide --template, or both --stack and --machine-type to create a session without a template")
+			}
+			workspaceID, err := cmdutil.ResolveWorkspaceID(cmd)
+			if err != nil {
+				return err
+			}
+			sessionInputs, err := parseSessionInputs(inputs, secretInputs, savedInputs)
+			if err != nil {
+				return err
+			}
+			labelMap, err := parseLabelFlags("--label", labels)
+			if err != nil {
+				return err
+			}
+			req := internalrde.CreateSessionRequest{
+				Name:                    name,
+				Description:             description,
+				TemplateID:              templateID,
+				StackID:                 stack,
+				MachineType:             machineType,
+				SessionInputs:           sessionInputs,
+				EnabledFeatureFlagNames: featureFlags,
+				Cluster:                 cluster,
+				AIPrompt:                aiPrompt,
+				MapSavedToSessionInputs: mapSavedInputs,
+				Labels:                  labelMap,
+			}
+			if setAutoTerminate {
+				m := autoTerminateMinutes
+				req.AutoTerminateMinutes = &m
+			}
+			client, err := cmdutil.NewRDEClient(cmd)
+			if err != nil {
+				return err
+			}
+			svc := internalrde.NewService(client)
+
+			// --template accepts either a UUID or a template name; resolve
+			// names to IDs before issuing CreateSession so the user gets
+			// a clean error if the name is wrong or ambiguous. Skipped for
+			// template-less sessions, where no template is involved.
+			if req.TemplateID != "" {
+				resolvedID, err := svc.ResolveTemplateID(cmd.Context(), workspaceID, req.TemplateID)
+				if err != nil {
+					return err
+				}
+				req.TemplateID = resolvedID
+			}
+
+			res, err := svc.CreateSession(cmd.Context(), workspaceID, req)
+			if err != nil {
+				return err
+			}
+
+			if wait {
+				waitCtx, cancel := context.WithTimeout(cmd.Context(), waitTimeout)
+				defer cancel()
+				if !cmdutil.IsQuiet(cmd) && output.Format == output.FormatRaw {
+					_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Waiting for session %s to become ready (timeout %s)…\n", res.Session.ID, waitTimeout)
+				}
+				ready, waitErr := svc.WaitForReady(waitCtx, workspaceID, res.Session.ID, 0, nil)
+				if waitErr != nil {
+					// The session exists and is billing even though the wait
+					// failed; render it so its ID isn't lost — the only other
+					// place it appears is the "Waiting for session …"
+					// breadcrumb, suppressed under --quiet and any non-raw
+					// format.
+					if renderErr := output.Render(cmd.OutOrStdout(), output.Format, res, renderCreateResult); renderErr != nil {
+						return renderErr
+					}
+					return fmt.Errorf("waiting for session: %w", waitErr)
+				}
+				res.Session = ready
+				if ready.Status != "running" {
+					if renderErr := output.Render(cmd.OutOrStdout(), output.Format, res, renderCreateResult); renderErr != nil {
+						return renderErr
+					}
+					cmdutil.SilenceRootErrors(cmd)
+					return fmt.Errorf("session ended provisioning with status %q (expected running)", ready.Status)
+				}
+			}
+
+			return output.Render(cmd.OutOrStdout(), output.Format, res, renderCreateResult)
+		},
+	}
+
+	c.Flags().StringVar(&description, "description", "", "session description")
+	c.Flags().StringVar(&templateID, "template", "", "template ID or name to create the session from (omit to create a template-less session with --stack and --machine-type)")
+	c.Flags().StringVar(&stack, "stack", "", "stack ID for a template-less session, or to override the template's stack (see 'rde stack list')")
+	c.Flags().StringVar(&machineType, "machine-type", "", "machine type name for a template-less session, or to override the template's machine type (see 'rde machine-type list --stack STACK_ID')")
+	c.Flags().StringArrayVar(&inputs, "input", nil, "session input as key=value (repeatable)")
+	c.Flags().StringArrayVar(&secretInputs, "secret-input", nil, "session input as key=value, stored as a secret at rest (repeatable; the value is visible in shell history and process args — prefer --saved-input)")
+	c.Flags().StringArrayVar(&savedInputs, "saved-input", nil, "session input as key=savedInputID — uses a stored saved-input value (repeatable)")
+	c.Flags().StringArrayVarP(&labels, "label", "l", nil, "label to attach to the session as key=value (repeatable; at most 32; keys use letters, digits, and . _ / -, values additionally : and +; the bitrise.io/ key prefix is reserved)")
+	c.Flags().StringArrayVar(&featureFlags, "feature-flag", nil, "name of a feature flag to enable on the session (repeatable)")
+	c.Flags().StringVar(&cluster, "cluster", "", "target cluster name (use 'rde machine-type list --stack STACK_ID' to find candidates when the stack + machine type combo is ambiguous)")
+	c.Flags().StringVar(&aiPrompt, "ai-prompt", "", "initial AI prompt passed to Claude Code on session start")
+	c.Flags().IntVar(&autoTerminateMinutes, "auto-terminate-minutes", 0, "minutes until auto-termination; 0 disables; omitted uses backend default (~5 days)")
+	c.Flags().BoolVar(&mapSavedInputs, "map-saved-inputs", false, "auto-fill template session inputs from the user's saved inputs (matched by key)")
+	c.Flags().BoolVar(&wait, "wait", false, "wait until the session leaves provisioning (running, failed, …) before returning; exits 1 if the final status isn't running")
+	c.Flags().DurationVar(&waitTimeout, "wait-timeout", 10*time.Minute, "max time to wait when --wait is set (uses Go duration syntax: 30s, 5m, 1h)")
+	c.Flags().StringVarP(&format, cmdutil.FormatKey, "f", "", "Output format. Accepted: raw (default), json, yml")
+
+	c.PreRun = func(cmd *cobra.Command, _ []string) {
+		// Track whether --auto-terminate-minutes was explicitly set so we
+		// can distinguish "not provided" from "set to 0".
+		setAutoTerminate = cmd.Flags().Changed("auto-terminate-minutes")
+	}
+	return c
+}
+
+// parseSessionInputs converts the user-friendly --input/--secret-input/--saved-input
+// flags into SessionInputValue entries. Returns an error on the first malformed
+// entry; later iterations don't run.
+func parseSessionInputs(plain, secret, saved []string) ([]internalrde.SessionInputValue, error) {
+	out := make([]internalrde.SessionInputValue, 0, len(plain)+len(secret)+len(saved))
+	for _, kv := range plain {
+		k, v, ok := strings.Cut(kv, "=")
+		if !ok || k == "" {
+			return nil, fmt.Errorf("--input %q: expected key=value", kv)
+		}
+		out = append(out, internalrde.SessionInputValue{Key: k, Value: v})
+	}
+	for _, kv := range secret {
+		k, v, ok := strings.Cut(kv, "=")
+		if !ok || k == "" {
+			return nil, fmt.Errorf("--secret-input %q: expected key=value", kv)
+		}
+		out = append(out, internalrde.SessionInputValue{Key: k, Value: v, IsSecret: true})
+	}
+	for _, kv := range saved {
+		k, v, ok := strings.Cut(kv, "=")
+		if !ok || k == "" || v == "" {
+			return nil, fmt.Errorf("--saved-input %q: expected key=savedInputID", kv)
+		}
+		out = append(out, internalrde.SessionInputValue{Key: k, SavedInputID: v})
+	}
+	return out, nil
+}
+
+func renderCreateResult(w io.Writer, res internalrde.CreateSessionResult) error {
+	s := style.New(w)
+	ew := cmdutil.NewErrWriter(w)
+	ew.F("%s %s\n", s.BuildStatus("success").Render("✓"), "Session created")
+	if err := renderSessionDetail(w, res.Session); err != nil {
+		return err
+	}
+	if len(res.AutoMappedInputs) > 0 {
+		ew.Ln()
+		ew.Ln(s.Dim.Render("Auto-mapped session inputs from saved inputs:"))
+		for _, m := range res.AutoMappedInputs {
+			ew.F("  %s → %s\n", m.SessionInputKey, s.Slug.Render(m.SavedInputID))
+		}
+	}
+	return ew.Err
+}

--- a/cli/rde/session/create_test.go
+++ b/cli/rde/session/create_test.go
@@ -1,0 +1,50 @@
+package session
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/bitrise-io/bitrise/v2/cli/cmdtest"
+)
+
+func TestCreateCmd_RequiresTemplateAndName(t *testing.T) {
+	// NAME given positionally but no --template fails fast.
+	_, _, err := cmdtest.Run(t, newCreateCmd(), cmdtest.Opts{
+		RDEAPIBaseURL:      "http://unused",
+		DefaultWorkspaceID: "ws-1",
+		Args:               []string{"dev"},
+	})
+	if err == nil || !strings.Contains(err.Error(), "--template") {
+		t.Errorf("error = %v, want --template required", err)
+	}
+}
+
+func TestParseSessionInputs(t *testing.T) {
+	got, err := parseSessionInputs(
+		[]string{"repo=my-app"},
+		[]string{"token=ghp_x"},
+		[]string{"key=saved-id"},
+	)
+	if err != nil {
+		t.Fatalf("parseSessionInputs: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("got %d inputs, want 3", len(got))
+	}
+	if got[0].Key != "repo" || got[0].Value != "my-app" || got[0].IsSecret {
+		t.Errorf("plain input wrong: %+v", got[0])
+	}
+	if !got[1].IsSecret || got[1].Value != "ghp_x" {
+		t.Errorf("secret input wrong: %+v", got[1])
+	}
+	if got[2].SavedInputID != "saved-id" || got[2].Value != "" {
+		t.Errorf("saved input wrong: %+v", got[2])
+	}
+
+	if _, err := parseSessionInputs([]string{"bad"}, nil, nil); err == nil {
+		t.Error("expected error for malformed --input")
+	}
+	if _, err := parseSessionInputs(nil, nil, []string{"key="}); err == nil {
+		t.Error("expected error for --saved-input with empty ID")
+	}
+}

--- a/cli/rde/session/delete.go
+++ b/cli/rde/session/delete.go
@@ -1,0 +1,43 @@
+package session
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/bitrise-io/bitrise/v2/cli/cmdutil"
+	internalrde "github.com/bitrise-io/bitrise/v2/internal/rde"
+)
+
+func newDeleteCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "delete SESSION_ID",
+		Short: "Permanently delete a session",
+		Args:  cmdutil.RequireArgs("SESSION_ID"),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cmdutil.LogCommandParameters(cmd)
+
+			workspaceID, err := cmdutil.ResolveWorkspaceID(cmd)
+			if err != nil {
+				return err
+			}
+			client, err := cmdutil.NewRDEClient(cmd)
+			if err != nil {
+				return err
+			}
+			svc := internalrde.NewService(client)
+			sessionID, err := svc.ResolveSessionID(cmd.Context(), workspaceID, args[0])
+			if err != nil {
+				return err
+			}
+			if err := svc.DeleteSession(cmd.Context(), workspaceID, sessionID); err != nil {
+				return err
+			}
+			if !cmdutil.IsQuiet(cmd) {
+				_, err := fmt.Fprintf(cmd.ErrOrStderr(), "Deleted session %s\n", sessionID)
+				return err
+			}
+			return nil
+		},
+	}
+}

--- a/cli/rde/session/delete_terminated.go
+++ b/cli/rde/session/delete_terminated.go
@@ -1,0 +1,72 @@
+package session
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/bitrise-io/bitrise/v2/cli/cmdutil"
+	internalrde "github.com/bitrise-io/bitrise/v2/internal/rde"
+	"github.com/bitrise-io/bitrise/v2/output"
+)
+
+// deleteTerminatedResult is the --format json/yml shape: {"deleted_count": N}.
+type deleteTerminatedResult struct {
+	DeletedCount int `json:"deleted_count" yaml:"deleted_count"`
+}
+
+func newDeleteTerminatedCmd() *cobra.Command {
+	var (
+		assumeYes bool
+		format    string
+	)
+	c := &cobra.Command{
+		Use:   "delete-terminated",
+		Short: "Permanently delete every terminated session in the workspace",
+		Long: `Permanently delete every terminated session in the workspace.
+This cannot be undone. Pass --yes to skip the confirmation prompt.`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cmdutil.LogCommandParameters(cmd)
+
+			if err := output.ConfigureOutputFormat(format); err != nil {
+				return fmt.Errorf("failed to configure output format: %w", err)
+			}
+
+			workspaceID, err := cmdutil.ResolveWorkspaceID(cmd)
+			if err != nil {
+				return err
+			}
+			if !assumeYes {
+				if _, err := fmt.Fprint(cmd.ErrOrStderr(),
+					"This will permanently delete every terminated session in the workspace.\nProceed? [y/N]: "); err != nil {
+					return err
+				}
+				answer, err := cmdutil.ReadSecretInput(cmd.InOrStdin(), cmd.ErrOrStderr(), "", true)
+				if err != nil {
+					return err
+				}
+				if answer != "y" && answer != "Y" && answer != "yes" {
+					return fmt.Errorf("aborted")
+				}
+			}
+			client, err := cmdutil.NewRDEClient(cmd)
+			if err != nil {
+				return err
+			}
+			count, err := internalrde.NewService(client).DeleteTerminatedSessions(cmd.Context(), workspaceID)
+			if err != nil {
+				return err
+			}
+			return output.Render(cmd.OutOrStdout(), output.Format, deleteTerminatedResult{DeletedCount: count}, renderDeleteTerminated)
+		},
+	}
+	c.Flags().BoolVar(&assumeYes, "yes", false, "skip the confirmation prompt")
+	c.Flags().StringVarP(&format, cmdutil.FormatKey, "f", "", "Output format. Accepted: raw (default), json, yml")
+	return c
+}
+
+func renderDeleteTerminated(w io.Writer, r deleteTerminatedResult) error {
+	_, err := fmt.Fprintf(w, "Deleted %d terminated session(s)\n", r.DeletedCount)
+	return err
+}

--- a/cli/rde/session/helpers.go
+++ b/cli/rde/session/helpers.go
@@ -11,6 +11,26 @@ import (
 	"github.com/bitrise-io/bitrise/v2/internal/style"
 )
 
+// parseLabelFlags converts repeatable key=value flag values into a label
+// map; flagName names the flag in error messages. Only the shape is checked
+// here — key and value charset/length, entry count, and the reserved
+// "bitrise.io/" key prefix are enforced by the backend, whose field
+// violations surface through the API error.
+func parseLabelFlags(flagName string, kvs []string) (map[string]string, error) {
+	if len(kvs) == 0 {
+		return nil, nil
+	}
+	out := make(map[string]string, len(kvs))
+	for _, kv := range kvs {
+		k, v, ok := strings.Cut(kv, "=")
+		if !ok || k == "" || v == "" {
+			return nil, fmt.Errorf("%s %q: expected key=value", flagName, kv)
+		}
+		out[k] = v
+	}
+	return out, nil
+}
+
 // validateLabelSelectors rejects selector shapes that can never match (bare
 // keys, empty keys or values — label values are non-empty by contract). The
 // strings otherwise pass to the backend verbatim, which enforces the full

--- a/cli/rde/session/mutation_test.go
+++ b/cli/rde/session/mutation_test.go
@@ -1,0 +1,799 @@
+package session
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/bitrise-io/bitrise/v2/cli/cmdtest"
+	"github.com/bitrise-io/bitrise/v2/output"
+)
+
+func TestCreateCmd_HappyPath(t *testing.T) {
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/v1/workspaces/ws-1/sessions" {
+			t.Errorf("unexpected: %s %s", r.Method, r.URL.Path)
+		}
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		_, _ = io.WriteString(w, `{"session":{"id":"s-new","name":"dev","status":"SESSION_STATUS_PENDING"}}`)
+	}))
+	defer srv.Close()
+
+	stdout, _, err := cmdtest.Run(t, newCreateCmd(), cmdtest.Opts{
+		RDEAPIBaseURL:      srv.URL,
+		DefaultWorkspaceID: "ws-1",
+		Args:               []string{"dev", "--template", uuidTemplate, "--input", "repo=my-app"},
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if gotBody["templateId"] != uuidTemplate || gotBody["name"] != "dev" {
+		t.Errorf("unexpected create body: %v", gotBody)
+	}
+	if !strings.Contains(stdout, "Session created") || !strings.Contains(stdout, "s-new") {
+		t.Errorf("stdout missing create confirmation:\n%s", stdout)
+	}
+}
+
+func TestCreateCmd_JSONOutput(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `{"session":{"id":"s-new","name":"dev","status":"SESSION_STATUS_PENDING"},
+			"autoMappedInputs":[{"sessionInputKey":"gh","savedInputId":"sv-1"}]}`)
+	}))
+	defer srv.Close()
+
+	stdout, _, err := cmdtest.Run(t, newCreateCmd(), cmdtest.Opts{
+		RDEAPIBaseURL:      srv.URL,
+		DefaultWorkspaceID: "ws-1",
+		Args:               []string{"dev", "--template", uuidTemplate, "--map-saved-inputs"},
+		Format:             output.FormatJSON,
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	var got struct {
+		Session struct {
+			ID     string `json:"id"`
+			Status string `json:"status"`
+		} `json:"session"`
+		AutoMapped []struct {
+			SessionInputKey string `json:"session_input_key"`
+		} `json:"auto_mapped_inputs"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &got); err != nil {
+		t.Fatalf("unmarshal JSON output: %v\n%s", err, stdout)
+	}
+	if got.Session.ID != "s-new" || got.Session.Status != "pending" {
+		t.Errorf("unexpected session JSON: %+v", got.Session)
+	}
+	if len(got.AutoMapped) != 1 || got.AutoMapped[0].SessionInputKey != "gh" {
+		t.Errorf("unexpected auto-mapped JSON: %+v", got.AutoMapped)
+	}
+}
+
+func TestCreateCmd_RequiresName(t *testing.T) {
+	_, _, err := cmdtest.Run(t, newCreateCmd(), cmdtest.Opts{
+		RDEAPIBaseURL:      "http://unused",
+		DefaultWorkspaceID: "ws-1",
+		Args:               []string{"--template", uuidTemplate},
+	})
+	if err == nil || !strings.Contains(err.Error(), "NAME") {
+		t.Errorf("error = %v, want NAME positional required", err)
+	}
+}
+
+func TestCreateCmd_AutoTerminateZeroIsSent(t *testing.T) {
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		_, _ = io.WriteString(w, `{"session":{"id":"s-new","name":"dev"}}`)
+	}))
+	defer srv.Close()
+
+	// Explicitly setting --auto-terminate-minutes 0 must send 0 (disable),
+	// distinct from omitting the flag (backend default).
+	_, _, err := cmdtest.Run(t, newCreateCmd(), cmdtest.Opts{
+		RDEAPIBaseURL:      srv.URL,
+		DefaultWorkspaceID: "ws-1",
+		Args:               []string{"dev", "--template", uuidTemplate, "--auto-terminate-minutes", "0"},
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	v, ok := gotBody["autoTerminateMinutes"]
+	if !ok {
+		t.Fatalf("autoTerminateMinutes should be present when flag is set, body=%v", gotBody)
+	}
+	if v != float64(0) {
+		t.Errorf("autoTerminateMinutes = %v, want 0", v)
+	}
+}
+
+func TestCreateCmd_AutoTerminateOmittedWhenFlagUnset(t *testing.T) {
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		_, _ = io.WriteString(w, `{"session":{"id":"s-new","name":"dev"}}`)
+	}))
+	defer srv.Close()
+
+	_, _, err := cmdtest.Run(t, newCreateCmd(), cmdtest.Opts{
+		RDEAPIBaseURL:      srv.URL,
+		DefaultWorkspaceID: "ws-1",
+		Args:               []string{"dev", "--template", uuidTemplate},
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if _, ok := gotBody["autoTerminateMinutes"]; ok {
+		t.Errorf("autoTerminateMinutes should be omitted when flag unset, body=%v", gotBody)
+	}
+}
+
+func TestCreateCmd_TemplateLess(t *testing.T) {
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/v1/workspaces/ws-1/sessions" {
+			t.Errorf("unexpected: %s %s", r.Method, r.URL.Path)
+		}
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		_, _ = io.WriteString(w, `{"session":{"id":"s-new","name":"dev","status":"SESSION_STATUS_PENDING"}}`)
+	}))
+	defer srv.Close()
+
+	stdout, _, err := cmdtest.Run(t, newCreateCmd(), cmdtest.Opts{
+		RDEAPIBaseURL:      srv.URL,
+		DefaultWorkspaceID: "ws-1",
+		Args:               []string{"dev", "--stack", "osx-xcode-16.0.x-edge", "--machine-type", "g2.mac.m2pro.6c-14g"},
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if _, ok := gotBody["templateId"]; ok {
+		t.Errorf("templateId should be omitted for a template-less session, body=%v", gotBody)
+	}
+	if gotBody["stackId"] != "osx-xcode-16.0.x-edge" || gotBody["machineType"] != "g2.mac.m2pro.6c-14g" {
+		t.Errorf("unexpected create body: %v", gotBody)
+	}
+	if !strings.Contains(stdout, "Session created") || !strings.Contains(stdout, "s-new") {
+		t.Errorf("stdout missing create confirmation:\n%s", stdout)
+	}
+}
+
+func TestCreateCmd_StackOverridesWithTemplate(t *testing.T) {
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		_, _ = io.WriteString(w, `{"session":{"id":"s-new","name":"dev"}}`)
+	}))
+	defer srv.Close()
+
+	// --stack / --machine-type may accompany a template to override its
+	// defaults; the template ID is still sent.
+	_, _, err := cmdtest.Run(t, newCreateCmd(), cmdtest.Opts{
+		RDEAPIBaseURL:      srv.URL,
+		DefaultWorkspaceID: "ws-1",
+		Args:               []string{"dev", "--template", uuidTemplate, "--stack", "osx-xcode-16.0.x-edge", "--machine-type", "g2.mac.m2pro.6c-14g"},
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if gotBody["templateId"] != uuidTemplate {
+		t.Errorf("templateId = %v, want %s", gotBody["templateId"], uuidTemplate)
+	}
+	if gotBody["stackId"] != "osx-xcode-16.0.x-edge" || gotBody["machineType"] != "g2.mac.m2pro.6c-14g" {
+		t.Errorf("unexpected create body: %v", gotBody)
+	}
+}
+
+func TestCreateCmd_RequiresTemplateOrMachineSpec(t *testing.T) {
+	cases := map[string][]string{
+		"no template, no machine spec": {"dev"},
+		"stack without machine type":   {"dev", "--stack", "osx-xcode-16.0.x-edge"},
+		"machine type without stack":   {"dev", "--machine-type", "g2.mac.m2pro.6c-14g"},
+	}
+	for name, args := range cases {
+		t.Run(name, func(t *testing.T) {
+			_, _, err := cmdtest.Run(t, newCreateCmd(), cmdtest.Opts{
+				RDEAPIBaseURL:      "http://unused",
+				DefaultWorkspaceID: "ws-1",
+				Args:               args,
+			})
+			if err == nil || !strings.Contains(err.Error(), "--machine-type") {
+				t.Errorf("error = %v, want template-or-stack/machine-type requirement", err)
+			}
+		})
+	}
+}
+
+func TestCreateCmd_LabelsSent(t *testing.T) {
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		_, _ = io.WriteString(w, `{"session":{"id":"s-new","name":"dev"}}`)
+	}))
+	defer srv.Close()
+
+	_, _, err := cmdtest.Run(t, newCreateCmd(), cmdtest.Opts{
+		RDEAPIBaseURL:      srv.URL,
+		DefaultWorkspaceID: "ws-1",
+		Args:               []string{"dev", "--template", uuidTemplate, "-l", "branch=main", "--label", "team=mobile"},
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	labels, ok := gotBody["labels"].(map[string]any)
+	if !ok || labels["branch"] != "main" || labels["team"] != "mobile" {
+		t.Errorf("labels = %v, want branch=main team=mobile", gotBody["labels"])
+	}
+}
+
+func TestCreateCmd_LabelsOmittedWhenUnset(t *testing.T) {
+	// No --label — the body must not carry a labels field at all.
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		_, _ = io.WriteString(w, `{"session":{"id":"s-new","name":"dev"}}`)
+	}))
+	defer srv.Close()
+
+	_, _, err := cmdtest.Run(t, newCreateCmd(), cmdtest.Opts{
+		RDEAPIBaseURL:      srv.URL,
+		DefaultWorkspaceID: "ws-1",
+		Args:               []string{"dev", "--template", uuidTemplate},
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if _, ok := gotBody["labels"]; ok {
+		t.Errorf("labels should be omitted, body=%v", gotBody)
+	}
+}
+
+func TestCreateCmd_MalformedLabelErrors(t *testing.T) {
+	_, _, err := cmdtest.Run(t, newCreateCmd(), cmdtest.Opts{
+		RDEAPIBaseURL:      "http://unused",
+		DefaultWorkspaceID: "ws-1",
+		Args:               []string{"dev", "--template", uuidTemplate, "--label", "no-equals"},
+	})
+	if err == nil || !strings.Contains(err.Error(), "--label") {
+		t.Errorf("error = %v, want --label parse error", err)
+	}
+}
+
+func TestCreateCmd_WaitBlocksUntilRunning(t *testing.T) {
+	var getCount int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/workspaces/ws-1/sessions":
+			_, _ = io.WriteString(w, `{"session":{"id":"s-new","name":"dev","status":"SESSION_STATUS_PENDING"}}`)
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/workspaces/ws-1/sessions/s-new":
+			getCount++
+			// Report the session as running so WaitForReady settles on the
+			// first poll and no poll interval elapses.
+			_, _ = io.WriteString(w, `{"session":{"id":"s-new","name":"dev","status":"SESSION_STATUS_RUNNING"}}`)
+		default:
+			t.Errorf("unexpected: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	stdout, stderr, err := cmdtest.Run(t, newCreateCmd(), cmdtest.Opts{
+		RDEAPIBaseURL:      srv.URL,
+		DefaultWorkspaceID: "ws-1",
+		Args:               []string{"dev", "--template", uuidTemplate, "--wait"},
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if getCount < 1 {
+		t.Errorf("expected --wait to poll GetSession after create, got %d GETs", getCount)
+	}
+	if !strings.Contains(stdout, "running") || !strings.Contains(stdout, "s-new") {
+		t.Errorf("stdout should show the final running status:\n%s", stdout)
+	}
+	if !strings.Contains(stderr, "Waiting for session") {
+		t.Errorf("stderr should announce the wait:\n%s", stderr)
+	}
+}
+
+func TestCreateCmd_WaitNonRunningExitsNonZero(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/workspaces/ws-1/sessions":
+			_, _ = io.WriteString(w, `{"session":{"id":"s-new","name":"dev","status":"SESSION_STATUS_PENDING"}}`)
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/workspaces/ws-1/sessions/s-new":
+			// Provisioning failed — --wait must surface it as a non-zero exit.
+			_, _ = io.WriteString(w, `{"session":{"id":"s-new","name":"dev","status":"SESSION_STATUS_FAILED"}}`)
+		default:
+			t.Errorf("unexpected: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	stdout, _, err := cmdtest.Run(t, newCreateCmd(), cmdtest.Opts{
+		RDEAPIBaseURL:      srv.URL,
+		DefaultWorkspaceID: "ws-1",
+		Args:               []string{"dev", "--template", uuidTemplate, "--wait"},
+	})
+	if err == nil || !strings.Contains(err.Error(), "expected running") {
+		t.Errorf("error = %v, want a non-running final-status error", err)
+	}
+	if !strings.Contains(stdout, "s-new") {
+		t.Errorf("stdout should still carry the created session:\n%s", stdout)
+	}
+}
+
+func TestCreateCmd_WaitErrorStillRendersSession(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/workspaces/ws-1/sessions":
+			_, _ = io.WriteString(w, `{"session":{"id":"s-new","name":"dev","status":"SESSION_STATUS_PENDING"}}`)
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/workspaces/ws-1/sessions/s-new":
+			// A --wait-timeout expiry is the real-world trigger; a failing
+			// poll reaches the same path without depending on timing.
+			w.WriteHeader(http.StatusInternalServerError)
+		default:
+			t.Errorf("unexpected: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	stdout, _, err := cmdtest.Run(t, newCreateCmd(), cmdtest.Opts{
+		RDEAPIBaseURL:      srv.URL,
+		DefaultWorkspaceID: "ws-1",
+		Args:               []string{"dev", "--template", uuidTemplate, "--wait"},
+		Format:             output.FormatJSON,
+	})
+	if err == nil || !strings.Contains(err.Error(), "waiting for session") {
+		t.Errorf("error = %v, want a wait error", err)
+	}
+	// The session was created and is billing: its ID must survive the failed
+	// wait, including in a machine-readable format where the stderr
+	// breadcrumb carrying it is suppressed.
+	if !strings.Contains(stdout, "s-new") {
+		t.Errorf("stdout should carry the created session despite the wait error:\n%s", stdout)
+	}
+}
+
+func TestUpdateCmd_RequiresAField(t *testing.T) {
+	_, _, err := cmdtest.Run(t, newUpdateCmd(), cmdtest.Opts{
+		RDEAPIBaseURL:      "http://unused",
+		DefaultWorkspaceID: "ws-1",
+		Args:               []string{"s-1"},
+	})
+	if err == nil || !strings.Contains(err.Error(), "--name") {
+		t.Errorf("error = %v, want at-least-one-field error", err)
+	}
+}
+
+func TestUpdateCmd_OnlySetFieldsSent(t *testing.T) {
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPatch || r.URL.Path != "/v1/workspaces/ws-1/sessions/"+uuidSession {
+			t.Errorf("unexpected: %s %s", r.Method, r.URL.Path)
+		}
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		_, _ = io.WriteString(w, `{"session":{"id":"s-1","name":"renamed"}}`)
+	}))
+	defer srv.Close()
+
+	_, _, err := cmdtest.Run(t, newUpdateCmd(), cmdtest.Opts{
+		RDEAPIBaseURL:      srv.URL,
+		DefaultWorkspaceID: "ws-1",
+		Args:               []string{uuidSession, "--name", "renamed"},
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if gotBody["name"] != "renamed" {
+		t.Errorf("name = %v, want renamed", gotBody["name"])
+	}
+	// --description / --auto-terminate-minutes weren't set, so they drop out.
+	if _, ok := gotBody["description"]; ok {
+		t.Errorf("description should be omitted, body=%v", gotBody)
+	}
+	if _, ok := gotBody["autoTerminateMinutes"]; ok {
+		t.Errorf("autoTerminateMinutes should be omitted, body=%v", gotBody)
+	}
+}
+
+func TestUpdateCmd_LabelsSentAndRendered(t *testing.T) {
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPatch {
+			t.Errorf("method = %s, want PATCH", r.Method)
+		}
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		_, _ = io.WriteString(w, `{"session":{"id":"`+uuidSession+`","name":"dev","status":"SESSION_STATUS_RUNNING","labels":{"branch":"main","team":"mobile"}}}`)
+	}))
+	defer srv.Close()
+
+	stdout, _, err := cmdtest.Run(t, newUpdateCmd(), cmdtest.Opts{
+		RDEAPIBaseURL:      srv.URL,
+		DefaultWorkspaceID: "ws-1",
+		Args:               []string{uuidSession, "--label", "branch=main", "--unset-label", "wip"},
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	labels, ok := gotBody["labels"].(map[string]any)
+	if !ok || labels["branch"] != "main" {
+		t.Errorf("labels = %v, want branch=main", gotBody["labels"])
+	}
+	removed, ok := gotBody["removeLabels"].([]any)
+	if !ok || len(removed) != 1 || removed[0] != "wip" {
+		t.Errorf("removeLabels = %v, want [wip]", gotBody["removeLabels"])
+	}
+	// The human detail view renders the returned labels.
+	for _, want := range []string{"Labels", "branch", "main", "team", "mobile"} {
+		if !strings.Contains(stdout, want) {
+			t.Errorf("stdout missing %q:\n%s", want, stdout)
+		}
+	}
+}
+
+func TestUpdateCmd_LabelSetAndUnsetConflict(t *testing.T) {
+	_, _, err := cmdtest.Run(t, newUpdateCmd(), cmdtest.Opts{
+		RDEAPIBaseURL:      "http://unused",
+		DefaultWorkspaceID: "ws-1",
+		Args:               []string{uuidSession, "--label", "wip=yes", "--unset-label", "wip"},
+	})
+	if err == nil || !strings.Contains(err.Error(), "both set") {
+		t.Errorf("error = %v, want set/unset conflict error", err)
+	}
+}
+
+func TestTerminateCmd_HappyPath(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/v1/workspaces/ws-1/sessions/"+uuidSession+"/terminate" {
+			t.Errorf("unexpected: %s %s", r.Method, r.URL.Path)
+		}
+		_, _ = io.WriteString(w, `{"session":{"id":"s-1","name":"dev","status":"SESSION_STATUS_TERMINATING"}}`)
+	}))
+	defer srv.Close()
+
+	stdout, _, err := cmdtest.Run(t, newTerminateCmd(), cmdtest.Opts{
+		RDEAPIBaseURL:      srv.URL,
+		DefaultWorkspaceID: "ws-1",
+		Args:               []string{uuidSession},
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !strings.Contains(stdout, "terminating") {
+		t.Errorf("stdout missing status:\n%s", stdout)
+	}
+}
+
+func TestRestoreCmd_HappyPath(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/workspaces/ws-1/sessions/"+uuidSession:
+			// Pre-flight disk-status check before the restore call.
+			_, _ = io.WriteString(w, `{"session":{"id":"s-1","name":"dev","status":"SESSION_STATUS_TERMINATED","persistentDiskStatus":"PERSISTENT_DISK_STATUS_AVAILABLE"}}`)
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/workspaces/ws-1/sessions/"+uuidSession+"/restore":
+			_, _ = io.WriteString(w, `{"session":{"id":"s-1","name":"dev","status":"SESSION_STATUS_STARTING"}}`)
+		default:
+			t.Errorf("unexpected: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	stdout, _, err := cmdtest.Run(t, newRestoreCmd(), cmdtest.Opts{
+		RDEAPIBaseURL:      srv.URL,
+		DefaultWorkspaceID: "ws-1",
+		Args:               []string{uuidSession},
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !strings.Contains(stdout, "starting") {
+		t.Errorf("stdout missing status:\n%s", stdout)
+	}
+}
+
+func TestRestoreCmd_DiskUnavailableFailsFast(t *testing.T) {
+	var restoreCalled bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/workspaces/ws-1/sessions/"+uuidSession:
+			_, _ = io.WriteString(w, `{"session":{"id":"s-1","name":"dev","status":"SESSION_STATUS_TERMINATED","persistentDiskStatus":"PERSISTENT_DISK_STATUS_UNAVAILABLE"}}`)
+		case r.URL.Path == "/v1/workspaces/ws-1/sessions/"+uuidSession+"/restore":
+			restoreCalled = true
+		default:
+			t.Errorf("unexpected: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	_, _, err := cmdtest.Run(t, newRestoreCmd(), cmdtest.Opts{
+		RDEAPIBaseURL:      srv.URL,
+		DefaultWorkspaceID: "ws-1",
+		Args:               []string{uuidSession},
+	})
+	if err == nil {
+		t.Fatal("expected restore to fail when the persistent disk is unavailable")
+	}
+	if !strings.Contains(err.Error(), "no longer available") {
+		t.Errorf("error missing reason: %v", err)
+	}
+	if restoreCalled {
+		t.Error("restore endpoint should not be called when the disk is unavailable")
+	}
+}
+
+func TestRestoreCmd_DiskExpiringSoonWarnsButProceeds(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/workspaces/ws-1/sessions/"+uuidSession:
+			_, _ = io.WriteString(w, `{"session":{"id":"s-1","name":"dev","status":"SESSION_STATUS_TERMINATED","persistentDiskStatus":"PERSISTENT_DISK_STATUS_UNAVAILABLE_SOON"}}`)
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/workspaces/ws-1/sessions/"+uuidSession+"/restore":
+			_, _ = io.WriteString(w, `{"session":{"id":"s-1","name":"dev","status":"SESSION_STATUS_STARTING"}}`)
+		default:
+			t.Errorf("unexpected: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	stdout, stderr, err := cmdtest.Run(t, newRestoreCmd(), cmdtest.Opts{
+		RDEAPIBaseURL:      srv.URL,
+		DefaultWorkspaceID: "ws-1",
+		Args:               []string{uuidSession},
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !strings.Contains(stderr, "unavailable soon") {
+		t.Errorf("stderr missing expiry warning:\n%s", stderr)
+	}
+	if !strings.Contains(stdout, "starting") {
+		t.Errorf("stdout missing status:\n%s", stdout)
+	}
+}
+
+func TestRestoreCmd_WaitBlocksUntilRunning(t *testing.T) {
+	// Keep the id consistent across pre-flight GET, restore POST, and the
+	// wait poll (WaitForReady polls the id from the restore response body).
+	sess := func(status string) string {
+		return `{"session":{"id":"` + uuidSession + `","name":"dev","status":"` + status + `"}}`
+	}
+	var getCount int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/workspaces/ws-1/sessions/"+uuidSession:
+			getCount++
+			if getCount == 1 {
+				// Pre-flight disk-status check before the restore call.
+				_, _ = io.WriteString(w, `{"session":{"id":"`+uuidSession+`","name":"dev","status":"SESSION_STATUS_TERMINATED","persistentDiskStatus":"PERSISTENT_DISK_STATUS_AVAILABLE"}}`)
+				return
+			}
+			// WaitForReady poll: report the session as running so it settles
+			// immediately (no poll interval elapses).
+			_, _ = io.WriteString(w, sess("SESSION_STATUS_RUNNING"))
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/workspaces/ws-1/sessions/"+uuidSession+"/restore":
+			_, _ = io.WriteString(w, sess("SESSION_STATUS_STARTING"))
+		default:
+			t.Errorf("unexpected: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	stdout, stderr, err := cmdtest.Run(t, newRestoreCmd(), cmdtest.Opts{
+		RDEAPIBaseURL:      srv.URL,
+		DefaultWorkspaceID: "ws-1",
+		Args:               []string{uuidSession, "--wait"},
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if getCount < 2 {
+		t.Errorf("expected --wait to poll GetSession after restore, got %d GETs", getCount)
+	}
+	if !strings.Contains(stdout, "running") {
+		t.Errorf("stdout should show the final running status:\n%s", stdout)
+	}
+	if !strings.Contains(stderr, "Waiting for session") {
+		t.Errorf("stderr should announce the wait:\n%s", stderr)
+	}
+}
+
+func TestRestoreCmd_WaitNonRunningExitsNonZero(t *testing.T) {
+	sess := func(status string) string {
+		return `{"session":{"id":"` + uuidSession + `","name":"dev","status":"` + status + `"}}`
+	}
+	var getCount int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/workspaces/ws-1/sessions/"+uuidSession:
+			getCount++
+			if getCount == 1 {
+				_, _ = io.WriteString(w, `{"session":{"id":"`+uuidSession+`","name":"dev","status":"SESSION_STATUS_TERMINATED","persistentDiskStatus":"PERSISTENT_DISK_STATUS_AVAILABLE"}}`)
+				return
+			}
+			// Provisioning failed — --wait must surface it as a non-zero exit.
+			_, _ = io.WriteString(w, sess("SESSION_STATUS_FAILED"))
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/workspaces/ws-1/sessions/"+uuidSession+"/restore":
+			_, _ = io.WriteString(w, sess("SESSION_STATUS_STARTING"))
+		default:
+			t.Errorf("unexpected: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	_, _, err := cmdtest.Run(t, newRestoreCmd(), cmdtest.Opts{
+		RDEAPIBaseURL:      srv.URL,
+		DefaultWorkspaceID: "ws-1",
+		Args:               []string{uuidSession, "--wait"},
+	})
+	if err == nil || !strings.Contains(err.Error(), "expected running") {
+		t.Errorf("error = %v, want a non-running final-status error", err)
+	}
+}
+
+func TestDeleteCmd_HappyPath(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete || r.URL.Path != "/v1/workspaces/ws-1/sessions/"+uuidSession {
+			t.Errorf("unexpected: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	stdout, stderr, err := cmdtest.Run(t, newDeleteCmd(), cmdtest.Opts{
+		RDEAPIBaseURL:      srv.URL,
+		DefaultWorkspaceID: "ws-1",
+		Args:               []string{uuidSession},
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !strings.Contains(stderr, "Deleted session "+uuidSession) {
+		t.Errorf("stderr missing confirmation: %q", stderr)
+	}
+	if stdout != "" {
+		t.Errorf("stdout should be empty for delete, got: %q", stdout)
+	}
+}
+
+// TestDeleteCmd_ResolvesName: a non-UUID arg is treated as a session name,
+// looked up via ListSessions, and the resolved ID is what actually gets
+// deleted.
+func TestDeleteCmd_ResolvesName(t *testing.T) {
+	var deletedPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/workspaces/ws-1/sessions":
+			_, _ = io.WriteString(w, `{"sessions":[{"id":"s-9","name":"my-box"},{"id":"s-7","name":"other"}]}`)
+		case r.Method == http.MethodDelete:
+			deletedPath = r.URL.Path
+		default:
+			t.Errorf("unexpected: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	_, stderr, err := cmdtest.Run(t, newDeleteCmd(), cmdtest.Opts{
+		RDEAPIBaseURL:      srv.URL,
+		DefaultWorkspaceID: "ws-1",
+		Args:               []string{"my-box"},
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if deletedPath != "/v1/workspaces/ws-1/sessions/s-9" {
+		t.Errorf("deleted path = %q, want the resolved id s-9", deletedPath)
+	}
+	if !strings.Contains(stderr, "Deleted session s-9") {
+		t.Errorf("stderr should confirm deletion of the resolved id: %q", stderr)
+	}
+}
+
+// TestDeleteCmd_AmbiguousNameError pins the non-uniqueness guard: when a name
+// matches more than one session, delete refuses rather than guessing.
+func TestDeleteCmd_AmbiguousNameError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && r.URL.Path == "/v1/workspaces/ws-1/sessions" {
+			_, _ = io.WriteString(w, `{"sessions":[{"id":"s-1","name":"dup"},{"id":"s-2","name":"dup"}]}`)
+			return
+		}
+		t.Errorf("nothing should be deleted for an ambiguous name: %s %s", r.Method, r.URL.Path)
+	}))
+	defer srv.Close()
+
+	_, _, err := cmdtest.Run(t, newDeleteCmd(), cmdtest.Opts{
+		RDEAPIBaseURL:      srv.URL,
+		DefaultWorkspaceID: "ws-1",
+		Args:               []string{"dup"},
+	})
+	if err == nil || !strings.Contains(err.Error(), "ambiguous") {
+		t.Errorf("error = %v, want ambiguous-name error", err)
+	}
+}
+
+func TestDeleteTerminatedCmd_YesSkipsPrompt(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/v1/workspaces/ws-1/sessions:delete-terminated" {
+			t.Errorf("unexpected: %s %s", r.Method, r.URL.Path)
+		}
+		_, _ = io.WriteString(w, `{"deletedCount":3}`)
+	}))
+	defer srv.Close()
+
+	stdout, _, err := cmdtest.Run(t, newDeleteTerminatedCmd(), cmdtest.Opts{
+		RDEAPIBaseURL:      srv.URL,
+		DefaultWorkspaceID: "ws-1",
+		Args:               []string{"--yes"},
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !strings.Contains(stdout, "Deleted 3 terminated session(s)") {
+		t.Errorf("unexpected stdout: %q", stdout)
+	}
+}
+
+func TestDeleteTerminatedCmd_JSONOutput(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `{"deletedCount":3}`)
+	}))
+	defer srv.Close()
+
+	stdout, _, err := cmdtest.Run(t, newDeleteTerminatedCmd(), cmdtest.Opts{
+		RDEAPIBaseURL:      srv.URL,
+		DefaultWorkspaceID: "ws-1",
+		Args:               []string{"--yes"},
+		Format:             output.FormatJSON,
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	var got struct {
+		DeletedCount int `json:"deleted_count"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &got); err != nil {
+		t.Fatalf("unmarshal JSON output: %v\n%s", err, stdout)
+	}
+	if got.DeletedCount != 3 {
+		t.Errorf("deleted_count = %d, want 3", got.DeletedCount)
+	}
+}
+
+func TestDeleteTerminatedCmd_AbortsOnNo(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		t.Error("server should not be hit when the user declines confirmation")
+	}))
+	defer srv.Close()
+
+	// No --yes; feed "n" to the confirmation prompt.
+	_, _, err := cmdtest.Run(t, newDeleteTerminatedCmd(), cmdtest.Opts{
+		RDEAPIBaseURL:      srv.URL,
+		DefaultWorkspaceID: "ws-1",
+		Stdin:              "n\n",
+	})
+	if err == nil || !strings.Contains(err.Error(), "aborted") {
+		t.Errorf("error = %v, want aborted", err)
+	}
+}
+
+func TestDeleteTerminatedCmd_ProceedsOnYes(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `{"deletedCount":1}`)
+	}))
+	defer srv.Close()
+
+	stdout, _, err := cmdtest.Run(t, newDeleteTerminatedCmd(), cmdtest.Opts{
+		RDEAPIBaseURL:      srv.URL,
+		DefaultWorkspaceID: "ws-1",
+		Stdin:              "y\n",
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !strings.Contains(stdout, "Deleted 1 terminated session(s)") {
+		t.Errorf("unexpected stdout: %q", stdout)
+	}
+}

--- a/cli/rde/session/restore.go
+++ b/cli/rde/session/restore.go
@@ -1,0 +1,103 @@
+package session
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/bitrise-io/bitrise/v2/cli/cmdutil"
+	internalrde "github.com/bitrise-io/bitrise/v2/internal/rde"
+	"github.com/bitrise-io/bitrise/v2/output"
+)
+
+func newRestoreCmd() *cobra.Command {
+	var (
+		wait        bool
+		waitTimeout time.Duration
+		format      string
+	)
+	c := &cobra.Command{
+		Use:   "restore SESSION_ID",
+		Short: "Restore a terminated session (re-provisions its VM from the persistent disk)",
+		Long: `Restore a terminated session (re-provisions its VM from the persistent disk).
+
+Restore is asynchronous: by default the command returns while the session is
+still "starting". Pass --wait to block until the session finishes provisioning
+(mirrors 'session create --wait'); the command exits non-zero if the session
+ends in any state other than "running". This lets an unattended caller restore
+and then immediately use the session without hand-rolling a poll loop.`,
+		Args: cmdutil.RequireArgs("SESSION_ID"),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cmdutil.LogCommandParameters(cmd)
+
+			if err := output.ConfigureOutputFormat(format); err != nil {
+				return fmt.Errorf("failed to configure output format: %w", err)
+			}
+
+			workspaceID, err := cmdutil.ResolveWorkspaceID(cmd)
+			if err != nil {
+				return err
+			}
+			client, err := cmdutil.NewRDEClient(cmd)
+			if err != nil {
+				return err
+			}
+			svc := internalrde.NewService(client)
+			sessionID, err := svc.ResolveSessionID(cmd.Context(), workspaceID, args[0])
+			if err != nil {
+				return err
+			}
+
+			// A terminated session is restored from its persistent disk, so
+			// check the disk first: fail fast with a clear reason when it's
+			// gone, and warn when it's about to expire (the server still
+			// allows the restore, so this is the only chance to surface it).
+			sess, err := svc.GetSession(cmd.Context(), workspaceID, sessionID)
+			if err != nil {
+				return err
+			}
+			switch sess.PersistentDiskStatus {
+			case internalrde.DiskStatusUnavailable:
+				return fmt.Errorf("session %s cannot be restored: its persistent disk is no longer available", sessionID)
+			case internalrde.DiskStatusUnavailableSoon:
+				if !cmdutil.IsQuiet(cmd) && output.Format == output.FormatRaw {
+					_, _ = fmt.Fprintf(cmd.ErrOrStderr(),
+						"Warning: this session's persistent disk will become unavailable soon (within ~1 week) — restore while you still can.\n")
+				}
+			}
+
+			restored, err := svc.RestoreSession(cmd.Context(), workspaceID, sessionID)
+			if err != nil {
+				return err
+			}
+
+			if wait {
+				waitCtx, cancel := context.WithTimeout(cmd.Context(), waitTimeout)
+				defer cancel()
+				if !cmdutil.IsQuiet(cmd) && output.Format == output.FormatRaw {
+					_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Waiting for session %s to become ready (timeout %s)…\n", restored.ID, waitTimeout)
+				}
+				ready, waitErr := svc.WaitForReady(waitCtx, workspaceID, restored.ID, 0, nil)
+				if waitErr != nil {
+					return fmt.Errorf("waiting for session: %w", waitErr)
+				}
+				restored = ready
+				if ready.Status != "running" {
+					if renderErr := output.Render(cmd.OutOrStdout(), output.Format, restored, renderSessionDetail); renderErr != nil {
+						return renderErr
+					}
+					cmdutil.SilenceRootErrors(cmd)
+					return fmt.Errorf("session ended provisioning with status %q (expected running)", ready.Status)
+				}
+			}
+
+			return output.Render(cmd.OutOrStdout(), output.Format, restored, renderSessionDetail)
+		},
+	}
+	c.Flags().BoolVar(&wait, "wait", false, "wait until the session leaves provisioning (running, failed, …) before returning; exits 1 if the final status isn't running")
+	c.Flags().DurationVar(&waitTimeout, "wait-timeout", 10*time.Minute, "max time to wait when --wait is set (Go duration syntax: 30s, 5m, 1h)")
+	c.Flags().StringVarP(&format, cmdutil.FormatKey, "f", "", "Output format. Accepted: raw (default), json, yml")
+	return c
+}

--- a/cli/rde/session/terminate.go
+++ b/cli/rde/session/terminate.go
@@ -1,0 +1,77 @@
+package session
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/bitrise-io/bitrise/v2/cli/cmdutil"
+	internalrde "github.com/bitrise-io/bitrise/v2/internal/rde"
+	"github.com/bitrise-io/bitrise/v2/output"
+)
+
+func newTerminateCmd() *cobra.Command {
+	var (
+		wait        bool
+		waitTimeout time.Duration
+		format      string
+	)
+	c := &cobra.Command{
+		Use:   "terminate SESSION_ID",
+		Short: "Terminate a running session (preserves it for later restart)",
+		Long: `Terminate a running session (preserves it for later restart).
+
+Terminate is asynchronous: by default the command returns while the session
+is still "terminating". Pass --wait to block until the session settles into a
+terminal state ("terminated" or "failed"). This is what makes a
+'terminate --wait && delete' pipeline reliable — delete rejects any session
+that isn't yet terminated or failed.`,
+		Args: cmdutil.RequireArgs("SESSION_ID"),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cmdutil.LogCommandParameters(cmd)
+
+			if err := output.ConfigureOutputFormat(format); err != nil {
+				return fmt.Errorf("failed to configure output format: %w", err)
+			}
+
+			workspaceID, err := cmdutil.ResolveWorkspaceID(cmd)
+			if err != nil {
+				return err
+			}
+			client, err := cmdutil.NewRDEClient(cmd)
+			if err != nil {
+				return err
+			}
+			svc := internalrde.NewService(client)
+			sessionID, err := svc.ResolveSessionID(cmd.Context(), workspaceID, args[0])
+			if err != nil {
+				return err
+			}
+			sess, err := svc.TerminateSession(cmd.Context(), workspaceID, sessionID)
+			if err != nil {
+				return err
+			}
+
+			if wait {
+				waitCtx, cancel := context.WithTimeout(cmd.Context(), waitTimeout)
+				defer cancel()
+				if !cmdutil.IsQuiet(cmd) && output.Format == output.FormatRaw {
+					_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Waiting for session %s to terminate (timeout %s)…\n", sess.ID, waitTimeout)
+				}
+				settled, waitErr := svc.WaitForTerminated(waitCtx, workspaceID, sess.ID, 0)
+				if waitErr != nil {
+					return fmt.Errorf("waiting for session to terminate: %w", waitErr)
+				}
+				sess = settled
+			}
+
+			return output.Render(cmd.OutOrStdout(), output.Format, sess, renderSessionDetail)
+		},
+	}
+	c.Flags().BoolVar(&wait, "wait", false, "block until the session settles into a terminal state (terminated/failed) before returning; makes 'terminate --wait && delete' reliable")
+	c.Flags().DurationVar(&waitTimeout, "wait-timeout", 10*time.Minute, "max time to wait when --wait is set (Go duration syntax: 30s, 5m, 1h)")
+	c.Flags().StringVarP(&format, cmdutil.FormatKey, "f", "", "Output format. Accepted: raw (default), json, yml")
+	return c
+}

--- a/cli/rde/session/update.go
+++ b/cli/rde/session/update.go
@@ -1,0 +1,102 @@
+package session
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/bitrise-io/bitrise/v2/cli/cmdutil"
+	internalrde "github.com/bitrise-io/bitrise/v2/internal/rde"
+	"github.com/bitrise-io/bitrise/v2/output"
+)
+
+func newUpdateCmd() *cobra.Command {
+	var (
+		name                 string
+		description          string
+		autoTerminateMinutes int
+		labels               []string
+		unsetLabels          []string
+		format               string
+	)
+	c := &cobra.Command{
+		Use:   "update SESSION_ID",
+		Short: "Update a session's name, description, auto-terminate duration, or labels",
+		Long: `Update a session's name, description, auto-terminate duration, or labels.
+
+Labels change incrementally: --label key=value upserts one label (an existing
+key is overwritten, other keys are left untouched) and --unset-label key
+removes one; both are repeatable. Removing a key the session doesn't have is
+a no-op.`,
+		Args: cmdutil.RequireArgs("SESSION_ID"),
+		Example: `  bitrise rde session update SESSION_ID --name new-name
+  bitrise rde session update SESSION_ID --auto-terminate-minutes 0
+  bitrise rde session update SESSION_ID --label branch=main --unset-label wip`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cmdutil.LogCommandParameters(cmd)
+
+			if err := output.ConfigureOutputFormat(format); err != nil {
+				return fmt.Errorf("failed to configure output format: %w", err)
+			}
+
+			workspaceID, err := cmdutil.ResolveWorkspaceID(cmd)
+			if err != nil {
+				return err
+			}
+			req := internalrde.UpdateSessionRequest{}
+			if cmd.Flags().Changed("name") {
+				n := name
+				req.Name = &n
+			}
+			if cmd.Flags().Changed("description") {
+				d := description
+				req.Description = &d
+			}
+			if cmd.Flags().Changed("auto-terminate-minutes") {
+				m := autoTerminateMinutes
+				req.AutoTerminateMinutes = &m
+			}
+			labelMap, err := parseLabelFlags("--label", labels)
+			if err != nil {
+				return err
+			}
+			req.Labels = labelMap
+			// The backend resolves a key that is both set and removed in
+			// favor of the removal; a direct contradiction on one command
+			// line is a mistake worth stopping before the request goes out.
+			for _, k := range unsetLabels {
+				if k == "" {
+					return fmt.Errorf("--unset-label: key must not be empty")
+				}
+				if _, ok := labelMap[k]; ok {
+					return fmt.Errorf("label %q cannot be both set (--label) and removed (--unset-label)", k)
+				}
+			}
+			req.RemoveLabels = unsetLabels
+			if req.Name == nil && req.Description == nil && req.AutoTerminateMinutes == nil && len(req.Labels) == 0 && len(req.RemoveLabels) == 0 {
+				return fmt.Errorf("at least one of --name, --description, --auto-terminate-minutes, --label, --unset-label is required")
+			}
+			client, err := cmdutil.NewRDEClient(cmd)
+			if err != nil {
+				return err
+			}
+			svc := internalrde.NewService(client)
+			sessionID, err := svc.ResolveSessionID(cmd.Context(), workspaceID, args[0])
+			if err != nil {
+				return err
+			}
+			sess, err := svc.UpdateSession(cmd.Context(), workspaceID, sessionID, req)
+			if err != nil {
+				return err
+			}
+			return output.Render(cmd.OutOrStdout(), output.Format, sess, renderSessionDetail)
+		},
+	}
+	c.Flags().StringVar(&name, "name", "", "new session name")
+	c.Flags().StringVar(&description, "description", "", "new session description")
+	c.Flags().IntVar(&autoTerminateMinutes, "auto-terminate-minutes", 0, "auto-terminate duration in minutes; 0 disables. Resets the deadline to now + minutes.")
+	c.Flags().StringArrayVarP(&labels, "label", "l", nil, "label to set on the session as key=value (repeatable; merged into the existing labels)")
+	c.Flags().StringArrayVar(&unsetLabels, "unset-label", nil, "label key to remove from the session (repeatable; unknown keys are ignored)")
+	c.Flags().StringVarP(&format, cmdutil.FormatKey, "f", "", "Output format. Accepted: raw (default), json, yml")
+	return c
+}

--- a/cli/rde/session/uuids_test.go
+++ b/cli/rde/session/uuids_test.go
@@ -1,5 +1,9 @@
 package session
 
+// uuidTemplate is a UUID-shaped template arg so ResolveTemplateID
+// short-circuits without an extra ListTemplates call.
+const uuidTemplate = "11111111-2222-3333-4444-555555555555"
+
 // uuidSession is a UUID-shaped session arg. Real RDE session IDs are UUIDs,
 // so this short-circuits ResolveSessionID's name lookup.
 const uuidSession = "99999999-8888-7777-6666-555555555555"


### PR DESCRIPTION
`rde session` lifecycle commands: `create`, `update`, `restore`, `terminate`, `delete`