### PR TITLE
RDE 12 - rde session remote commands

### DIFF
--- a/cli/rde/session/cmd.go
+++ b/cli/rde/session/cmd.go
@@ -30,6 +30,12 @@ the command errors and lists the candidate IDs to pick from.`,
 		newTerminateCmd(),
 		newDeleteCmd(),
 		newDeleteTerminatedCmd(),
+		newExecCmd(),
+		newLogsCmd(),
+		newUploadCmd(),
+		newDownloadCmd(),
+		newVNCCmd(),
+		newOpenVNCCmd(),
 	)
 	return c
 }

--- a/cli/rde/session/download.go
+++ b/cli/rde/session/download.go
@@ -1,0 +1,59 @@
+package session
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/bitrise-io/bitrise/v2/cli/cmdutil"
+	internalrde "github.com/bitrise-io/bitrise/v2/internal/rde"
+)
+
+func newDownloadCmd() *cobra.Command {
+	var onlyContents bool
+	c := &cobra.Command{
+		Use:   "download SESSION_ID REMOTE_PATH LOCAL_PATH",
+		Short: "Download a file or directory from a session",
+		Long: `Download a file or directory from a running session to the local machine.
+
+The remote path is tar+gzip'd server-side, served via a signed download URL,
+then extracted into LOCAL_PATH locally.
+
+When REMOTE_PATH is a directory, the directory itself is recreated inside
+LOCAL_PATH by default. Pass --only-contents to drop just its contents into
+LOCAL_PATH instead.`,
+		Example: `  bitrise rde session download SESSION_ID /Users/vagrant/project/build ./build
+  bitrise rde session download SESSION_ID /Users/vagrant/logs ./logs --only-contents`,
+		Args: cmdutil.RequireArgs("SESSION_ID", "REMOTE_PATH", "LOCAL_PATH"),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cmdutil.LogCommandParameters(cmd)
+
+			sessionID, sourcePath, localDest := args[0], args[1], args[2]
+			workspaceID, err := cmdutil.ResolveWorkspaceID(cmd)
+			if err != nil {
+				return err
+			}
+			client, err := cmdutil.NewRDEClient(cmd)
+			if err != nil {
+				return err
+			}
+			svc := internalrde.NewService(client)
+			sessionID, err = svc.ResolveSessionID(cmd.Context(), workspaceID, sessionID)
+			if err != nil {
+				return err
+			}
+			if !cmdutil.IsQuiet(cmd) {
+				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Downloading %s → %s from session %s…\n", sourcePath, localDest, sessionID)
+			}
+			if err := svc.DownloadFile(cmd.Context(), workspaceID, sessionID, sourcePath, localDest, onlyContents); err != nil {
+				return err
+			}
+			if !cmdutil.IsQuiet(cmd) {
+				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Download complete.\n")
+			}
+			return nil
+		},
+	}
+	c.Flags().BoolVar(&onlyContents, "only-contents", false, "when REMOTE_PATH is a directory, extract only its contents (not the directory itself)")
+	return c
+}

--- a/cli/rde/session/exec.go
+++ b/cli/rde/session/exec.go
@@ -1,0 +1,227 @@
+package session
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/bitrise-io/bitrise/v2/cli/cmdutil"
+	internalrde "github.com/bitrise-io/bitrise/v2/internal/rde"
+	"github.com/bitrise-io/bitrise/v2/internal/style"
+	"github.com/bitrise-io/bitrise/v2/output"
+)
+
+func newExecCmd() *cobra.Command {
+	var (
+		shellMode bool
+		timeout   time.Duration
+		envFlags  []string
+		noEnvFile bool
+		format    string
+	)
+	c := &cobra.Command{
+		Use:   "exec SESSION_ID -- COMMAND [ARGS...]",
+		Short: "Run a command on a session over SSH",
+		Long: `Run a command on a session over SSH and capture its output.
+
+The command runs in a forced-interactive login bash shell (bash -i -l -c) so
+the session's PATH, brew-installed binaries, git-lfs, and language version
+managers (nvm, pyenv, rbenv, asdf) are all loaded.
+
+By default the tokens after '--' are treated as a program plus literal
+arguments: each is passed through verbatim, so shell metacharacters (;, &&,
+|, $(...), redirection) are NOT interpreted — 'exec ID -- echo "a; b"' runs
+echo with the single literal argument 'a; b'. This keeps quoted arguments
+intact (e.g. -m "a message"). (Quote such arguments so your local shell
+hands them over as one token rather than splitting them itself.)
+
+Pass --shell to interpret everything after '--' as a shell command line
+instead, so pipes, &&, command substitution and redirection work:
+
+  bitrise rde session exec SESSION_ID --shell -- 'cd repo && xcodebuild | xcpretty'
+
+This is the first-class replacement for hand-wrapping every command in
+bash -lc "…". Quote the command (or its metacharacters) so your local shell
+passes them through unchanged. --shell must come before '--'; after '--' it
+is just another literal token.
+
+If a local SSH agent is available ($SSH_AUTH_SOCK set), it's forwarded into
+the session — git-over-SSH inside the session uses the caller's local keys.
+
+Local environment variables can be forwarded to the remote command with
+--env (repeatable, before '--'): --env NAME forwards the local value of
+NAME (an error if unset), --env NAME=VALUE sets a literal. A repo can pin
+a shared list in .bitrise/rde.yml (found in the working directory or any
+ancestor):
+
+  exec:
+    env:
+      - API_BASE_URL
+      - NPM_TOKEN=abc123
+
+File entries use the same NAME / NAME=VALUE forms, except a NAME that is
+unset locally is skipped with a warning instead of failing, so a shared
+file never breaks a teammate. --env overrides a same-named file entry;
+--no-env-file skips the file entirely. Commit the file to share the list
+with your team, or gitignore it to keep a personal list (including
+NAME=VALUE literals) out of the repo. Forwarded variables are announced
+by name on stderr (silence with -q) — values are never printed locally,
+but they do ride in the remote command line, so they are visible in ps
+on the session while the command runs.
+
+In raw mode: stdout streams to this CLI's stdout, stderr to stderr, and
+this CLI exits non-zero when the remote command exits non-zero.
+
+In --format json/yml mode: a single exit_code/stdout/stderr object is
+emitted to stdout regardless of the command's exit status.
+
+The remote command is capped at 10 minutes by default; raise it with --timeout
+(e.g. --timeout 20m for a cold xcodebuild) or pass --timeout 0 to disable the
+cap. exec holds the SSH connection open for the whole run, so the command dies
+if the connection drops — for fire-and-forget work that must outlive the
+connection, nohup it inside the session instead.`,
+		Example: `  bitrise rde session exec SESSION_ID -- echo hello
+  bitrise rde session exec SESSION_ID -- npm test
+  bitrise rde session exec SESSION_ID -- git commit -m "a message"
+  bitrise rde session exec SESSION_ID --shell -- 'cd repo && ls | head'
+  bitrise rde session exec SESSION_ID --env NPM_TOKEN --env CI=1 -- npm test
+  bitrise rde session exec SESSION_ID --timeout 20m -- ./scripts/cold-build.sh
+  bitrise rde session exec SESSION_ID --format json -- ls -la /opt`,
+		Args: func(_ *cobra.Command, args []string) error {
+			if len(args) < 2 {
+				return fmt.Errorf("session exec requires SESSION_ID followed by a command (e.g. 'rde session exec ID -- echo hi')")
+			}
+			return nil
+		},
+		// DisableFlagParsing stays off so our own flags (--shell, --format …)
+		// are parsed. Combined with the explicit `--` convention, tokens after
+		// `--` are still handed through as positional args, so a user can write
+		// `exec ID -- ls -la /opt` without `-la` being read as our flag.
+		DisableFlagParsing: false,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cmdutil.LogCommandParameters(cmd)
+
+			if err := output.ConfigureOutputFormat(format); err != nil {
+				return fmt.Errorf("failed to configure output format: %w", err)
+			}
+
+			sessionID := args[0]
+			command := buildExecCommand(args[1:], shellMode)
+			if strings.TrimSpace(command) == "" {
+				return fmt.Errorf("command is empty")
+			}
+			// Resolve the forwarded env before anything touches the network,
+			// so a typo'd --env or a broken dotfile fails fast.
+			var fileEntries []string
+			var envFilePath string
+			if !noEnvFile {
+				repoCfg, path, err := internalrde.LoadRepoConfig()
+				if err != nil {
+					return err
+				}
+				fileEntries, envFilePath = repoCfg.Exec.Env, path
+			}
+			envVars, skippedEnv, err := internalrde.ResolveExecEnv(fileEntries, envFilePath, envFlags, os.LookupEnv)
+			if err != nil {
+				return err
+			}
+			workspaceID, err := cmdutil.ResolveWorkspaceID(cmd)
+			if err != nil {
+				return err
+			}
+			client, err := cmdutil.NewRDEClient(cmd)
+			if err != nil {
+				return err
+			}
+			svc := internalrde.NewService(client)
+			sessionID, err = svc.ResolveSessionID(cmd.Context(), workspaceID, sessionID)
+			if err != nil {
+				return err
+			}
+			// Notices print here — after session resolution, so "Forwarding"
+			// only announces an exec that's actually about to run — and
+			// before Execute, so they land ahead of any streamed output.
+			if err := printExecEnvNotices(cmd, envVars, skippedEnv, envFilePath); err != nil {
+				return err
+			}
+			res, err := svc.Execute(cmd.Context(), workspaceID, sessionID, command, envVars, timeout)
+			if err != nil {
+				return err
+			}
+			return renderExecResult(cmd, res)
+		},
+	}
+	c.Flags().BoolVar(&shellMode, "shell", false, "interpret everything after '--' as a shell command line (pipes, &&, $(...), redirection) instead of a program with literal arguments")
+	c.Flags().DurationVar(&timeout, "timeout", internalrde.DefaultExecuteTimeout, "max time the remote command may run before it's aborted; 0 disables the cap (Go duration syntax: 30s, 10m, 1h)")
+	c.Flags().StringArrayVar(&envFlags, "env", nil, "environment variable for the remote command: NAME forwards the local value (errors if unset), NAME=VALUE sets a literal (repeatable; must come before '--')")
+	c.Flags().BoolVar(&noEnvFile, "no-env-file", false, "skip reading forwarded env vars from .bitrise/rde.yml")
+	c.Flags().StringVarP(&format, cmdutil.FormatKey, "f", "", "Output format. Accepted: raw (default), json, yml")
+	return c
+}
+
+// printExecEnvNotices writes the env-forwarding diagnostics to stderr: a
+// warning naming dotfile entries skipped because they're unset locally
+// (never suppressed — warnings ignore --quiet), then a names-only forwarding
+// notice (suppressed by --quiet). Values are never printed.
+func printExecEnvNotices(cmd *cobra.Command, vars []internalrde.EnvVar, skipped []string, filePath string) error {
+	ew := cmdutil.NewErrWriter(cmd.ErrOrStderr())
+	if len(skipped) > 0 {
+		s := style.New(cmd.ErrOrStderr())
+		ew.F("%s %s not set locally — skipped (listed in %s)\n", s.Warn.Render("Warning:"), strings.Join(skipped, ", "), filePath)
+	}
+	if len(vars) > 0 && !cmdutil.IsQuiet(cmd) {
+		names := make([]string, len(vars))
+		for i, v := range vars {
+			names[i] = v.Name
+		}
+		ew.F("Forwarding env: %s\n", strings.Join(names, ", "))
+	}
+	return ew.Err
+}
+
+// buildExecCommand turns the post-`--` tokens into the command string sent to
+// the session. The remote side always wraps it in `bash -i -l -c '<cmd>'`
+// (see internal/rde), so the only question here is how the tokens are joined:
+//
+//   - shell mode: joined verbatim with spaces, so the wrapped bash interprets
+//     metacharacters (matches the backend's `bash_c_command`). The caller is
+//     responsible for quoting so their local shell passes the metacharacters
+//     through.
+//   - default: each token is POSIX-quoted, so it reaches bash as a literal
+//     argv element and shell metacharacters are inert.
+func buildExecCommand(cmdArgs []string, shell bool) string {
+	if shell {
+		return strings.Join(cmdArgs, " ")
+	}
+	return cmdutil.JoinShellArgs(cmdArgs)
+}
+
+func renderExecResult(cmd *cobra.Command, res internalrde.ExecResult) error {
+	if output.Format != output.FormatRaw {
+		return output.Print(cmd.OutOrStdout(), res, output.Format)
+	}
+	// Raw mode: stream stdout and stderr to their natural sinks. We don't
+	// echo a JSON-shaped envelope — users piping `| jq` should be using
+	// --format json.
+	if res.Stdout != "" {
+		if _, err := io.WriteString(cmd.OutOrStdout(), res.Stdout); err != nil {
+			return err
+		}
+	}
+	if res.Stderr != "" {
+		if _, err := io.WriteString(cmd.ErrOrStderr(), res.Stderr); err != nil {
+			return err
+		}
+	}
+	if res.ExitCode != 0 {
+		// Suppress cobra's "Error: ..." line — the remote command's
+		// stderr already explains the failure.
+		cmdutil.SilenceRootErrors(cmd)
+		return fmt.Errorf("remote command exited with status %d", res.ExitCode)
+	}
+	return nil
+}

--- a/cli/rde/session/exec_test.go
+++ b/cli/rde/session/exec_test.go
@@ -1,0 +1,254 @@
+package session
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/bitrise-io/bitrise/v2/cli/cmdtest"
+	"github.com/bitrise-io/bitrise/v2/cli/cmdutil"
+	internalrde "github.com/bitrise-io/bitrise/v2/internal/rde"
+	"github.com/bitrise-io/bitrise/v2/output"
+)
+
+func TestBuildExecCommand(t *testing.T) {
+	cases := []struct {
+		name  string
+		args  []string
+		shell bool
+		want  string
+	}{
+		{
+			name: "default quotes each token so metacharacters stay literal",
+			args: []string{"echo", "a; b"},
+			want: `echo 'a; b'`,
+		},
+		{
+			name: "default leaves simple argv untouched",
+			args: []string{"npm", "test"},
+			want: "npm test",
+		},
+		{
+			name:  "shell mode joins a single quoted command verbatim",
+			args:  []string{"cd repo && ls | head"},
+			shell: true,
+			want:  "cd repo && ls | head",
+		},
+		{
+			name:  "shell mode joins multiple tokens with spaces, no quoting",
+			args:  []string{"cd", "/x", "&&", "ls"},
+			shell: true,
+			want:  "cd /x && ls",
+		},
+		{
+			// Shell mode does not escape single quotes — that is the remote
+			// wrapper's job (see internalrde.buildLoginShellCmd). Here the
+			// command is passed through verbatim, quotes and all.
+			name:  "shell mode passes single quotes through unescaped",
+			args:  []string{"grep -rn 'TODO' ."},
+			shell: true,
+			want:  "grep -rn 'TODO' .",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := buildExecCommand(tc.args, tc.shell); got != tc.want {
+				t.Errorf("buildExecCommand(%q, shell=%v) = %q, want %q", tc.args, tc.shell, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestExecCmd_TimeoutFlagDefault pins that exec registers --timeout and that
+// its default tracks the service-layer default (so a change to one without the
+// other is caught).
+func TestExecCmd_TimeoutFlagDefault(t *testing.T) {
+	c := newExecCmd()
+	if c.Flags().Lookup("timeout") == nil {
+		t.Fatal("exec should register a --timeout flag")
+	}
+	got, err := c.Flags().GetDuration("timeout")
+	if err != nil {
+		t.Fatalf("GetDuration(timeout): %v", err)
+	}
+	if got != internalrde.DefaultExecuteTimeout {
+		t.Errorf("--timeout default = %s, want %s", got, internalrde.DefaultExecuteTimeout)
+	}
+	if internalrde.DefaultExecuteTimeout != 10*time.Minute {
+		t.Errorf("DefaultExecuteTimeout = %s, want 10m", internalrde.DefaultExecuteTimeout)
+	}
+}
+
+func TestExecCmd_EnvFlagsRegistered(t *testing.T) {
+	c := newExecCmd()
+	envFlag := c.Flags().Lookup("env")
+	if envFlag == nil {
+		t.Fatal("exec should register an --env flag")
+	}
+	if envFlag.Value.Type() != "stringArray" {
+		t.Errorf("--env type = %q, want stringArray (repeatable, no comma-splitting)", envFlag.Value.Type())
+	}
+	noFile, err := c.Flags().GetBool("no-env-file")
+	if err != nil {
+		t.Fatalf("GetBool(no-env-file): %v", err)
+	}
+	if noFile {
+		t.Error("--no-env-file should default to false")
+	}
+}
+
+// TestExecCmd_EnvFlagUnsetVarFailsFast pins that a --env NAME with no local
+// value errors before any network call — the server fails the test on any
+// request — and that the error names the variable.
+func TestExecCmd_EnvFlagUnsetVarFailsFast(t *testing.T) {
+	t.Chdir(t.TempDir()) // no dotfile in scope
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		t.Errorf("unexpected request before env validation: %s %s", r.Method, r.URL.Path)
+	}))
+	t.Cleanup(srv.Close)
+
+	_, _, err := cmdtest.Run(t, newExecCmd(), cmdtest.Opts{
+		RDEAPIBaseURL:      srv.URL,
+		DefaultWorkspaceID: "ws-1",
+		Args:               []string{uuidSession, "--env", "BCLI_TEST_DEFINITELY_UNSET", "--", "echo", "hi"},
+	})
+	if err == nil || !strings.Contains(err.Error(), "BCLI_TEST_DEFINITELY_UNSET") {
+		t.Fatalf("err = %v, want error naming BCLI_TEST_DEFINITELY_UNSET", err)
+	}
+}
+
+func TestExecCmd_DotfileWarningAndNotice(t *testing.T) {
+	writeExecEnvDotfile(t, "exec:\n  env:\n    - BCLI_TEST_DEFINITELY_UNSET\n    - FOO=secret-value-xyz\n")
+	srv := terminatedSessionServer(t)
+
+	_, stderr, err := cmdtest.Run(t, newExecCmd(), cmdtest.Opts{
+		RDEAPIBaseURL:      srv.URL,
+		DefaultWorkspaceID: "ws-1",
+		Args:               []string{uuidSession, "--", "echo", "hi"},
+	})
+	if err == nil {
+		t.Fatal("expected the exec against a terminated session to error")
+	}
+	if !strings.Contains(stderr, "BCLI_TEST_DEFINITELY_UNSET not set locally") {
+		t.Errorf("stderr missing skip warning:\n%s", stderr)
+	}
+	if !strings.Contains(stderr, "Forwarding env: FOO") {
+		t.Errorf("stderr missing forwarding notice:\n%s", stderr)
+	}
+	if strings.Contains(stderr, "secret-value-xyz") {
+		t.Errorf("stderr leaks a forwarded value:\n%s", stderr)
+	}
+}
+
+func TestExecCmd_NoEnvFileFlag(t *testing.T) {
+	writeExecEnvDotfile(t, "exec:\n  env:\n    - BCLI_TEST_DEFINITELY_UNSET\n    - FOO=secret-value-xyz\n")
+	srv := terminatedSessionServer(t)
+
+	_, stderr, err := cmdtest.Run(t, newExecCmd(), cmdtest.Opts{
+		RDEAPIBaseURL:      srv.URL,
+		DefaultWorkspaceID: "ws-1",
+		Args:               []string{uuidSession, "--no-env-file", "--", "echo", "hi"},
+	})
+	if err == nil {
+		t.Fatal("expected the exec against a terminated session to error")
+	}
+	for _, unwanted := range []string{"not set locally", "Forwarding env"} {
+		if strings.Contains(stderr, unwanted) {
+			t.Errorf("stderr should not mention %q with --no-env-file:\n%s", unwanted, stderr)
+		}
+	}
+}
+
+// TestExecCmd_QuietSuppressesNoticeNotWarning attaches the persistent --quiet
+// flag directly to the command under test (cmdutil.IsQuiet reads it off
+// cmd.Root(), which for a standalone command is the command itself): with -q
+// the forwarding notice disappears while the skip warning stays, per the
+// output scheme's rule that warnings ignore --quiet.
+func TestExecCmd_QuietSuppressesNoticeNotWarning(t *testing.T) {
+	writeExecEnvDotfile(t, "exec:\n  env:\n    - BCLI_TEST_DEFINITELY_UNSET\n    - FOO=secret-value-xyz\n")
+	srv := terminatedSessionServer(t)
+
+	cmd := newExecCmd()
+	cmd.PersistentFlags().BoolP(cmdutil.FlagQuiet, "q", false, "quiet")
+
+	_, stderr, err := cmdtest.Run(t, cmd, cmdtest.Opts{
+		RDEAPIBaseURL:      srv.URL,
+		DefaultWorkspaceID: "ws-1",
+		Args:               []string{uuidSession, "-q", "--", "echo", "hi"},
+	})
+	if err == nil {
+		t.Fatal("expected the exec against a terminated session to error")
+	}
+	if strings.Contains(stderr, "Forwarding env") {
+		t.Errorf("-q should suppress the forwarding notice:\n%s", stderr)
+	}
+	if !strings.Contains(stderr, "BCLI_TEST_DEFINITELY_UNSET not set locally") {
+		t.Errorf("-q must not suppress the skip warning:\n%s", stderr)
+	}
+}
+
+// TestRenderExecResult_NonRawFormats pins the format-predicate translation
+// (format != FormatRaw, not == FormatJSON as in the reference implementation,
+// which never had a third format to consider): both json and yml render the
+// full structured result rather than falling through to the raw stdout/stderr
+// streaming branch.
+func TestRenderExecResult_NonRawFormats(t *testing.T) {
+	res := internalrde.ExecResult{ExitCode: 0, Stdout: "hi\n", Stderr: ""}
+	for _, format := range []string{output.FormatJSON, output.FormatYML} {
+		t.Run(format, func(t *testing.T) {
+			old := output.Format
+			output.Format = format
+			defer func() { output.Format = old }()
+
+			cmd := &cobra.Command{}
+			var out bytes.Buffer
+			cmd.SetOut(&out)
+
+			if err := renderExecResult(cmd, res); err != nil {
+				t.Fatalf("renderExecResult: %v", err)
+			}
+			if !strings.Contains(out.String(), "hi") {
+				t.Errorf("%s output missing stdout field:\n%s", format, out.String())
+			}
+		})
+	}
+}
+
+// writeExecEnvDotfile drops a .bitrise/rde.yml into dir and chdirs there, so
+// the test exercises the auto-read path without picking up any real dotfile
+// in an ancestor of the package directory.
+func writeExecEnvDotfile(t *testing.T, body string) {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, ".bitrise"), 0o755); err != nil { // test-only tempdir, perms do not matter
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".bitrise", "rde.yml"), []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(dir)
+}
+
+// terminatedSessionServer serves a GET for uuidSession whose status is
+// terminated, so exec's Execute call fails cleanly after the env diagnostics
+// have been printed (no SSH dial is attempted against a terminated session).
+func terminatedSessionServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && r.URL.Path == "/v1/workspaces/ws-1/sessions/"+uuidSession {
+			_, _ = io.WriteString(w, `{"session":{"id":"s-1","name":"dev","status":"SESSION_STATUS_TERMINATED"}}`)
+			return
+		}
+		t.Errorf("unexpected: %s %s", r.Method, r.URL.Path)
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}

--- a/cli/rde/session/list.go
+++ b/cli/rde/session/list.go
@@ -19,20 +19,31 @@ type listResult struct {
 }
 
 func newListCmd() *cobra.Command {
-	var selectors []string
-	var format string
+	var (
+		selectors []string
+		scope     string
+		format    string
+	)
 	c := &cobra.Command{
 		Use:   "list",
 		Short: "List RDE sessions in the workspace",
-		Long: `List every RDE session the authenticated user has in the workspace.
+		Long: `List RDE sessions in the workspace.
 
 Filter by labels with --label-selector key=value (repeatable; selectors are
 exact matches and are ANDed, at most 8 per request).
+
+By default every session the authenticated user has in the workspace is
+listed. Pass --scope workspace for sessions owned by the workspace itself
+rather than by a user (for example sessions spawned by workspace device
+preview links) — every workspace member sees the same list. The owning user
+or workspace is reported via the owner_type and owner_id fields in
+--format json/yml.
 
 The session list comes from the backend in arbitrary order; the CLI does
 not paginate (the API doesn't paginate this endpoint either).`,
 		Example: `  bitrise rde session list
   bitrise rde session list --workspace my-workspace
+  bitrise rde session list --scope workspace
   bitrise rde session list -l team=mobile -l branch=main
   bitrise rde session list --format json | jq '.items[].id'`,
 		Args: cobra.NoArgs,
