### PR TITLE
Update Mise version

### DIFF
--- a/toolprovider/mise/mise.go
+++ b/toolprovider/mise/mise.go
@@ -25,22 +25,22 @@ import (
 // 3. Verify checksums
 // 4. Update version string and checksums below
 // 5. IMPORTANT, DO NOT FORGET: Mirror artifacts to GCS bucket (see bootstrap.go) in case github.com goes down
-const misePreviewVersion = "v2026.5.12"
+const misePreviewVersion = "v2026.9.1"
 
 var misePreviewChecksums = map[string]string{
+	"linux-x64":   "063dda9149ab6be53da877c2d176afe0eac68e64cf8ca295bd0528720701c65d",
+	"linux-arm64": "98d2ea7b82dd966afdb8a9f4e9edbca771acf2a30d2842bfc0efdb7b61c886a3",
+	"macos-x64":   "eed76838c68aa49b7bf07c468dd4993855bbb342a4442f67355b6ffbe746e4d4",
+	"macos-arm64": "bfea0ab417b48c1e8b99412fcaf20ce17424a3286a8766d7d2b0051fe321d565",
+}
+
+const miseStableVersion = "v2026.5.12"
+
+var miseStableChecksums = map[string]string{
 	"linux-x64":   "bd0930c0b619f51ddb60e32e5cce18a5533567b2f1ba9fc4875b9f39a2bb3ed8",
 	"linux-arm64": "67c2bd96da9c6da030db4174b2dd0f8e6636c25519b23a15f0b734556e6e5ee0",
 	"macos-x64":   "dcab53de40bbd42c10607d64081e9df328c4885db30b41c4421f27e18b8f7efa",
 	"macos-arm64": "5b883c868a0748dd0c595d30fd000ec5138dfabdeef2c30222866ebf34af1ae3",
-}
-
-const miseStableVersion = "v2026.3.16"
-
-var miseStableChecksums = map[string]string{
-	"linux-x64":   "96417e479462d9a1836654461ec4b86eba8ff4f12260c09b93800fd50c25490c",
-	"linux-arm64": "6e0362723bddec3b25923a6c7c447c3f10eba4bf6e3db6973e175fa0a60ab974",
-	"macos-x64":   "a6f6f320b547dec3eff321e301fa05268dfc73a620d35ec3292603fbab1c4c29",
-	"macos-arm64": "9d6e2bfea3e00ffb566ad1a369914cb029c32a28eb4b699e8655cf3c3d4ef87e",
 }
 
 var KnownGitHubTokenEnvVars = []string{


### PR DESCRIPTION
## Summary
- Bumps `misePreviewVersion` from `v2026.5.12` to `v2026.9.1` (latest jdx/mise release), with checksums re-verified against upstream `SHASUMS256.txt` and artifacts mirrored to `gs://mise-release-mirror/v2026.9.1/`.
- Promotes the previous preview (`v2026.5.12`, already verified/mirrored) to `miseStableVersion`, replacing `v2026.3.16`.

## Risk assessment: High
Across the 56 releases in range `(v2026.5.12, v2026.9.1]` there are 6 sections explicitly titled "Breaking Changes". None affect the mise subcommands this repo invokes directly (`env`, `install`, `latest`, `ls`, `ls-remote`, `settings`, `plugins`, `registry`) — none of these were removed or renamed.

Notable changelog items:
- Node/Swift signature verification is now built-in (pure-Rust rPGP) and always runs when enabled, no longer silently skipped when the external `gpg` binary is missing. Opt out via `gpg_verify = false` if needed. ([jdx/mise#11148](https://github.com/jdx/mise/pull/11148))
- `mise oci push --tool` removed (not used here).
- `conf.d` fragment filename interpretation changed for dotted names like `node.tools.toml` (not used here).
- Minimum Rust version for building from source raised to 1.95; `mise completion` flag changes (build-time only, not used here).
- No related open issues found in `bitrise-io/bitrise` for any of the flagged items.

## Test plan
- [x] `go build ./toolprovider/...` succeeds
- [x] SHA-256 checksums for all 4 platform artifacts verified against upstream `SHASUMS256.txt`
- [x] All 4 platform artifacts confirmed present in `gs://mise-release-mirror/v2026.9.1/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)