@@ -46,6 +57,11 @@ not paginate (the API doesn't paginate this endpoint either).`,
 			if err := validateLabelSelectors(selectors); err != nil {
 				return err
 			}
+			switch scope {
+			case internalrde.SessionScopeMine, internalrde.SessionScopeWorkspace:
+			default:
+				return fmt.Errorf("--scope must be %s or %s", internalrde.SessionScopeMine, internalrde.SessionScopeWorkspace)
+			}
 			workspaceID, err := cmdutil.ResolveWorkspaceID(cmd)
 			if err != nil {
 				return err
@@ -54,7 +70,7 @@ not paginate (the API doesn't paginate this endpoint either).`,
 			if err != nil {
 				return err
 			}
-			sessions, err := internalrde.NewService(client).ListSessions(cmd.Context(), workspaceID, selectors)
+			sessions, err := internalrde.NewService(client).ListSessions(cmd.Context(), workspaceID, selectors, scope)
 			if err != nil {
 				return err
 			}
@@ -62,7 +78,11 @@ not paginate (the API doesn't paginate this endpoint either).`,
 		},
 	}
 	c.Flags().StringArrayVarP(&selectors, "label-selector", "l", nil, "only sessions whose labels match key=value exactly (repeatable; multiple selectors must all match)")
+	c.Flags().StringVar(&scope, "scope", internalrde.SessionScopeMine, "which sessions to list: mine (sessions you created) or workspace (sessions owned by the workspace itself, visible to every member)")
 	c.Flags().StringVarP(&format, cmdutil.FormatKey, "f", "", "Output format. Accepted: raw (default), json, yml")
+	_ = c.RegisterFlagCompletionFunc("scope", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+		return []string{"mine\tsessions you created (default)", "workspace\tsessions owned by the workspace itself"}, cobra.ShellCompDirectiveNoFileComp
+	})
 	return c
 }
 

--- a/cli/rde/session/logs.go
+++ b/cli/rde/session/logs.go
@@ -1,0 +1,171 @@
+package session
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/signal"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/bitrise-io/bitrise/v2/cli/cmdutil"
+	internalrde "github.com/bitrise-io/bitrise/v2/internal/rde"
+	"github.com/bitrise-io/bitrise/v2/output"
+)
+
+// followRetryInterval is how long --follow waits before retrying while the
+// stage hasn't produced any logs yet. A package var so tests can shorten it;
+// not exposed as a flag to keep the command surface small.
+var followRetryInterval = 3 * time.Second
+
+// snapshotIdleTimeout is how long the default (non-follow) mode waits for new
+// content before deciding the replayed log has drained and exiting. The
+// backend never signals end-of-log, so this idle gap is how "print what's
+// there, then stop" terminates. A package var so tests can shorten it; not a
+// flag, to keep the command surface small.
+var snapshotIdleTimeout = 2 * time.Second
+
+func newLogsCmd() *cobra.Command {
+	var (
+		stage  string
+		follow bool
+		format string
+	)
+
+	c := &cobra.Command{
+		Use:   "logs SESSION_ID --stage warmup|startup",
+		Short: "Print a session's warmup or startup logs",
+		Long: `Print the warmup or startup script logs for a session — useful for debugging a
+session stuck provisioning or one that came up failed. The log replays from the
+start every time you connect.
+
+By default this prints the log captured so far and exits, without waiting for
+more output. Pass --follow to keep streaming new output live until you stop it
+with Ctrl-C (the backend does not signal end-of-log, so --follow runs until
+interrupted).
+
+  --stage    which script's logs to show: warmup or startup (required). warmup
+             runs once at session creation; startup runs on every session
+             start/restart.
+  --follow   keep streaming new output until Ctrl-C, and wait for the stage to
+             start if it hasn't produced any logs yet (instead of erroring).
+
+--format is rejected — logs stream as raw text, not a single object. Pipe or
+redirect as needed; diagnostics go to stderr so a redirect captures only log
+text.`,
+		Example: `  bitrise rde session logs SESSION_ID --stage startup
+  bitrise rde session logs SESSION_ID --stage warmup
+  bitrise rde session logs SESSION_ID --stage startup --follow
+  bitrise rde session logs SESSION_ID --stage startup > session.log`,
+		Args: cmdutil.RequireArgs("SESSION_ID"),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cmdutil.LogCommandParameters(cmd)
+
+			if err := output.ConfigureOutputFormat(format); err != nil {
+				return fmt.Errorf("failed to configure output format: %w", err)
+			}
+			// Reject any machine-readable format before any network round-trip
+			// — the feed is plain text, not a single object.
+			if output.Format != output.FormatRaw {
+				return fmt.Errorf("session logs cannot be combined with --format %s (the feed is plain text, not a single object)", output.Format)
+			}
+			// Validate --stage up front so a typo errors before the stream
+			// header prints (mirrors notifications' --order validation).
+			switch stage {
+			case internalrde.LogStageWarmup, internalrde.LogStageStartup:
+			default:
+				return fmt.Errorf("--stage must be %s or %s", internalrde.LogStageWarmup, internalrde.LogStageStartup)
+			}
+
+			workspaceID, err := cmdutil.ResolveWorkspaceID(cmd)
+			if err != nil {
+				return err
+			}
+			client, err := cmdutil.NewRDEClient(cmd)
+			if err != nil {
+				return err
+			}
+			svc := internalrde.NewService(client)
+			sessionID, err := svc.ResolveSessionID(cmd.Context(), workspaceID, args[0])
+			if err != nil {
+				return err
+			}
+
+			// Stop cleanly on Ctrl-C: cancelling the context ends the stream
+			// and StreamSessionLogs returns nil, so the command exits 0.
+			ctx, cancel := signal.NotifyContext(cmd.Context(), os.Interrupt)
+			defer cancel()
+
+			out := cmd.OutOrStdout()
+			emit := func(chunk string) error {
+				_, werr := io.WriteString(out, chunk)
+				return werr
+			}
+
+			if follow {
+				return runFollow(ctx, cmd, svc, workspaceID, sessionID, stage, emit)
+			}
+			return runSnapshot(ctx, cmd, svc, workspaceID, sessionID, stage, emit)
+		},
+	}
+
+	c.Flags().StringVar(&stage, "stage", "", "which logs to show: warmup or startup (required)")
+	c.Flags().BoolVarP(&follow, "follow", "f", false, "keep streaming until Ctrl-C, waiting for the stage to start if needed")
+	_ = c.MarkFlagRequired("stage")
+	// logs already owns -f for --follow, so --format registers with no
+	// shorthand here.
+	c.Flags().StringVar(&format, cmdutil.FormatKey, "", "Output format. Accepted: raw (default), json, yml")
+
+	_ = c.RegisterFlagCompletionFunc("stage", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+		return []string{
+			internalrde.LogStageWarmup + "\twarmup script (once at creation)",
+			internalrde.LogStageStartup + "\tstartup script (every start/restart)",
+		}, cobra.ShellCompDirectiveNoFileComp
+	})
+	return c
+}
+
+// runSnapshot prints the stage log captured so far and exits, without waiting
+// for new output. The backend never sends EOF, so it relies on an idle gap
+// (snapshotIdleTimeout): the replayed backlog arrives in a burst, then the
+// stream goes quiet and the command returns. A pre-stream 404 ("logs not
+// available yet") is turned into a friendly, actionable message and a non-zero
+// exit rather than a raw API error.
+func runSnapshot(ctx context.Context, cmd *cobra.Command, svc *internalrde.Service, workspaceID, sessionID, stage string, emit func(string) error) error {
+	err := svc.StreamSessionLogs(ctx, workspaceID, sessionID, stage, snapshotIdleTimeout, emit)
+	if internalrde.IsNotFound(err) {
+		cmdutil.SilenceRootErrors(cmd)
+		_, _ = fmt.Fprintf(cmd.ErrOrStderr(),
+			"No %s logs available yet — the session may still be provisioning. Retry shortly, or pass --follow to wait.\n", stage)
+		return err
+	}
+	return err
+}
+
+// runFollow streams the stage log live until Ctrl-C. If the stage hasn't
+// started producing logs yet (404), it waits followRetryInterval and retries
+// — the dashboard does the same. The retry is safe because a 404 only ever
+// comes back pre-stream (nothing has been printed yet), so it can't duplicate
+// already-streamed output. idleTimeout is 0 here: follow never self-terminates.
+func runFollow(ctx context.Context, cmd *cobra.Command, svc *internalrde.Service, workspaceID, sessionID, stage string, emit func(string) error) error {
+	if !cmdutil.IsQuiet(cmd) {
+		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Streaming %s logs for session %s — Ctrl-C to stop…\n", stage, sessionID)
+	}
+	for {
+		err := svc.StreamSessionLogs(ctx, workspaceID, sessionID, stage, 0, emit)
+		if err == nil {
+			return nil
+		}
+		if internalrde.IsNotFound(err) && ctx.Err() == nil {
+			select {
+			case <-ctx.Done():
+				return nil
+			case <-time.After(followRetryInterval):
+				continue
+			}
+		}
+		return err
+	}
+}

--- a/cli/rde/session/logs_test.go
+++ b/cli/rde/session/logs_test.go
@@ -1,0 +1,187 @@
+package session
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/bitrise-io/bitrise/v2/cli/cmdtest"
+	"github.com/bitrise-io/bitrise/v2/output"
+)
+
+// testSessionID is UUID-shaped so ResolveSessionID short-circuits without a
+// ListSessions round-trip (which would otherwise hit our log-streaming server).
+const testSessionID = "11111111-2222-3333-4444-555555555555"
+
+func TestLogsCmd_SnapshotStreamsToStdout(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if want := "/v1/workspaces/ws-1/sessions/11111111-2222-3333-4444-555555555555/logs/2"; r.URL.Path != want { // startup -> 2
+			t.Errorf("path = %s, want %s", r.URL.Path, want)
+		}
+		writeFrames(w, logFrame("hello\n"), logFrame("world\n"))
+	}))
+	defer srv.Close()
+
+	stdout, _, err := cmdtest.Run(t, logsCmd(), cmdtest.Opts{
+		RDEAPIBaseURL:      srv.URL,
+		DefaultWorkspaceID: "ws-1",
+		Args:               []string{testSessionID, "--stage", "startup"},
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if stdout != "hello\nworld\n" {
+		t.Errorf("stdout = %q, want raw concatenated log", stdout)
+	}
+}
+
+func TestLogsCmd_SnapshotNotReady404(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"code":5,"message":"logs not available yet for this stage"}`))
+	}))
+	defer srv.Close()
+
+	stdout, stderr, err := cmdtest.Run(t, logsCmd(), cmdtest.Opts{
+		RDEAPIBaseURL:      srv.URL,
+		DefaultWorkspaceID: "ws-1",
+		Args:               []string{testSessionID, "--stage", "warmup"},
+	})
+	if err == nil {
+		t.Fatal("expected non-zero exit (error) on 404")
+	}
+	if stdout != "" {
+		t.Errorf("stdout = %q, want empty", stdout)
+	}
+	if !strings.Contains(stderr, "available yet") || !strings.Contains(stderr, "--follow") {
+		t.Errorf("stderr = %q, want a friendly 'not available yet … --follow' message", stderr)
+	}
+}
+
+func TestLogsCmd_FollowRetriesPast404ThenStreams(t *testing.T) {
+	var hits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if atomic.AddInt32(&hits, 1) == 1 {
+			// First connect: stage hasn't produced output yet.
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"code":5,"message":"logs not available yet for this stage"}`))
+			return
+		}
+		writeFrames(w, logFrame("now streaming\n"))
+	}))
+	defer srv.Close()
+
+	old := followRetryInterval
+	followRetryInterval = time.Millisecond
+	defer func() { followRetryInterval = old }()
+
+	stdout, stderr, err := cmdtest.Run(t, logsCmd(), cmdtest.Opts{
+		RDEAPIBaseURL:      srv.URL,
+		DefaultWorkspaceID: "ws-1",
+		Args:               []string{testSessionID, "--stage", "startup", "--follow"},
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if stdout != "now streaming\n" {
+		t.Errorf("stdout = %q, want streamed content after retry", stdout)
+	}
+	if !strings.Contains(stderr, "Streaming") {
+		t.Errorf("stderr = %q, want the follow header", stderr)
+	}
+	if got := atomic.LoadInt32(&hits); got < 2 {
+		t.Errorf("server hits = %d, want >= 2 (404 then stream)", got)
+	}
+}
+
+func TestLogsCmd_RejectsMachineReadableOutput(t *testing.T) {
+	for _, format := range []string{output.FormatJSON, output.FormatYML} {
+		t.Run(format, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+				t.Error("should not hit the network when a machine-readable format is rejected")
+			}))
+			defer srv.Close()
+
+			_, _, err := cmdtest.Run(t, logsCmd(), cmdtest.Opts{
+				RDEAPIBaseURL:      srv.URL,
+				DefaultWorkspaceID: "ws-1",
+				Format:             format,
+				Args:               []string{testSessionID, "--stage", "startup"},
+			})
+			if err == nil {
+				t.Fatalf("expected error rejecting --format %s", format)
+			}
+			if !strings.Contains(err.Error(), format) {
+				t.Errorf("error = %q, want it to mention %s", err.Error(), format)
+			}
+		})
+	}
+}
+
+func TestLogsCmd_RequiresStage(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		t.Error("should not hit the network when --stage is missing")
+	}))
+	defer srv.Close()
+
+	_, _, err := cmdtest.Run(t, logsCmd(), cmdtest.Opts{
+		RDEAPIBaseURL:      srv.URL,
+		DefaultWorkspaceID: "ws-1",
+		Args:               []string{testSessionID},
+	})
+	if err == nil {
+		t.Fatal("expected error when --stage is not set")
+	}
+	if !strings.Contains(err.Error(), "stage") {
+		t.Errorf("error = %q, want it to mention the required stage flag", err.Error())
+	}
+}
+
+func TestLogsCmd_BadStageErrorsBeforeNetwork(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		t.Error("should not hit the network for an invalid --stage")
+	}))
+	defer srv.Close()
+
+	_, stderr, err := cmdtest.Run(t, logsCmd(), cmdtest.Opts{
+		RDEAPIBaseURL:      srv.URL,
+		DefaultWorkspaceID: "ws-1",
+		Args:               []string{testSessionID, "--stage", "bogus"},
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid --stage")
+	}
+	if strings.Contains(stderr, "Streaming") {
+		t.Errorf("stderr = %q, header should not print before validation fails", stderr)
+	}
+}
+
+// logsCmd returns a logs command with SilenceUsage set, mirroring what the
+// production root does — so a runtime error doesn't dump usage into the test's
+// captured stdout.
+func logsCmd() *cobra.Command {
+	c := newLogsCmd()
+	c.SilenceUsage = true
+	return c
+}
+
+// logFrame is the success wire frame for one chunk, newline-terminated.
+func logFrame(content string) string {
+	b, _ := json.Marshal(content)
+	return `{"result":{"logContent":` + string(b) + `}}` + "\n"
+}
+
+func writeFrames(w http.ResponseWriter, frames ...string) {
+	for _, f := range frames {
+		_, _ = w.Write([]byte(f))
+		if fl, ok := w.(http.Flusher); ok {
+			fl.Flush()
+		}
+	}
+}

--- a/cli/rde/session/open_vnc.go
+++ b/cli/rde/session/open_vnc.go
@@ -1,0 +1,89 @@
+package session
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/bitrise-io/bitrise/v2/cli/cmdutil"
+	internalrde "github.com/bitrise-io/bitrise/v2/internal/rde"
+	"github.com/bitrise-io/bitrise/v2/output"
+)
+
+// openVNCResult is the --format json/yml shape of `session open-vnc`. The
+// password is intentionally omitted — `open-vnc` hands the URL to the OS
+// handler, so there's no reason to also print it.
+type openVNCResult struct {
+	Opened   bool   `json:"opened" yaml:"opened"`
+	Address  string `json:"address" yaml:"address"`
+	Username string `json:"username,omitempty" yaml:"username,omitempty"`
+}
+
+// urlOpener spawns the platform-appropriate URL handler. Overridable in
+// tests so we can assert what we'd run without launching anything.
+var urlOpener = cmdutil.OpenVNCURL
+
+func newOpenVNCCmd() *cobra.Command {
+	var format string
+	c := &cobra.Command{
+		Use:   "open-vnc SESSION_ID",
+		Short: "Open a session's VNC endpoint in the OS-default viewer",
+		Long: `Hand the session's VNC URL to the operating system's default URL handler:
+
+  - macOS:    /usr/bin/open
+  - Linux:    xdg-open (must be installed; install x11-utils or similar)
+  - Windows:  cmd /c start
+
+The OS launches whatever app is registered for vnc:// (Screen Sharing on
+macOS by default; Remmina/Vinagre on Linux; a third-party client on Windows).
+
+The URL contains the ephemeral VNC password as a userinfo component. The
+URL is passed as an argv element to the OS handler, so it is briefly
+visible to other processes on the machine that can read this process's
+argv (e.g. ` + "`ps`" + `). On a single-user dev machine this is usually fine;
+on a shared host, prefer ` + "`rde session vnc`" + ` and paste the URL into your
+viewer manually.`,
+		Example: `  bitrise rde session open-vnc SESSION_ID
+  bitrise rde session open-vnc SESSION_ID --format json`,
+		Args: cmdutil.RequireArgs("SESSION_ID"),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cmdutil.LogCommandParameters(cmd)
+
+			if err := output.ConfigureOutputFormat(format); err != nil {
+				return fmt.Errorf("failed to configure output format: %w", err)
+			}
+
+			workspaceID, err := cmdutil.ResolveWorkspaceID(cmd)
+			if err != nil {
+				return err
+			}
+			client, err := cmdutil.NewRDEClient(cmd)
+			if err != nil {
+				return err
+			}
+			svc := internalrde.NewService(client)
+			sessionID, err := svc.ResolveSessionID(cmd.Context(), workspaceID, args[0])
+			if err != nil {
+				return err
+			}
+			creds, err := svc.GetSessionVNC(cmd.Context(), workspaceID, sessionID)
+			if err != nil {
+				return err
+			}
+			if err := urlOpener(cmd.Context(), creds.URL); err != nil {
+				return fmt.Errorf("open VNC URL: %w", err)
+			}
+			res := openVNCResult{Opened: true, Address: creds.Address, Username: creds.Username}
+			if output.Format != output.FormatRaw {
+				return output.Render(cmd.OutOrStdout(), output.Format, res, nil)
+			}
+			if !cmdutil.IsQuiet(cmd) {
+				_, err := fmt.Fprintf(cmd.ErrOrStderr(), "Opened VNC viewer for %s\n", creds.Address)
+				return err
+			}
+			return nil
+		},
+	}
+	c.Flags().StringVarP(&format, cmdutil.FormatKey, "f", "", "Output format. Accepted: raw (default), json, yml")
+	return c
+}

--- a/cli/rde/session/session_test.go
+++ b/cli/rde/session/session_test.go
@@ -82,6 +82,49 @@ func TestListCmd_LabelSelectorsQuery(t *testing.T) {
 	}
 }
 
+func TestListCmd_ScopeQuery(t *testing.T) {
+	var gotScope string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotScope = r.URL.Query().Get("scope")
+		_, _ = io.WriteString(w, `{"sessions":[]}`)
+	}))
+	defer srv.Close()
+
+	// Default scope is mine, sent as the backend's enum name.
+	if _, _, err := cmdtest.Run(t, newListCmd(), cmdtest.Opts{
+		RDEAPIBaseURL:      srv.URL,
+		DefaultWorkspaceID: "ws-1",
+	}); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if gotScope != "SESSION_LIST_SCOPE_MINE" {
+		t.Errorf("default scope = %q, want SESSION_LIST_SCOPE_MINE", gotScope)
+	}
+
+	if _, _, err := cmdtest.Run(t, newListCmd(), cmdtest.Opts{
+		RDEAPIBaseURL:      srv.URL,
+		DefaultWorkspaceID: "ws-1",
+		Args:               []string{"--scope", "workspace"},
+	}); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if gotScope != "SESSION_LIST_SCOPE_WORKSPACE" {
+		t.Errorf("scope = %q, want SESSION_LIST_SCOPE_WORKSPACE", gotScope)
+	}
+}
+
+func TestListCmd_InvalidScopeErrors(t *testing.T) {
+	// Validation happens before any HTTP call.
+	_, _, err := cmdtest.Run(t, newListCmd(), cmdtest.Opts{
+		RDEAPIBaseURL:      "http://unused",
+		DefaultWorkspaceID: "ws-1",
+		Args:               []string{"--scope", "everyone"},
+	})
+	if err == nil || !strings.Contains(err.Error(), "--scope") {
+		t.Errorf("error = %v, want scope validation error", err)
+	}
+}
+
 func TestListCmd_MalformedSelectorErrors(t *testing.T) {
 	_, _, err := cmdtest.Run(t, newListCmd(), cmdtest.Opts{
 		RDEAPIBaseURL:      "http://unused",

--- a/cli/rde/session/upload.go
+++ b/cli/rde/session/upload.go
@@ -1,0 +1,56 @@
+package session
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/bitrise-io/bitrise/v2/cli/cmdutil"
+	internalrde "github.com/bitrise-io/bitrise/v2/internal/rde"
+)
+
+func newUploadCmd() *cobra.Command {
+	c := &cobra.Command{
+		Use:   "upload SESSION_ID LOCAL_PATH REMOTE_FOLDER",
+		Short: "Upload a local file or directory into a session",
+		Long: `Upload a local file or directory into a running session.
+
+The local path is tarred + gzipped, uploaded to cloud storage via a signed
+URL, then extracted on the session VM at REMOTE_FOLDER.
+
+For directories: the directory's contents are extracted into REMOTE_FOLDER
+(not the directory itself).`,
+		Example: `  bitrise rde session upload SESSION_ID ./project /Users/vagrant/project
+  bitrise rde session upload SESSION_ID ./build.tar.gz /Users/vagrant/artifacts`,
+		Args: cmdutil.RequireArgs("SESSION_ID", "LOCAL_PATH", "REMOTE_FOLDER"),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cmdutil.LogCommandParameters(cmd)
+
+			sessionID, sourcePath, destFolder := args[0], args[1], args[2]
+			workspaceID, err := cmdutil.ResolveWorkspaceID(cmd)
+			if err != nil {
+				return err
+			}
+			client, err := cmdutil.NewRDEClient(cmd)
+			if err != nil {
+				return err
+			}
+			svc := internalrde.NewService(client)
+			sessionID, err = svc.ResolveSessionID(cmd.Context(), workspaceID, sessionID)
+			if err != nil {
+				return err
+			}
+			if !cmdutil.IsQuiet(cmd) {
+				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Uploading %s → %s on session %s…\n", sourcePath, destFolder, sessionID)
+			}
+			if err := svc.UploadFile(cmd.Context(), workspaceID, sessionID, sourcePath, destFolder); err != nil {
+				return err
+			}
+			if !cmdutil.IsQuiet(cmd) {
+				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Upload complete.\n")
+			}
+			return nil
+		},
+	}
+	return c
+}

--- a/cli/rde/session/vnc.go
+++ b/cli/rde/session/vnc.go
@@ -1,0 +1,140 @@
+package session
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"os/signal"
+	"strconv"
+
+	"github.com/spf13/cobra"
+
+	"github.com/bitrise-io/bitrise/v2/cli/cmdutil"
+	internalrde "github.com/bitrise-io/bitrise/v2/internal/rde"
+	"github.com/bitrise-io/bitrise/v2/output"
+)
+
+func newVNCCmd() *cobra.Command {
+	var forwardPort int
+	var format string
+	c := &cobra.Command{
+		Use:   "vnc SESSION_ID",
+		Short: "Print VNC connection details, or forward the endpoint to a local port",
+		Long: `Print the VNC connection details (address, host, port, username, password,
+and a ready-to-use vnc:// URL) for a session.
+
+The VNC password is ephemeral and tied to this session. Avoid pasting the
+output into chat or sharing it — anyone with the URL can connect to the
+session. ` + "`rde session view`" + ` and other commands intentionally hide it.
+
+In raw mode the URL is the only thing on stdout, so it's safe to pipe:
+
+  open "$(bitrise rde session vnc SESSION_ID)"
+
+In --format json/yml mode a fully-decomposed {address, host, port, username,
+password, url} object is emitted — host and port are always discrete fields,
+so a caller building its own connection never has to parse the address or URL.
+
+Pass --forward PORT to open an SSH tunnel and expose the session's VNC endpoint
+on a local port, then block until Ctrl-C (use 0 to auto-pick a free port):
+
+  bitrise rde session vnc SESSION_ID --forward 0      # auto-pick a local port
+  bitrise rde session vnc SESSION_ID --forward 5901   # bind localhost:5901
+
+A native VNC client (macOS Screen Sharing, Remmina, …) can then connect to the
+printed localhost address. The tunnel rides the same SSH connection the CLI
+already uses, so no direct network route to the session is required and no
+credentials are embedded in a URL handed to the OS. Prefer ` + "`rde session open-vnc`" + `
+when you just want to launch your viewer against a directly-reachable endpoint.`,
+		Example: `  bitrise rde session vnc SESSION_ID
+  bitrise rde session vnc SESSION_ID --format json
+  bitrise rde session vnc SESSION_ID --forward 5901
+  open "$(bitrise rde session vnc SESSION_ID)"`,
+		Args: cmdutil.RequireArgs("SESSION_ID"),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cmdutil.LogCommandParameters(cmd)
+
+			if err := output.ConfigureOutputFormat(format); err != nil {
+				return fmt.Errorf("failed to configure output format: %w", err)
+			}
+
+			workspaceID, err := cmdutil.ResolveWorkspaceID(cmd)
+			if err != nil {
+				return err
+			}
+			client, err := cmdutil.NewRDEClient(cmd)
+			if err != nil {
+				return err
+			}
+			// Reject the unsupported flag combo before resolving the name — no
+			// point in a lookup round-trip for a request we won't serve
+			// (mirrors `view --watch`). --forward runs a long-lived tunnel, not
+			// a single-object result, so it can't satisfy the machine-readable
+			// contract.
+			forwarding := cmd.Flags().Changed("forward")
+			if forwarding && output.Format != output.FormatRaw {
+				return fmt.Errorf("--forward cannot be combined with --format %s (it runs a long-lived tunnel, not a single-object result)", output.Format)
+			}
+
+			svc := internalrde.NewService(client)
+			sessionID, err := svc.ResolveSessionID(cmd.Context(), workspaceID, args[0])
+			if err != nil {
+				return err
+			}
+
+			if forwarding {
+				return runVNCForward(cmd, svc, workspaceID, sessionID, forwardPort)
+			}
+
+			creds, err := svc.GetSessionVNC(cmd.Context(), workspaceID, sessionID)
+			if err != nil {
+				return err
+			}
+			return output.Render(cmd.OutOrStdout(), output.Format, creds, renderVNCCredentials)
+		},
+	}
+	c.Flags().IntVar(&forwardPort, "forward", 0,
+		"forward the session's VNC endpoint to this local port, then block until Ctrl-C; use 0 to auto-pick a free port")
+	c.Flags().StringVarP(&format, cmdutil.FormatKey, "f", "", "Output format. Accepted: raw (default), json, yml")
+	return c
+}
+
+// runVNCForward opens the local-port tunnel and blocks until Ctrl-C. It prints
+// the ready-to-use local vnc:// URL on stdout (one line, same as the non-forward
+// path) and a human status on stderr.
+func runVNCForward(cmd *cobra.Command, svc *internalrde.Service, workspaceID, sessionID string, localPort int) error {
+	// Ctrl-C cancels the tunnel and returns cleanly rather than hard-killing.
+	ctx, stop := signal.NotifyContext(cmd.Context(), os.Interrupt)
+	defer stop()
+
+	// onReady fires once the local listener is up; ForwardVNC hands back the
+	// session's credentials (fetched exactly once, service-side) so the printed
+	// URL points at the local address.
+	onReady := func(localAddr string, creds internalrde.VNCCredentials) {
+		line := localAddr
+		if host, portStr, splitErr := net.SplitHostPort(localAddr); splitErr == nil {
+			if p, atoiErr := strconv.Atoi(portStr); atoiErr == nil {
+				line = internalrde.FormatVNCURL(host, p, creds.Username, creds.Password)
+			}
+		}
+		_, _ = fmt.Fprintln(cmd.OutOrStdout(), line)
+		if !cmdutil.IsQuiet(cmd) {
+			_, _ = fmt.Fprintf(cmd.ErrOrStderr(),
+				"Forwarding the session's VNC endpoint to %s — connect your VNC client there. Press Ctrl-C to stop.\n", localAddr)
+		}
+	}
+
+	if err := svc.ForwardVNC(ctx, workspaceID, sessionID, localPort, onReady); err != nil {
+		return err
+	}
+	if !cmdutil.IsQuiet(cmd) {
+		_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "Stopped forwarding.")
+	}
+	return nil
+}
+
+func renderVNCCredentials(w io.Writer, creds internalrde.VNCCredentials) error {
+	_, err := fmt.Fprintln(w, creds.URL)
+	return err
+}

--- a/cli/rde/session/vnc_test.go
+++ b/cli/rde/session/vnc_test.go
@@ -1,0 +1,241 @@
+package session
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/bitrise-io/bitrise/v2/cli/cmdtest"
+	internalrde "github.com/bitrise-io/bitrise/v2/internal/rde"
+	"github.com/bitrise-io/bitrise/v2/output"
+)
+
+func TestVNCCmd_HumanPrintsOnlyURL(t *testing.T) {
+	// Raw mode emits a single line (the vnc:// URL) so callers can pipe
+	// it into `open` or another launcher without parsing.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `{"session":{
+			"id":"s-1","name":"dev","status":"SESSION_STATUS_RUNNING",
+			"vncAddress":"host.example:5901","vncUsername":"vagrant","vncPassword":"pw@with:special"
+		}}`)
+	}))
+	defer srv.Close()
+
+	stdout, _, err := cmdtest.Run(t, newVNCCmd(), cmdtest.Opts{RDEAPIBaseURL: srv.URL, DefaultWorkspaceID: "ws-1", Args: []string{uuidSession}})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	got := strings.TrimSpace(stdout)
+	want := "vnc://vagrant:pw%40with%3Aspecial@host.example:5901"
+	if got != want {
+		t.Errorf("stdout = %q, want exactly %q", got, want)
+	}
+}
+
+func TestVNCCmd_JSONIncludesPassword(t *testing.T) {
+	// The dedicated vnc subcommand exists *because* the password is needed.
+	// Its JSON shape includes it. The stable view-JSON contract does NOT —
+	// that's covered by TestViewCmd_JSONOmitsVNCPassword below.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `{"session":{
+			"id":"s-1","name":"dev","status":"SESSION_STATUS_RUNNING",
+			"vncAddress":"vnc://host.example:5900","vncUsername":"vagrant","vncPassword":"hunter2"
+		}}`)
+	}))
+	defer srv.Close()
+
+	stdout, _, err := cmdtest.Run(t, newVNCCmd(), cmdtest.Opts{RDEAPIBaseURL: srv.URL, DefaultWorkspaceID: "ws-1", Format: output.FormatJSON, Args: []string{uuidSession}})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	var got internalrde.VNCCredentials
+	if err := json.Unmarshal([]byte(stdout), &got); err != nil {
+		t.Fatalf("unmarshal JSON output: %v\n%s", err, stdout)
+	}
+	if got.Username != "vagrant" || got.Password != "hunter2" {
+		t.Errorf("credentials = %+v, want vagrant/hunter2", got)
+	}
+	if !strings.Contains(got.URL, "hunter2") {
+		t.Errorf("url %q should embed the password", got.URL)
+	}
+}
+
+func TestVNCCmd_JSONIncludesHostPort(t *testing.T) {
+	// The decomposed host/port fields let a caller build its own connection
+	// without ever parsing `address` or the URL.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `{"session":{
+			"id":"s-1","name":"dev","status":"SESSION_STATUS_RUNNING",
+			"vncAddress":"host.example:5901","vncUsername":"vagrant","vncPassword":"hunter2"
+		}}`)
+	}))
+	defer srv.Close()
+
+	stdout, _, err := cmdtest.Run(t, newVNCCmd(), cmdtest.Opts{RDEAPIBaseURL: srv.URL, DefaultWorkspaceID: "ws-1", Format: output.FormatJSON, Args: []string{uuidSession}})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	var got internalrde.VNCCredentials
+	if err := json.Unmarshal([]byte(stdout), &got); err != nil {
+		t.Fatalf("unmarshal JSON output: %v\n%s", err, stdout)
+	}
+	if got.Host != "host.example" || got.Port != 5901 {
+		t.Errorf("host/port = %q/%d, want host.example/5901", got.Host, got.Port)
+	}
+}
+
+func TestVNCCmd_ForwardRejectsMachineReadableOutput(t *testing.T) {
+	// --forward is a long-lived tunnel; it can't satisfy the single-object
+	// contract, so the combination is rejected before any network call —
+	// including the session-name lookup. A bare name argument (not a UUID)
+	// would otherwise resolve via ListSessions first, so exercising it here
+	// pins the rejection ahead of name resolution. Covers both machine
+	// formats, not just json.
+	for _, format := range []string{output.FormatJSON, output.FormatYML} {
+		for _, arg := range []string{uuidSession, "my-session"} {
+			t.Run(format+"/"+arg, func(t *testing.T) {
+				srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+					t.Error("no HTTP call should be made when --forward is rejected for a machine-readable format")
+				}))
+				defer srv.Close()
+
+				_, _, err := cmdtest.Run(t, newVNCCmd(), cmdtest.Opts{
+					RDEAPIBaseURL:      srv.URL,
+					DefaultWorkspaceID: "ws-1",
+					Format:             format,
+					Args:               []string{arg, "--forward", "5901"},
+				})
+				if err == nil || !strings.Contains(err.Error(), "--forward cannot be combined with --format") {
+					t.Errorf("err = %v, want --forward/--format rejection", err)
+				}
+			})
+		}
+	}
+}
+
+func TestVNCCmd_NoEndpointError(t *testing.T) {
+	// A session with no vncAddress (e.g. a Linux template that doesn't
+	// expose VNC, or one still provisioning) must error rather than print
+	// an empty/half-baked URL.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `{"session":{"id":"s-1","name":"dev","status":"SESSION_STATUS_RUNNING"}}`)
+	}))
+	defer srv.Close()
+
+	_, _, err := cmdtest.Run(t, newVNCCmd(), cmdtest.Opts{RDEAPIBaseURL: srv.URL, DefaultWorkspaceID: "ws-1", Args: []string{uuidSession}})
+	if err == nil || !strings.Contains(err.Error(), "VNC") {
+		t.Errorf("err = %v, want a VNC-not-available error", err)
+	}
+}
+
+func TestViewCmd_JSONOmitsVNCPassword(t *testing.T) {
+	// Companion to view's SSH-password omission check. The view JSON
+	// contract must never leak the VNC password — users who need it call
+	// `session vnc` explicitly.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `{"session":{
+			"id":"s-1","name":"dev","status":"SESSION_STATUS_RUNNING",
+			"vncAddress":"h:5900","vncUsername":"u","vncPassword":"vnchunter2"
+		}}`)
+	}))
+	defer srv.Close()
+
+	stdout, _, err := cmdtest.Run(t, newViewCmd(), cmdtest.Opts{RDEAPIBaseURL: srv.URL, DefaultWorkspaceID: "ws-1", Format: output.FormatJSON, Args: []string{uuidSession}})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if strings.Contains(stdout, "vnchunter2") || strings.Contains(stdout, "vnc_password") {
+		t.Errorf("VNC password leaked into view JSON:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, "vnc_address") {
+		t.Errorf("vnc_address missing from view JSON:\n%s", stdout)
+	}
+}
+
+func TestOpenVNCCmd_HandsURLToOpener(t *testing.T) {
+	// Capture what we'd pass to the OS handler without actually shelling
+	// out. The URL must carry the password (so the OS handler can pass it
+	// to the VNC client); stdout must stay empty in raw mode so the
+	// password never lands in shell history / scrollback.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `{"session":{
+			"id":"s-1","name":"dev","status":"SESSION_STATUS_RUNNING",
+			"vncAddress":"host.example:5900","vncUsername":"vagrant","vncPassword":"hunter2"
+		}}`)
+	}))
+	defer srv.Close()
+
+	var gotURL string
+	prev := urlOpener
+	urlOpener = func(_ context.Context, url string) error { gotURL = url; return nil }
+	defer func() { urlOpener = prev }()
+
+	stdout, stderr, err := cmdtest.Run(t, newOpenVNCCmd(), cmdtest.Opts{RDEAPIBaseURL: srv.URL, DefaultWorkspaceID: "ws-1", Args: []string{uuidSession}})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	wantURL := "vnc://vagrant:hunter2@host.example:5900"
+	if gotURL != wantURL {
+		t.Errorf("opener got URL %q", gotURL)
+	}
+	if strings.TrimSpace(stdout) != "" {
+		t.Errorf("raw stdout should be empty (no password leakage), got:\n%s", stdout)
+	}
+	if !strings.Contains(stderr, "Opened VNC viewer") {
+		t.Errorf("stderr missing confirmation line:\n%s", stderr)
+	}
+}
+
+func TestOpenVNCCmd_JSONOmitsPassword(t *testing.T) {
+	// JSON mode is the same: confirmation envelope only, no password.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `{"session":{
+			"id":"s-1","name":"dev","status":"SESSION_STATUS_RUNNING",
+			"vncAddress":"h:5900","vncUsername":"u","vncPassword":"hunter2"
+		}}`)
+	}))
+	defer srv.Close()
+
+	prev := urlOpener
+	urlOpener = func(_ context.Context, _ string) error { return nil }
+	defer func() { urlOpener = prev }()
+
+	stdout, _, err := cmdtest.Run(t, newOpenVNCCmd(), cmdtest.Opts{RDEAPIBaseURL: srv.URL, DefaultWorkspaceID: "ws-1", Format: output.FormatJSON, Args: []string{uuidSession}})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if strings.Contains(stdout, "hunter2") || strings.Contains(stdout, "password") {
+		t.Errorf("password leaked into open-vnc JSON:\n%s", stdout)
+	}
+	var got openVNCResult
+	if err := json.Unmarshal([]byte(stdout), &got); err != nil {
+		t.Fatalf("unmarshal JSON output: %v\n%s", err, stdout)
+	}
+	if !got.Opened || got.Address != "h:5900" || got.Username != "u" {
+		t.Errorf("unexpected JSON: %+v", got)
+	}
+}
+
+func TestOpenVNCCmd_OpenerErrorSurfaces(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `{"session":{
+			"id":"s-1","name":"dev","status":"SESSION_STATUS_RUNNING",
+			"vncAddress":"h:5900","vncUsername":"u","vncPassword":"pw"
+		}}`)
+	}))
+	defer srv.Close()
+
+	prev := urlOpener
+	urlOpener = func(_ context.Context, _ string) error { return errors.New("xdg-open not found") }
+	defer func() { urlOpener = prev }()
+
+	_, _, err := cmdtest.Run(t, newOpenVNCCmd(), cmdtest.Opts{RDEAPIBaseURL: srv.URL, DefaultWorkspaceID: "ws-1", Args: []string{uuidSession}})
+	if err == nil || !strings.Contains(err.Error(), "xdg-open") {
+		t.Errorf("err = %v, want opener error to surface", err)
+	}
+}

--- a/internal/rde/service_test.go
+++ b/internal/rde/service_test.go
@@ -16,11 +16,11 @@ import (
 
 func TestListSessions_PathAuthAndStatusMapping(t *testing.T) {
 	rs := newRecordingServer(t, `{"sessions":[
-		{"id":"s1","name":"dev","status":"SESSION_STATUS_RUNNING","templateSnapshot":{"templateName":"tmpl"},"labels":{"team":"mobile"}},
+		{"id":"s1","name":"dev","status":"SESSION_STATUS_RUNNING","templateSnapshot":{"templateName":"tmpl"},"labels":{"team":"mobile"},"ownerType":"workspace","ownerId":"my-ws"},
 		{"id":"s2","name":"old","status":"SESSION_STATUS_TERMINATED"}
 	]}`)
 
-	sessions, err := rs.service().ListSessions(context.Background(), "ws-1", nil)
+	sessions, err := rs.service().ListSessions(context.Background(), "ws-1", nil, "")
 	if err != nil {
 		t.Fatalf("ListSessions: %v", err)
 	}
@@ -48,15 +48,33 @@ func TestListSessions_PathAuthAndStatusMapping(t *testing.T) {
 	if sessions[0].Labels["team"] != "mobile" {
 		t.Errorf("labels[0] = %v, want team=mobile", sessions[0].Labels)
 	}
+	// Owner fields pass through verbatim — no enum-prefix mapping.
+	if sessions[0].OwnerType != "workspace" || sessions[0].OwnerID != "my-ws" {
+		t.Errorf("owner[0] = %q/%q, want workspace/my-ws", sessions[0].OwnerType, sessions[0].OwnerID)
+	}
+	if sessions[1].OwnerType != "" || sessions[1].OwnerID != "" {
+		t.Errorf("owner[1] = %q/%q, want empty", sessions[1].OwnerType, sessions[1].OwnerID)
+	}
 }
 
 func TestListSessions_LabelSelectorsPassThrough(t *testing.T) {
 	rs := newRecordingServer(t, `{"sessions":[]}`)
 
-	if _, err := rs.service().ListSessions(context.Background(), "ws-1", []string{"team=mobile"}); err != nil {
+	if _, err := rs.service().ListSessions(context.Background(), "ws-1", []string{"team=mobile"}, ""); err != nil {
 		t.Fatalf("ListSessions: %v", err)
 	}
 	if want := "labelSelectors=team%3Dmobile"; rs.lastQuery != want {
+		t.Errorf("query = %q, want %q", rs.lastQuery, want)
+	}
+}
+
+func TestListSessions_ScopePassThrough(t *testing.T) {
+	rs := newRecordingServer(t, `{"sessions":[]}`)
+
+	if _, err := rs.service().ListSessions(context.Background(), "ws-1", nil, SessionScopeWorkspace); err != nil {
+		t.Fatalf("ListSessions: %v", err)
+	}
+	if want := "scope=SESSION_LIST_SCOPE_WORKSPACE"; rs.lastQuery != want {
 		t.Errorf("query = %q, want %q", rs.lastQuery, want)
 	}
 }
@@ -407,7 +425,7 @@ func TestResolveSessionID_NoMatchError(t *testing.T) {
 
 func TestNilClientGuards(t *testing.T) {
 	svc := NewService(nil)
-	if _, err := svc.ListSessions(context.Background(), "ws", nil); err == nil {
+	if _, err := svc.ListSessions(context.Background(), "ws", nil, ""); err == nil {
 		t.Error("ListSessions with nil client should error")
 	}
 	if _, err := svc.ListSavedInputs(context.Background()); err == nil {

--- a/internal/rde/session.go
+++ b/internal/rde/session.go
@@ -44,8 +44,16 @@ type Session struct {
 	VNCPassword          string            `json:"-" yaml:"-"`
 	PersistentDiskStatus string            `json:"persistent_disk_status,omitempty" yaml:"persistent_disk_status,omitempty"`
 	Labels               map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`
-	CreatedAt            *time.Time        `json:"created_at,omitempty" yaml:"created_at,omitempty"`
-	UpdatedAt            *time.Time        `json:"updated_at,omitempty" yaml:"updated_at,omitempty"`
+	// OwnerType says who owns the session: "user" (the creating user; the
+	// default) or "workspace" (the workspace itself — visible to every
+	// member of the workspace). Passed through verbatim so future owner
+	// kinds reach callers without a CLI change.
+	OwnerType string `json:"owner_type,omitempty" yaml:"owner_type,omitempty"`
+	// OwnerID is the owner's identifier, typed by OwnerType: the owning
+	// user's ID for "user", the workspace slug for "workspace".
+	OwnerID   string     `json:"owner_id,omitempty" yaml:"owner_id,omitempty"`
+	CreatedAt *time.Time `json:"created_at,omitempty" yaml:"created_at,omitempty"`
+	UpdatedAt *time.Time `json:"updated_at,omitempty" yaml:"updated_at,omitempty"`
 }
 
 // Resumable reports whether `rde claude` can resume this session: a running
@@ -149,14 +157,24 @@ type CreateSessionResult struct {
 	AutoMappedInputs []AutoMappedInput `json:"auto_mapped_inputs,omitempty" yaml:"auto_mapped_inputs,omitempty"`
 }
 
-// ListSessions returns the caller's sessions in the workspace, optionally
-// filtered by label selectors ("key=value" exact matches, ANDed). Pass nil
-// for the full list.
-func (s *Service) ListSessions(ctx context.Context, workspaceID string, labelSelectors []string) ([]Session, error) {
+// Session list scopes accepted by ListSessions' scope argument (and the
+// `session list --scope` flag). Empty means the backend default, which is
+// SessionScopeMine.
+const (
+	SessionScopeMine      = "mine"
+	SessionScopeWorkspace = "workspace"
+)
+
+// ListSessions returns sessions in the workspace, optionally filtered by
+// label selectors ("key=value" exact matches, ANDed) — pass nil for the full
+// list. scope selects whose sessions are listed: SessionScopeMine (the
+// caller's own; also the backend default when empty) or SessionScopeWorkspace
+// (sessions owned by the workspace itself, visible to every member).
+func (s *Service) ListSessions(ctx context.Context, workspaceID string, labelSelectors []string, scope string) ([]Session, error) {
 	if s.client == nil {
 		return nil, errClient()
 	}
-	wire, err := s.client.ListSessions(ctx, workspaceID, labelSelectors)
+	wire, err := s.client.ListSessions(ctx, workspaceID, labelSelectors, scope)
 	if err != nil {
 		return nil, err
 	}
@@ -186,6 +204,9 @@ func (s *Service) GetSession(ctx context.Context, workspaceID, sessionID string)
 // Session names aren't unique (unlike a UUID), so an ambiguous match is an
 // expected outcome — the error lists the candidate IDs so the user can re-run
 // with the exact one. Mirrors ResolveTemplateID.
+//
+// Names resolve against the default scope only (the caller's own sessions);
+// workspace-owned sessions are addressed by ID.
 func (s *Service) ResolveSessionID(ctx context.Context, workspaceID, value string) (string, error) {
 	if value == "" {
 		return "", fmt.Errorf("session is required")
@@ -193,7 +214,7 @@ func (s *Service) ResolveSessionID(ctx context.Context, workspaceID, value strin
 	if looksLikeUUID(value) {
 		return value, nil
 	}
-	sessions, err := s.ListSessions(ctx, workspaceID, nil)
+	sessions, err := s.ListSessions(ctx, workspaceID, nil, "")
 	if err != nil {
 		return "", fmt.Errorf("list sessions to resolve %q: %w", value, err)
 	}
@@ -574,6 +595,8 @@ func sessionFromAPI(w rdeapi.Session) Session {
 		VNCPassword:          w.VNCPassword,
 		PersistentDiskStatus: diskStatusFromAPI(w.PersistentDiskStatus),
 		Labels:               w.Labels,
+		OwnerType:            w.OwnerType,
+		OwnerID:              w.OwnerID,
 	}
 	out.AgentSessionStatusUpdatedAt = parseTime(w.AgentSessionStatusUpdatedAt)
 	out.AutoTerminateAt = parseTime(w.AutoTerminateAt)

--- a/internal/rdeapi/sessions.go
+++ b/internal/rdeapi/sessions.go
@@ -32,8 +32,16 @@ type Session struct {
 	VNCPassword                 string                   `json:"vncPassword,omitempty"`
 	PersistentDiskStatus        string                   `json:"persistentDiskStatus,omitempty"`
 	Labels                      map[string]string        `json:"labels,omitempty"`
-	CreatedAt                   string                   `json:"createdAt,omitempty"`
-	UpdatedAt                   string                   `json:"updatedAt,omitempty"`
+	// OwnerType says who owns the session: "user" (the creating user; the
+	// default) or "workspace" (the workspace itself — such sessions are
+	// visible to every member of the workspace). The backend may add more
+	// owner kinds over time, so treat unknown values as opaque.
+	OwnerType string `json:"ownerType,omitempty"`
+	// OwnerID is the owner's identifier, typed by OwnerType: the owning
+	// user's ID for "user", the workspace slug for "workspace".
+	OwnerID   string `json:"ownerId,omitempty"`
+	CreatedAt string `json:"createdAt,omitempty"`
+	UpdatedAt string `json:"updatedAt,omitempty"`
 }
 
 // SessionTemplateSnapshot is the template config snapshotted at session
@@ -205,23 +213,35 @@ func (c *Client) CompareSessionTemplate(ctx context.Context, workspaceID, sessio
 	return resp, nil
 }
 
-// ListSessions returns the caller's sessions in the workspace. Each
-// labelSelectors entry is a "key=value" exact-match label filter; multiple
-// selectors are ANDed and passed through verbatim as repeated query params
-// (the backend validates them: key=value form, at most 8, no duplicate
-// keys).
+// ListSessions returns sessions in the workspace. Each labelSelectors entry
+// is a "key=value" exact-match label filter; multiple selectors are ANDed and
+// passed through verbatim as repeated query params (the backend validates
+// them: key=value form, at most 8, no duplicate keys).
+//
+// scope selects whose sessions are listed: "mine" (sessions the caller
+// created; also the backend default when empty) or "workspace" (sessions
+// owned by the workspace itself, visible to every member of the workspace).
+// The value is translated to the backend's enum name; anything else is
+// omitted so the backend default applies — mirrors how
+// ListSessionNotifications handles order.
 // Endpoint: GET /v1/workspaces/{workspaceId}/sessions.
-func (c *Client) ListSessions(ctx context.Context, workspaceID string, labelSelectors []string) ([]Session, error) {
+func (c *Client) ListSessions(ctx context.Context, workspaceID string, labelSelectors []string, scope string) ([]Session, error) {
 	if workspaceID == "" {
 		return nil, fmt.Errorf("workspace ID is required")
 	}
 	p := wsPath(workspaceID, "/sessions")
-	if len(labelSelectors) > 0 {
-		q := url.Values{}
-		for _, sel := range labelSelectors {
-			q.Add("labelSelectors", sel)
-		}
-		p += "?" + q.Encode()
+	q := url.Values{}
+	for _, sel := range labelSelectors {
+		q.Add("labelSelectors", sel)
+	}
+	switch scope {
+	case "mine":
+		q.Set("scope", "SESSION_LIST_SCOPE_MINE")
+	case "workspace":
+		q.Set("scope", "SESSION_LIST_SCOPE_WORKSPACE")
+	}
+	if encoded := q.Encode(); encoded != "" {
+		p += "?" + encoded
 	}
 	var resp listSessionsResp
 	if err := c.getJSON(ctx, p, &resp); err != nil {

--- a/internal/rdeapi/sessions_test.go
+++ b/internal/rdeapi/sessions_test.go
@@ -9,11 +9,11 @@ import (
 
 func TestListSessions_PathAndParse(t *testing.T) {
 	rs := newRecordingServer(t, `{"sessions":[
-		{"id":"s1","name":"dev","status":"SESSION_STATUS_RUNNING","templateSnapshot":{"templateName":"tmpl","stackId":"osx-xcode-16.0.x-edge"},"labels":{"team":"mobile"}},
+		{"id":"s1","name":"dev","status":"SESSION_STATUS_RUNNING","templateSnapshot":{"templateName":"tmpl","stackId":"osx-xcode-16.0.x-edge"},"labels":{"team":"mobile"},"ownerType":"workspace","ownerId":"my-ws"},
 		{"id":"s2","name":"old","status":"SESSION_STATUS_TERMINATED"}
 	]}`)
 
-	sessions, err := rs.client().ListSessions(context.Background(), "ws-1", nil)
+	sessions, err := rs.client().ListSessions(context.Background(), "ws-1", nil, "")
 	if err != nil {
 		t.Fatalf("ListSessions: %v", err)
 	}
@@ -39,18 +39,49 @@ func TestListSessions_PathAndParse(t *testing.T) {
 	if sessions[0].Labels["team"] != "mobile" {
 		t.Errorf("labels = %v, want team=mobile", sessions[0].Labels)
 	}
+	if sessions[0].OwnerType != "workspace" || sessions[0].OwnerID != "my-ws" {
+		t.Errorf("owner = %q/%q, want workspace/my-ws", sessions[0].OwnerType, sessions[0].OwnerID)
+	}
 }
 
 func TestListSessions_LabelSelectorsQuery(t *testing.T) {
 	rs := newRecordingServer(t, `{"sessions":[]}`)
 
-	if _, err := rs.client().ListSessions(context.Background(), "ws-1", []string{"team=mobile", "branch=main"}); err != nil {
+	if _, err := rs.client().ListSessions(context.Background(), "ws-1", []string{"team=mobile", "branch=main"}, ""); err != nil {
 		t.Fatalf("ListSessions: %v", err)
 	}
 	// One repeated labelSelectors param per selector, "=" percent-encoded,
 	// order preserved (grpc-gateway maps them onto the repeated proto field).
 	if want := "labelSelectors=team%3Dmobile&labelSelectors=branch%3Dmain"; rs.lastQuery != want {
 		t.Errorf("query = %s, want %s", rs.lastQuery, want)
+	}
+}
+
+func TestListSessions_ScopeQuery(t *testing.T) {
+	rs := newRecordingServer(t, `{"sessions":[]}`)
+
+	// Scope is translated to the backend's enum name.
+	if _, err := rs.client().ListSessions(context.Background(), "ws-1", nil, "workspace"); err != nil {
+		t.Fatalf("ListSessions: %v", err)
+	}
+	if want := "scope=SESSION_LIST_SCOPE_WORKSPACE"; rs.lastQuery != want {
+		t.Errorf("query = %q, want %q", rs.lastQuery, want)
+	}
+
+	// Scope combines with label selectors (Encode sorts by key).
+	if _, err := rs.client().ListSessions(context.Background(), "ws-1", []string{"team=mobile"}, "mine"); err != nil {
+		t.Fatalf("ListSessions: %v", err)
+	}
+	if want := "labelSelectors=team%3Dmobile&scope=SESSION_LIST_SCOPE_MINE"; rs.lastQuery != want {
+		t.Errorf("query = %q, want %q", rs.lastQuery, want)
+	}
+
+	// Unknown scopes are omitted so the backend default applies.
+	if _, err := rs.client().ListSessions(context.Background(), "ws-1", nil, "everyone"); err != nil {
+		t.Fatalf("ListSessions: %v", err)
+	}
+	if rs.lastQuery != "" {
+		t.Errorf("query = %q, want none for unknown scope", rs.lastQuery)
 	}
 }
 
@@ -320,7 +351,7 @@ func TestSessions_ValidationGuards(t *testing.T) {
 	ctx := context.Background()
 
 	cases := map[string]func() error{
-		"ListSessions/no-ws":           func() error { _, err := c.ListSessions(ctx, "", nil); return err },
+		"ListSessions/no-ws":           func() error { _, err := c.ListSessions(ctx, "", nil, ""); return err },
 		"GetSession/no-ws":             func() error { _, err := c.GetSession(ctx, "", "s1"); return err },
 		"GetSession/no-session":        func() error { _, err := c.GetSession(ctx, "ws", ""); return err },
 		"CreateSession/no-ws":          func() error { _, _, err := c.CreateSession(ctx, "", CreateSessionRequest{}); return err },


### PR DESCRIPTION
Adds exec, logs, upload, download, vnc, and open-vnc to `rde session` — everything that reaches the remote machine over SSH or transfers files. Pure CLI-layer port on top of internal/rde's Execute/StreamSessionLogs/ ForwardVNC/UploadFile/DownloadFile/GetSessionVNC (all landed in PRs 7-8).

Translated the reference's format == JSON checks to format != FormatRaw throughout, since this repo has a third machine-readable format (yml) the reference doesn't: exec's structured-vs-streamed render branch, the vnc --forward / session logs machine-readable rejections (both now reject yml too, not just json), and open-vnc's render-vs-breadcrumb branch.

Not verified against a real RDE session in this environment: exec's SSH dial, logs --follow, upload/download's tar+signed-URL transfer, and vnc's tunnel/forward path have no automated coverage by design (the reference implementation has none either — there's no fake SSH server anywhere in this migration). The ported tests are careful to only exercise paths that error out before any real SSH dial (a terminated session, a missing VNC endpoint, or a pre-network format rejection), matching the reference's own test design. Someone with access to a live session should still spot check exec/logs/upload/download/vnc manually before this ships.

Also carries an upstream change to the reference implementation that landed after PRs 5-12 were written, so the merged CLI doesn't regress a shipped feature — `rde session list --scope`. It reaches outside this PR's stated scope (internal/rdeapi, internal/rde) because that's where the layers live; keeping it here rather than amending the already-open PRs 6/7/10 was deliberate. The backend can list sessions owned by the workspace itself — for example sessions spawned by workspace device-preview links, visible to every workspace member — alongside the caller's own, and reports each session's owner:

- internal/rdeapi: ListSessions takes a scope ("mine" / "workspace"), translated to the backend's enum name in the query string and omitted when empty so the backend default applies; the Session wire type gains ownerType / ownerId.
- internal/rde: Service.ListSessions threads the scope through; the stable Session json/yml shape additively gains owner_type / owner_id (existing fields unchanged). Name resolution keeps using the default scope — workspace-owned sessions are addressed by ID.
- cli/rde/session: `session list` gains --scope mine|workspace (default mine), validated before the workspace lookup, with shell completion; the default table is unchanged — owner info surfaces in json/yml.