### PR TITLE
RDE 13 - rde template, rde saved-input commands

### DIFF
--- a/cli/cmdutil/secret.go
+++ b/cli/cmdutil/secret.go
@@ -39,6 +39,17 @@ func CheckPasswordStdinPiped(passwordStdin, isTerminal bool, exampleCmd string) 
 	return nil
 }
 
+// CheckValueStdinPiped is CheckPasswordStdinPiped's counterpart for commands
+// whose stdin secret arrives under --value-stdin (`rde saved-input`). Same
+// hazard, same shape — only the flag and the prose differ, so they stay as two
+// literal messages rather than one parameterized template.
+func CheckValueStdinPiped(valueStdin, isTerminal bool, exampleCmd string) error {
+	if valueStdin && isTerminal {
+		return fmt.Errorf("--value-stdin requires piped stdin (got an interactive terminal); pipe the value in, e.g.:\n  printf '%%s' \"$VALUE\" | %s --value-stdin", exampleCmd)
+	}
+	return nil
+}
+
 func readSecretInput(in io.Reader, stderr io.Writer, prompt string, fromStdin bool, trim func(string) string) (string, error) {
 	if fd, ok := TerminalFd(in); ok && !fromStdin {
 		if _, err := fmt.Fprint(stderr, prompt); err != nil {

--- a/cli/cmdutil/secret_test.go
+++ b/cli/cmdutil/secret_test.go
@@ -91,6 +91,25 @@ func TestCheckPasswordStdinPiped_ErrorsWhenTerminal(t *testing.T) {
 	}
 }
 
+func TestCheckValueStdinPiped(t *testing.T) {
+	err := CheckValueStdinPiped(true, true, "bitrise rde saved-input create --key <key>")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "--value-stdin requires piped stdin") {
+		t.Fatalf("error %q does not mention piped stdin", err.Error())
+	}
+	if !strings.Contains(err.Error(), "bitrise rde saved-input create --key <key> --value-stdin") {
+		t.Fatalf("error %q does not include the example command", err.Error())
+	}
+	if err := CheckValueStdinPiped(true, false, "x"); err != nil {
+		t.Errorf("--value-stdin + piped input: %v", err)
+	}
+	if err := CheckValueStdinPiped(false, true, "x"); err != nil {
+		t.Errorf("no --value-stdin, terminal: %v", err)
+	}
+}
+
 func TestCheckPasswordStdinPiped_OKCases(t *testing.T) {
 	const example = "bitrise user create --email <email>"
 	if err := CheckPasswordStdinPiped(true, false, example); err != nil {

--- a/cli/rde/cmd.go
+++ b/cli/rde/cmd.go
@@ -5,8 +5,10 @@ import (
 
 	"github.com/bitrise-io/bitrise/v2/cli/cmdutil"
 	"github.com/bitrise-io/bitrise/v2/cli/rde/machinetype"
+	"github.com/bitrise-io/bitrise/v2/cli/rde/savedinput"
 	"github.com/bitrise-io/bitrise/v2/cli/rde/session"
 	"github.com/bitrise-io/bitrise/v2/cli/rde/stack"
+	"github.com/bitrise-io/bitrise/v2/cli/rde/template"
 )
 
 // NewCmd returns the `bitrise rde` parent command.
@@ -22,7 +24,9 @@ Workspace resolution (highest to lowest precedence):
   BITRISE_WORKSPACE_ID      environment variable
   default_workspace_id      saved with 'bitrise config set'
   auto-detect               when none of the above is set: your only workspace is used,
-                             or you're prompted to pick one interactively`,
+                             or you're prompted to pick one interactively
+
+Saved inputs are user-scoped — they do not require --workspace.`,
 		Example: `  bitrise rde session list --workspace WORKSPACE_ID
   bitrise rde session list --format json
   bitrise rde machine-type list --stack osx-xcode-16.0.x-edge`,
@@ -34,6 +38,8 @@ Workspace resolution (highest to lowest precedence):
 		stack.NewCmd(),
 		machinetype.NewCmd(),
 		session.NewCmd(),
+		template.NewCmd(),
+		savedinput.NewCmd(),
 	)
 	return c
 }

--- a/cli/rde/savedinput/cmd.go
+++ b/cli/rde/savedinput/cmd.go
@@ -1,0 +1,29 @@
+// Package savedinput wires `bitrise rde saved-input` subcommands. Saved
+// inputs are USER-scoped (not workspace-scoped), so these commands don't
+// read --workspace.
+package savedinput
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/bitrise-io/bitrise/v2/cli/cmdutil"
+)
+
+// NewCmd returns the `bitrise rde saved-input` parent command.
+func NewCmd() *cobra.Command {
+	c := &cobra.Command{
+		Use:     "saved-input",
+		Aliases: []string{"saved-inputs"},
+		Short:   "Manage saved inputs (reusable credentials/values)",
+		Args:    cobra.NoArgs,
+		RunE:    cmdutil.DelegateToList,
+	}
+	c.AddCommand(
+		newListCmd(),
+		newViewCmd(),
+		newCreateCmd(),
+		newUpdateCmd(),
+		newDeleteCmd(),
+	)
+	return c
+}

--- a/cli/rde/savedinput/create.go
+++ b/cli/rde/savedinput/create.go
@@ -85,11 +85,21 @@ The value can be supplied three ways:
 // provided=false so the caller can leave the value untouched.
 //
 // This mirrors the secret-input convention used by `bitrise auth login`
-// (--with-token / --password-stdin plus a masked interactive default).
+// (--with-token / --password-stdin plus a masked interactive default), down to
+// requiring --value-stdin to actually be piped: falling through to an unmasked
+// read on a terminal would echo the secret with no prompt to explain the wait.
+//
+// The stdin read uses ReadPasswordInput, which trims only the trailing line
+// terminator, so a piped value is treated the same as one passed to --value
+// (which is not trimmed at all). The interactive prompt keeps ReadSecretInput's
+// full trim, where stripping copy/paste whitespace is what the user wants.
 func resolveValue(cmd *cobra.Command, value string, valueChanged, valueStdin, promptIfMissing bool) (resolved string, provided bool, err error) {
 	switch {
 	case valueStdin:
-		v, rerr := cmdutil.ReadSecretInput(cmd.InOrStdin(), cmd.ErrOrStderr(), "", true)
+		if cerr := cmdutil.CheckValueStdinPiped(valueStdin, cmdutil.IsTerminal(cmd.InOrStdin()), "bitrise rde saved-input "+cmd.Name()); cerr != nil {
+			return "", false, cerr
+		}
+		v, rerr := cmdutil.ReadPasswordInput(cmd.InOrStdin(), cmd.ErrOrStderr(), "", true)
 		return v, true, rerr
 	case valueChanged:
 		return value, true, nil

--- a/cli/rde/savedinput/create.go
+++ b/cli/rde/savedinput/create.go
@@ -1,0 +1,102 @@
+package savedinput
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/bitrise-io/bitrise/v2/cli/cmdutil"
+	internalrde "github.com/bitrise-io/bitrise/v2/internal/rde"
+	"github.com/bitrise-io/bitrise/v2/output"
+)
+
+func newCreateCmd() *cobra.Command {
+	var (
+		key        string
+		value      string
+		valueStdin bool
+		isSecret   bool
+		format     string
+	)
+	c := &cobra.Command{
+		Use:   "create",
+		Short: "Create a new saved input",
+		Long: `Create a new saved input.
+
+The value can be supplied three ways:
+  --value VALUE   use VALUE literally (pass --value - to store a literal dash)
+  --value-stdin   read the value from stdin without prompting; keeps secrets
+                  out of shell history
+  neither         prompt for the value interactively; input is masked when
+                  stdin is a terminal`,
+		Example: `  bitrise rde saved-input create --key repo-name --value my-app
+  echo -n "ghp_xxx" | bitrise rde saved-input create --key gh-token --value-stdin --secret
+  bitrise rde saved-input create --key gh-token --secret   # prompts for the value`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cmdutil.LogCommandParameters(cmd)
+
+			if err := output.ConfigureOutputFormat(format); err != nil {
+				return fmt.Errorf("failed to configure output format: %w", err)
+			}
+
+			if key == "" {
+				return fmt.Errorf("--key is required")
+			}
+			valueChanged := cmd.Flags().Changed("value")
+			value, _, err := resolveValue(cmd, value, valueChanged, valueStdin, true)
+			if err != nil {
+				return err
+			}
+			// Empty is only allowed when the caller explicitly passed --value "".
+			// An empty prompt or empty piped stdin is treated as a mistake.
+			if value == "" && !valueChanged {
+				return fmt.Errorf("value is empty")
+			}
+			client, err := cmdutil.NewRDEClient(cmd)
+			if err != nil {
+				return err
+			}
+			in, err := internalrde.NewService(client).CreateSavedInput(cmd.Context(), internalrde.CreateSavedInputRequest{
+				Key:      key,
+				Value:    value,
+				IsSecret: isSecret,
+			})
+			if err != nil {
+				return err
+			}
+			return output.Render(cmd.OutOrStdout(), output.Format, in, renderDetail)
+		},
+	}
+	c.Flags().StringVar(&key, "key", "", "saved-input key (required)")
+	c.Flags().StringVar(&value, "value", "", "value to store (literal)")
+	c.Flags().BoolVar(&valueStdin, "value-stdin", false, "read the value from stdin without prompting")
+	c.Flags().BoolVar(&isSecret, "secret", false, "encrypt value at rest; the value will be masked in subsequent reads")
+	c.Flags().StringVarP(&format, cmdutil.FormatKey, "f", "", "Output format. Accepted: raw (default), json, yml")
+	c.MarkFlagsMutuallyExclusive("value", "value-stdin")
+	return c
+}
+
+// resolveValue determines a saved-input value from the --value / --value-stdin
+// flags, which the caller marks mutually exclusive. When --value-stdin is set it
+// reads a single line from stdin without prompting. When --value was passed it
+// returns the literal flag value. Otherwise, if promptIfMissing is true it prompts
+// interactively (masked when stdin is a terminal); if false it reports
+// provided=false so the caller can leave the value untouched.
+//
+// This mirrors the secret-input convention used by `bitrise auth login`
+// (--with-token / --password-stdin plus a masked interactive default).
+func resolveValue(cmd *cobra.Command, value string, valueChanged, valueStdin, promptIfMissing bool) (resolved string, provided bool, err error) {
+	switch {
+	case valueStdin:
+		v, rerr := cmdutil.ReadSecretInput(cmd.InOrStdin(), cmd.ErrOrStderr(), "", true)
+		return v, true, rerr
+	case valueChanged:
+		return value, true, nil
+	case promptIfMissing:
+		v, rerr := cmdutil.ReadSecretInput(cmd.InOrStdin(), cmd.ErrOrStderr(), "Value: ", false)
+		return v, true, rerr
+	default:
+		return "", false, nil
+	}
+}

--- a/cli/rde/savedinput/delete.go
+++ b/cli/rde/savedinput/delete.go
@@ -1,0 +1,34 @@
+package savedinput
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/bitrise-io/bitrise/v2/cli/cmdutil"
+	internalrde "github.com/bitrise-io/bitrise/v2/internal/rde"
+)
+
+func newDeleteCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "delete SAVED_INPUT_ID",
+		Short: "Delete a saved input",
+		Args:  cmdutil.RequireArgs("SAVED_INPUT_ID"),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cmdutil.LogCommandParameters(cmd)
+
+			client, err := cmdutil.NewRDEClient(cmd)
+			if err != nil {
+				return err
+			}
+			if err := internalrde.NewService(client).DeleteSavedInput(cmd.Context(), args[0]); err != nil {
+				return err
+			}
+			if !cmdutil.IsQuiet(cmd) {
+				_, err := fmt.Fprintf(cmd.ErrOrStderr(), "Deleted saved input %s\n", args[0])
+				return err
+			}
+			return nil
+		},
+	}
+}

--- a/cli/rde/savedinput/list.go
+++ b/cli/rde/savedinput/list.go
@@ -1,0 +1,74 @@
+package savedinput
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/bitrise-io/bitrise/v2/cli/cmdutil"
+	internalrde "github.com/bitrise-io/bitrise/v2/internal/rde"
+	"github.com/bitrise-io/bitrise/v2/internal/style"
+	"github.com/bitrise-io/bitrise/v2/output"
+)
+
+type listResult struct {
+	Items []internalrde.SavedInput `json:"items" yaml:"items"`
+}
+
+func newListCmd() *cobra.Command {
+	var format string
+	c := &cobra.Command{
+		Use:   "list",
+		Short: "List saved inputs for the authenticated user",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cmdutil.LogCommandParameters(cmd)
+
+			if err := output.ConfigureOutputFormat(format); err != nil {
+				return fmt.Errorf("failed to configure output format: %w", err)
+			}
+
+			client, err := cmdutil.NewRDEClient(cmd)
+			if err != nil {
+				return err
+			}
+			items, err := internalrde.NewService(client).ListSavedInputs(cmd.Context())
+			if err != nil {
+				return err
+			}
+			return output.Render(cmd.OutOrStdout(), output.Format, listResult{Items: items}, renderList)
+		},
+	}
+	c.Flags().StringVarP(&format, cmdutil.FormatKey, "f", "", "Output format. Accepted: raw (default), json, yml")
+	return c
+}
+
+func renderList(w io.Writer, res listResult) error {
+	if len(res.Items) == 0 {
+		_, err := fmt.Fprintln(w, "No saved inputs found.")
+		return err
+	}
+	s := style.New(w)
+	headers := []string{"KEY", "SECRET", "VALUE", "ID"}
+	rows := make([][]string, 0, len(res.Items))
+	for _, in := range res.Items {
+		secret := ""
+		if in.IsSecret {
+			secret = "yes"
+		}
+		value := in.Value
+		if in.IsSecret {
+			value = "(hidden)"
+		}
+		rows = append(rows, []string{in.Key, secret, value, in.ID})
+	}
+	const colID = 3
+	styler := func(_, col int, content string) string {
+		if col == colID {
+			return s.Slug.Render(content)
+		}
+		return content
+	}
+	return style.Table(w, headers, rows, s.Header, styler)
+}

--- a/cli/rde/savedinput/main_test.go
+++ b/cli/rde/savedinput/main_test.go
@@ -1,0 +1,10 @@
+package savedinput
+
+import (
+	"os"
+	"testing"
+
+	"github.com/bitrise-io/bitrise/v2/cli/cmdtest"
+)
+
+func TestMain(m *testing.M) { os.Exit(cmdtest.RunIsolated(m)) }

--- a/cli/rde/savedinput/mutation_test.go
+++ b/cli/rde/savedinput/mutation_test.go
@@ -64,6 +64,43 @@ func TestUpdateCmd_ValueStdin(t *testing.T) {
 	}
 }
 
+// `--value-stdin < /dev/null` used to blank the stored value silently. Empty
+// piped input is a mistake (a missing file, a failed upstream command); --value
+// "" stays the deliberate way to clear.
+func TestUpdateCmd_ValueStdinRejectsEmpty(t *testing.T) {
+	_, _, err := cmdtest.Run(t, newUpdateCmd(), cmdtest.Opts{
+		RDEAPIBaseURL: "http://unused",
+		Args:          []string{"sv-1", "--value-stdin"},
+		Stdin:         "",
+	})
+	if err == nil || !strings.Contains(err.Error(), "empty") {
+		t.Errorf("error = %v, want an empty-value error", err)
+	}
+}
+
+// A piped value is trimmed the same way --value is (not at all beyond the line
+// terminator), so leading/trailing spaces that are part of the secret survive.
+func TestUpdateCmd_ValueStdinPreservesSurroundingSpace(t *testing.T) {
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		_, _ = io.WriteString(w, `{"savedInput":{"id":"sv-1","key":"repo"}}`)
+	}))
+	defer srv.Close()
+
+	_, _, err := cmdtest.Run(t, newUpdateCmd(), cmdtest.Opts{
+		RDEAPIBaseURL: srv.URL,
+		Args:          []string{"sv-1", "--value-stdin"},
+		Stdin:         "  pad ded  \n",
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if gotBody["value"] != "  pad ded  " {
+		t.Errorf("value = %q, want %q (only the newline trimmed)", gotBody["value"], "  pad ded  ")
+	}
+}
+
 func TestUpdateCmd_SecretFlagSendsBool(t *testing.T) {
 	var gotBody map[string]any
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/cli/rde/savedinput/mutation_test.go
+++ b/cli/rde/savedinput/mutation_test.go
@@ -1,0 +1,143 @@
+package savedinput
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/bitrise-io/bitrise/v2/cli/cmdtest"
+	"github.com/bitrise-io/bitrise/v2/output"
+)
+
+func TestUpdateCmd_RequiresAField(t *testing.T) {
+	_, _, err := cmdtest.Run(t, newUpdateCmd(), cmdtest.Opts{RDEAPIBaseURL: "http://unused", Args: []string{"sv-1"}})
+	if err == nil || !strings.Contains(err.Error(), "--value") {
+		t.Errorf("error = %v, want at-least-one-field error", err)
+	}
+}
+
+func TestUpdateCmd_ValueOnlyOmitsSecret(t *testing.T) {
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPatch || r.URL.Path != "/v1/saved-inputs/sv-1" {
+			t.Errorf("unexpected: %s %s", r.Method, r.URL.Path)
+		}
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		_, _ = io.WriteString(w, `{"savedInput":{"id":"sv-1","key":"repo","value":"new"}}`)
+	}))
+	defer srv.Close()
+
+	_, _, err := cmdtest.Run(t, newUpdateCmd(), cmdtest.Opts{RDEAPIBaseURL: srv.URL, Args: []string{"sv-1", "--value", "new"}})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if gotBody["value"] != "new" {
+		t.Errorf("value = %v, want new", gotBody["value"])
+	}
+	// --secret wasn't passed, so isSecret must be omitted (not reset to false).
+	if _, ok := gotBody["isSecret"]; ok {
+		t.Errorf("isSecret should be omitted, body=%v", gotBody)
+	}
+}
+
+func TestUpdateCmd_ValueStdin(t *testing.T) {
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		_, _ = io.WriteString(w, `{"savedInput":{"id":"sv-1","key":"repo","isSecret":true,"value":"***"}}`)
+	}))
+	defer srv.Close()
+
+	_, _, err := cmdtest.Run(t, newUpdateCmd(), cmdtest.Opts{
+		RDEAPIBaseURL: srv.URL,
+		Args:          []string{"sv-1", "--value-stdin"},
+		Stdin:         "new-secret\n",
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if gotBody["value"] != "new-secret" {
+		t.Errorf("value = %v, want new-secret (read from stdin)", gotBody["value"])
+	}
+}
+
+func TestUpdateCmd_SecretFlagSendsBool(t *testing.T) {
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		_, _ = io.WriteString(w, `{"savedInput":{"id":"sv-1","key":"repo","isSecret":true,"value":"***"}}`)
+	}))
+	defer srv.Close()
+
+	// --secret without --value: only the secret flag is patched.
+	_, _, err := cmdtest.Run(t, newUpdateCmd(), cmdtest.Opts{RDEAPIBaseURL: srv.URL, Args: []string{"sv-1", "--secret"}})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if gotBody["isSecret"] != true {
+		t.Errorf("isSecret = %v, want true", gotBody["isSecret"])
+	}
+	if _, ok := gotBody["value"]; ok {
+		t.Errorf("value should be omitted, body=%v", gotBody)
+	}
+}
+
+func TestUpdateCmd_JSONOutput(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `{"savedInput":{"id":"sv-1","key":"repo","value":"new"}}`)
+	}))
+	defer srv.Close()
+
+	stdout, _, err := cmdtest.Run(t, newUpdateCmd(), cmdtest.Opts{
+		RDEAPIBaseURL: srv.URL,
+		Args:          []string{"sv-1", "--value", "new"},
+		Format:        output.FormatJSON,
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal([]byte(stdout), &got); err != nil {
+		t.Fatalf("unmarshal JSON output: %v\n%s", err, stdout)
+	}
+	if got["id"] != "sv-1" || got["value"] != "new" {
+		t.Errorf("unexpected JSON: %v", got)
+	}
+}
+
+func TestUpdateCmd_RequiresArg(t *testing.T) {
+	_, _, err := cmdtest.Run(t, newUpdateCmd(), cmdtest.Opts{RDEAPIBaseURL: "http://unused", Args: []string{"--value", "x"}})
+	if err == nil {
+		t.Fatal("expected error when SAVED_INPUT_ID is missing")
+	}
+}
+
+func TestDeleteCmd_HappyPath(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete || r.URL.Path != "/v1/saved-inputs/sv-1" {
+			t.Errorf("unexpected: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	stdout, stderr, err := cmdtest.Run(t, newDeleteCmd(), cmdtest.Opts{RDEAPIBaseURL: srv.URL, Args: []string{"sv-1"}})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !strings.Contains(stderr, "Deleted saved input sv-1") {
+		t.Errorf("stderr missing confirmation: %q", stderr)
+	}
+	if stdout != "" {
+		t.Errorf("stdout should be empty for delete, got: %q", stdout)
+	}
+}
+
+func TestDeleteCmd_RequiresArg(t *testing.T) {
+	_, _, err := cmdtest.Run(t, newDeleteCmd(), cmdtest.Opts{RDEAPIBaseURL: "http://unused"})
+	if err == nil {
+		t.Fatal("expected error when SAVED_INPUT_ID is missing")
+	}
+}

--- a/cli/rde/savedinput/savedinput_test.go
+++ b/cli/rde/savedinput/savedinput_test.go
@@ -1,0 +1,222 @@
+package savedinput
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/bitrise-io/bitrise/v2/cli/cmdtest"
+	"github.com/bitrise-io/bitrise/v2/output"
+)
+
+func TestListCmd_HappyPath_MasksSecrets(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/saved-inputs" {
+			t.Errorf("unexpected path: %s (saved inputs are user-scoped)", r.URL.Path)
+		}
+		_, _ = io.WriteString(w, `{"savedInputs":[
+			{"id":"sv-1","key":"repo","value":"my-app"},
+			{"id":"sv-2","key":"gh-token","isSecret":true,"value":"ghp_LEAK"}
+		]}`)
+	}))
+	defer srv.Close()
+
+	stdout, _, err := cmdtest.Run(t, newListCmd(), cmdtest.Opts{RDEAPIBaseURL: srv.URL})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	for _, want := range []string{"repo", "my-app", "gh-token", "(hidden)", "sv-1", "sv-2"} {
+		if !strings.Contains(stdout, want) {
+			t.Errorf("stdout missing %q:\n%s", want, stdout)
+		}
+	}
+	// The masked secret's plaintext must never reach human output.
+	if strings.Contains(stdout, "ghp_LEAK") {
+		t.Errorf("secret value leaked into human output:\n%s", stdout)
+	}
+}
+
+func TestListCmd_JSONOutput(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `{"savedInputs":[{"id":"sv-1","key":"repo","value":"my-app"}]}`)
+	}))
+	defer srv.Close()
+
+	stdout, _, err := cmdtest.Run(t, newListCmd(), cmdtest.Opts{RDEAPIBaseURL: srv.URL, Format: output.FormatJSON})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	var got struct {
+		Items []struct {
+			ID    string `json:"id"`
+			Key   string `json:"key"`
+			Value string `json:"value"`
+		} `json:"items"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &got); err != nil {
+		t.Fatalf("unmarshal JSON output: %v\n%s", err, stdout)
+	}
+	if len(got.Items) != 1 || got.Items[0].Key != "repo" || got.Items[0].Value != "my-app" {
+		t.Errorf("unexpected JSON items: %+v", got.Items)
+	}
+}
+
+// TestJSONOutput_MasksSecrets is the regression guard for the secret leak:
+// the backend returns secret values in cleartext (and echoes the
+// just-submitted value back on create/update), so the CLI must blank them
+// before --format json marshals the record. Covers both list and view.
+func TestJSONOutput_MasksSecrets(t *testing.T) {
+	t.Run("list", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = io.WriteString(w, `{"savedInputs":[
+				{"id":"sv-1","key":"repo","value":"my-app"},
+				{"id":"sv-2","key":"gh-token","isSecret":true,"value":"ghp_LEAK"}
+			]}`)
+		}))
+		defer srv.Close()
+
+		stdout, _, err := cmdtest.Run(t, newListCmd(), cmdtest.Opts{RDEAPIBaseURL: srv.URL, Format: output.FormatJSON})
+		if err != nil {
+			t.Fatalf("Execute: %v", err)
+		}
+		if strings.Contains(stdout, "ghp_LEAK") {
+			t.Errorf("secret value leaked into JSON output:\n%s", stdout)
+		}
+	})
+
+	t.Run("view", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = io.WriteString(w, `{"savedInput":{"id":"sv-2","key":"gh-token","isSecret":true,"value":"ghp_LEAK"}}`)
+		}))
+		defer srv.Close()
+
+		stdout, _, err := cmdtest.Run(t, newViewCmd(), cmdtest.Opts{RDEAPIBaseURL: srv.URL, Args: []string{"sv-2"}, Format: output.FormatJSON})
+		if err != nil {
+			t.Fatalf("Execute: %v", err)
+		}
+		if strings.Contains(stdout, "ghp_LEAK") {
+			t.Errorf("secret value leaked into JSON output:\n%s", stdout)
+		}
+	})
+}
+
+func TestViewCmd_SecretHuman(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/saved-inputs/sv-2" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		_, _ = io.WriteString(w, `{"savedInput":{"id":"sv-2","key":"gh-token","isSecret":true,"value":"***"}}`)
+	}))
+	defer srv.Close()
+
+	stdout, _, err := cmdtest.Run(t, newViewCmd(), cmdtest.Opts{RDEAPIBaseURL: srv.URL, Args: []string{"sv-2"}})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	for _, want := range []string{"gh-token", "sv-2", "(hidden)", "yes"} {
+		if !strings.Contains(stdout, want) {
+			t.Errorf("stdout missing %q:\n%s", want, stdout)
+		}
+	}
+}
+
+func TestCreateCmd_RequiresKey(t *testing.T) {
+	_, _, err := cmdtest.Run(t, newCreateCmd(), cmdtest.Opts{RDEAPIBaseURL: "http://unused", Args: []string{"--value", "x"}})
+	if err == nil || !strings.Contains(err.Error(), "--key") {
+		t.Errorf("error = %v, want --key required", err)
+	}
+}
+
+func TestCreateCmd_EmptyValueRejected(t *testing.T) {
+	// Neither --value nor --value-stdin, and empty stdin (the prompt fallback
+	// reads it as a line): there is nothing to store, so it must error rather
+	// than create an empty value.
+	_, _, err := cmdtest.Run(t, newCreateCmd(), cmdtest.Opts{RDEAPIBaseURL: "http://unused", Args: []string{"--key", "repo"}, Stdin: ""})
+	if err == nil || !strings.Contains(err.Error(), "value is empty") {
+		t.Errorf("error = %v, want value-is-empty", err)
+	}
+}
+
+func TestCreateCmd_ValueStdin(t *testing.T) {
+	var body map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		_, _ = io.WriteString(w, `{"savedInput":{"id":"sv-new","key":"gh-token","isSecret":true,"value":"***"}}`)
+	}))
+	defer srv.Close()
+
+	_, _, err := cmdtest.Run(t, newCreateCmd(), cmdtest.Opts{
+		RDEAPIBaseURL: srv.URL,
+		Args:          []string{"--key", "gh-token", "--value-stdin", "--secret"},
+		Stdin:         "ghp_secret\n",
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if body["value"] != "ghp_secret" {
+		t.Errorf("value = %v, want ghp_secret (read from stdin, trailing newline trimmed)", body["value"])
+	}
+}
+
+// TestCreateCmd_LiteralDashValue guards the original question that started this:
+// with the "-" sentinel removed, --value - now stores a literal dash.
+func TestCreateCmd_LiteralDashValue(t *testing.T) {
+	var body map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		_, _ = io.WriteString(w, `{"savedInput":{"id":"sv-new","key":"dash","value":"-"}}`)
+	}))
+	defer srv.Close()
+
+	_, _, err := cmdtest.Run(t, newCreateCmd(), cmdtest.Opts{RDEAPIBaseURL: srv.URL, Args: []string{"--key", "dash", "--value", "-"}})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if body["value"] != "-" {
+		t.Errorf("value = %v, want literal -", body["value"])
+	}
+}
+
+func TestCreateCmd_ValueAndStdinMutuallyExclusive(t *testing.T) {
+	_, _, err := cmdtest.Run(t, newCreateCmd(), cmdtest.Opts{
+		RDEAPIBaseURL: "http://unused",
+		Args:          []string{"--key", "repo", "--value", "x", "--value-stdin"},
+	})
+	if err == nil {
+		t.Fatal("expected error when --value and --value-stdin are both set")
+	}
+}
+
+func TestCreateCmd_HappyPathJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/v1/saved-inputs" {
+			t.Errorf("unexpected: %s %s", r.Method, r.URL.Path)
+		}
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		if body["key"] != "gh-token" || body["isSecret"] != true {
+			t.Errorf("unexpected create body: %v", body)
+		}
+		_, _ = io.WriteString(w, `{"savedInput":{"id":"sv-new","key":"gh-token","isSecret":true,"value":"***"}}`)
+	}))
+	defer srv.Close()
+
+	stdout, _, err := cmdtest.Run(t, newCreateCmd(), cmdtest.Opts{
+		RDEAPIBaseURL: srv.URL,
+		Args:          []string{"--key", "gh-token", "--value", "ghp_x", "--secret"},
+		Format:        output.FormatJSON,
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal([]byte(stdout), &got); err != nil {
+		t.Fatalf("unmarshal JSON output: %v\n%s", err, stdout)
+	}
+	if got["id"] != "sv-new" || got["is_secret"] != true {
+		t.Errorf("unexpected JSON: %v", got)
+	}
+}

--- a/cli/rde/savedinput/update.go
+++ b/cli/rde/savedinput/update.go
@@ -40,6 +40,13 @@ the --secret flag.`,
 			if err != nil {
 				return err
 			}
+			// Mirrors create's guard: empty piped stdin is a mistake (a missing
+			// file or a failed command upstream), and silently blanking a stored
+			// value is the worst reading of it. --value "" stays the explicit way
+			// to clear one.
+			if provided && v == "" && valueStdin {
+				return fmt.Errorf("value read from stdin is empty; pass --value \"\" to deliberately clear the value")
+			}
 			if provided {
 				req.Value = &v
 			}

--- a/cli/rde/savedinput/update.go
+++ b/cli/rde/savedinput/update.go
@@ -1,0 +1,70 @@
+package savedinput
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/bitrise-io/bitrise/v2/cli/cmdutil"
+	internalrde "github.com/bitrise-io/bitrise/v2/internal/rde"
+	"github.com/bitrise-io/bitrise/v2/output"
+)
+
+func newUpdateCmd() *cobra.Command {
+	var (
+		value      string
+		valueStdin bool
+		isSecret   bool
+		format     string
+	)
+	c := &cobra.Command{
+		Use:   "update SAVED_INPUT_ID",
+		Short: "Update a saved input's value and/or secret flag",
+		Long: `Update a saved input's value and/or secret flag.
+
+Pass --value VALUE to set a new value, or --value-stdin to read it from stdin
+without prompting (keeps secrets out of shell history). Omit both to change only
+the --secret flag.`,
+		Args: cmdutil.RequireArgs("SAVED_INPUT_ID"),
+		Example: `  bitrise rde saved-input update ID --value new-value
+  echo -n "ghp_xxx" | bitrise rde saved-input update ID --value-stdin --secret`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cmdutil.LogCommandParameters(cmd)
+
+			if err := output.ConfigureOutputFormat(format); err != nil {
+				return fmt.Errorf("failed to configure output format: %w", err)
+			}
+
+			req := internalrde.UpdateSavedInputRequest{}
+			v, provided, err := resolveValue(cmd, value, cmd.Flags().Changed("value"), valueStdin, false)
+			if err != nil {
+				return err
+			}
+			if provided {
+				req.Value = &v
+			}
+			if cmd.Flags().Changed("secret") {
+				b := isSecret
+				req.IsSecret = &b
+			}
+			if req.Value == nil && req.IsSecret == nil {
+				return fmt.Errorf("at least one of --value, --value-stdin, or --secret is required")
+			}
+			client, err := cmdutil.NewRDEClient(cmd)
+			if err != nil {
+				return err
+			}
+			in, err := internalrde.NewService(client).UpdateSavedInput(cmd.Context(), args[0], req)
+			if err != nil {
+				return err
+			}
+			return output.Render(cmd.OutOrStdout(), output.Format, in, renderDetail)
+		},
+	}
+	c.Flags().StringVar(&value, "value", "", "new value (literal)")
+	c.Flags().BoolVar(&valueStdin, "value-stdin", false, "read the new value from stdin without prompting")
+	c.Flags().BoolVar(&isSecret, "secret", false, "set/unset the secret flag")
+	c.Flags().StringVarP(&format, cmdutil.FormatKey, "f", "", "Output format. Accepted: raw (default), json, yml")
+	c.MarkFlagsMutuallyExclusive("value", "value-stdin")
+	return c
+}

--- a/cli/rde/savedinput/view.go
+++ b/cli/rde/savedinput/view.go
@@ -1,0 +1,60 @@
+package savedinput
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/bitrise-io/bitrise/v2/cli/cmdutil"
+	internalrde "github.com/bitrise-io/bitrise/v2/internal/rde"
+	"github.com/bitrise-io/bitrise/v2/internal/style"
+	"github.com/bitrise-io/bitrise/v2/output"
+)
+
+func newViewCmd() *cobra.Command {
+	var format string
+	c := &cobra.Command{
+		Use:   "view SAVED_INPUT_ID",
+		Short: "Show details of a single saved input",
+		Args:  cmdutil.RequireArgs("SAVED_INPUT_ID"),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cmdutil.LogCommandParameters(cmd)
+
+			if err := output.ConfigureOutputFormat(format); err != nil {
+				return fmt.Errorf("failed to configure output format: %w", err)
+			}
+
+			client, err := cmdutil.NewRDEClient(cmd)
+			if err != nil {
+				return err
+			}
+			in, err := internalrde.NewService(client).GetSavedInput(cmd.Context(), args[0])
+			if err != nil {
+				return err
+			}
+			return output.Render(cmd.OutOrStdout(), output.Format, in, renderDetail)
+		},
+	}
+	c.Flags().StringVarP(&format, cmdutil.FormatKey, "f", "", "Output format. Accepted: raw (default), json, yml")
+	return c
+}
+
+func renderDetail(w io.Writer, in internalrde.SavedInput) error {
+	s := style.New(w)
+	ew := cmdutil.NewErrWriter(w)
+	lbl := func(label string) string { return s.Label.Render(fmt.Sprintf("%-12s", label)) }
+
+	ew.F("%s%s\n", lbl("Key:"), in.Key)
+	ew.F("%s%s\n", lbl("ID:"), s.Slug.Render(in.ID))
+	if in.IsSecret {
+		ew.F("%s%s\n", lbl("Value:"), s.Dim.Render("(hidden)"))
+		ew.F("%s%s\n", lbl("Secret:"), "yes")
+	} else {
+		ew.F("%s%s\n", lbl("Value:"), in.Value)
+	}
+	if in.UpdatedAt != nil {
+		ew.F("%s%s\n", lbl("Updated:"), in.UpdatedAt.UTC().Format("2006-01-02 15:04 UTC"))
+	}
+	return ew.Err
+}

--- a/cli/rde/template/cmd.go
+++ b/cli/rde/template/cmd.go
@@ -1,0 +1,30 @@
+package template
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/bitrise-io/bitrise/v2/cli/cmdutil"
+)
+
+// NewCmd returns the `bitrise rde template` parent command.
+func NewCmd() *cobra.Command {
+	c := &cobra.Command{
+		Use:   "template",
+		Short: "List and inspect RDE templates",
+		Long: `List and inspect RDE templates.
+
+Commands that take a TEMPLATE_ID also accept a template name — it's resolved
+to an ID for you. Names aren't unique, so if more than one template shares the
+name the command errors and lists the candidate IDs to pick from.`,
+		Args: cobra.NoArgs,
+		RunE: cmdutil.DelegateToList,
+	}
+	c.AddCommand(
+		newListCmd(),
+		newViewCmd(),
+		newCreateCmd(),
+		newUpdateCmd(),
+		newDeleteCmd(),
+	)
+	return c
+}

--- a/cli/rde/template/crud.go
+++ b/cli/rde/template/crud.go
@@ -1,0 +1,244 @@
+package template
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/bitrise-io/bitrise/v2/cli/cmdutil"
+	internalrde "github.com/bitrise-io/bitrise/v2/internal/rde"
+	"github.com/bitrise-io/bitrise/v2/output"
+)
+
+func newCreateCmd() *cobra.Command {
+	var (
+		file   string
+		format string
+	)
+	c := &cobra.Command{
+		Use:   "create",
+		Short: "Create a new RDE template from a JSON spec file",
+		Long: `Create a new RDE template from a JSON spec file. See the annotated
+example at the bottom for the JSON shape — or, once you have a template
+you like, round-trip from it (audit fields like id/created_at are ignored):
+
+  bitrise rde template view OTHER_TEMPLATE_ID --format json > template.json
+  # edit template.json
+  bitrise rde template create --file template.json
+
+Pass --file - to read the JSON from stdin.
+
+Required fields:
+  name           template name
+  stack_id       stack ID (see 'rde stack list')
+  machine_type   machine type name (see 'rde machine-type list')
+
+Optional fields:
+  description         free-text description
+  working_directory   default working directory for sessions
+  startup_script      bash script run on every session start
+  warmup_script       bash script run once during pre-warming
+  session_inputs      array of {key, description, required, default_value,
+                      expose_as_env_var} — values callers supply at create time
+  template_variables  array of {key, value, is_secret, expose_as_env_var} —
+                      baked-in values available to startup/warmup scripts
+  feature_flags       array of {name, description}
+  workspace_links     array of {label, folder_path, feature_flag_name} — IDE
+                      folder shortcuts
+
+Example spec exercising every field (a macOS iOS-app dev environment —
+adjust to taste):
+
+  {
+    "name": "example-ios-app",
+    "description": "Example macOS dev environment for an iOS app.",
+    "stack_id": "osx-xcode-16.0.x-edge",
+    "machine_type": "g2.mac.m2pro.6c-14g",
+    "working_directory": "/Users/vagrant/git",
+    "warmup_script": "set -euo pipefail\ncd ~\ngit clone \"https://${GITHUB_PAT}@github.com/example-org/example-app.git\" git\ncd git && bundle install && pod install --project-directory=ios\n",
+    "startup_script": "set -euo pipefail\ncd /Users/vagrant/git\ngit pull --ff-only || true\nsudo xcode-select -s \"/Applications/Xcode-${XCODE_VERSION}.app\"\n",
+    "session_inputs": [
+      {
+        "key": "GITHUB_PAT",
+        "description": "GitHub PAT with read access to example-org/example-app",
+        "required": true,
+        "expose_as_env_var": true
+      },
+      {
+        "key": "XCODE_VERSION",
+        "description": "Xcode version to select via xcode-select",
+        "default_value": "26.3",
+        "expose_as_env_var": true
+      }
+    ],
+    "template_variables": [
+      {"key": "APP_SCHEME", "value": "ExampleApp", "expose_as_env_var": true},
+      {"key": "FASTLANE_API_KEY", "is_secret": true, "expose_as_env_var": true}
+    ],
+    "feature_flags": [
+      {"name": "enable_beta_simulator", "description": "Boot the iOS beta simulator on session start"}
+    ],
+    "workspace_links": [
+      {"label": "Open app in Xcode", "folder_path": "/Users/vagrant/git/ios"},
+      {"label": "Open scripts (beta only)", "folder_path": "/Users/vagrant/git/scripts", "feature_flag_name": "enable_beta_simulator"}
+    ]
+  }`,
+		Example: `  bitrise rde template create --file template.json
+  cat template.json | bitrise rde template create --file -`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cmdutil.LogCommandParameters(cmd)
+
+			if err := output.ConfigureOutputFormat(format); err != nil {
+				return fmt.Errorf("failed to configure output format: %w", err)
+			}
+
+			if file == "" {
+				return fmt.Errorf("--file is required")
+			}
+			spec, err := readTemplateSpec(cmd.InOrStdin(), file)
+			if err != nil {
+				return err
+			}
+			workspaceID, err := cmdutil.ResolveWorkspaceID(cmd)
+			if err != nil {
+				return err
+			}
+			client, err := cmdutil.NewRDEClient(cmd)
+			if err != nil {
+				return err
+			}
+			t, err := internalrde.NewService(client).CreateTemplate(cmd.Context(), workspaceID, spec)
+			if err != nil {
+				return err
+			}
+			return output.Render(cmd.OutOrStdout(), output.Format, t, renderDetail)
+		},
+	}
+	c.Flags().StringVarP(&file, "file", "f", "", "path to a JSON spec file (use '-' for stdin)")
+	// No -f shorthand: --file owns it on this command.
+	c.Flags().StringVar(&format, cmdutil.FormatKey, "", "Output format. Accepted: raw (default), json, yml")
+	return c
+}
+
+func newUpdateCmd() *cobra.Command {
+	var (
+		file   string
+		format string
+	)
+	c := &cobra.Command{
+		Use:   "update TEMPLATE_ID",
+		Short: "Update an existing RDE template from a JSON spec file",
+		Long: `Update an existing RDE template from a JSON spec file.
+
+Only fields present in the file are sent. Array fields (template_variables,
+session_inputs, feature_flags, workspace_links) replace the server's
+existing list wholesale when present — to clear one, include it as [].
+
+Round-trip workflow:
+
+  bitrise rde template view TEMPLATE_ID --format json > template.json
+  # edit template.json
+  bitrise rde template update TEMPLATE_ID --file template.json
+
+Pass --file - to read the JSON from stdin.`,
+		Args: cmdutil.RequireArgs("TEMPLATE_ID"),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cmdutil.LogCommandParameters(cmd)
+
+			if err := output.ConfigureOutputFormat(format); err != nil {
+				return fmt.Errorf("failed to configure output format: %w", err)
+			}
+
+			if file == "" {
+				return fmt.Errorf("--file is required")
+			}
+			spec, err := readTemplateSpec(cmd.InOrStdin(), file)
+			if err != nil {
+				return err
+			}
+			workspaceID, err := cmdutil.ResolveWorkspaceID(cmd)
+			if err != nil {
+				return err
+			}
+			client, err := cmdutil.NewRDEClient(cmd)
+			if err != nil {
+				return err
+			}
+			svc := internalrde.NewService(client)
+			templateID, err := svc.ResolveTemplateID(cmd.Context(), workspaceID, args[0])
+			if err != nil {
+				return err
+			}
+			t, err := svc.UpdateTemplate(cmd.Context(), workspaceID, templateID, spec)
+			if err != nil {
+				return err
+			}
+			return output.Render(cmd.OutOrStdout(), output.Format, t, renderDetail)
+		},
+	}
+	c.Flags().StringVarP(&file, "file", "f", "", "path to a JSON spec file (use '-' for stdin)")
+	// No -f shorthand: --file owns it on this command.
+	c.Flags().StringVar(&format, cmdutil.FormatKey, "", "Output format. Accepted: raw (default), json, yml")
+	return c
+}
+
+func newDeleteCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "delete TEMPLATE_ID",
+		Short: "Delete an RDE template",
+		Long: `Delete an RDE template (soft-delete server-side). Existing sessions
+created from this template keep working — they reference a snapshot — but
+the template can no longer be selected for new sessions.`,
+		Args: cmdutil.RequireArgs("TEMPLATE_ID"),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cmdutil.LogCommandParameters(cmd)
+
+			workspaceID, err := cmdutil.ResolveWorkspaceID(cmd)
+			if err != nil {
+				return err
+			}
+			client, err := cmdutil.NewRDEClient(cmd)
+			if err != nil {
+				return err
+			}
+			svc := internalrde.NewService(client)
+			templateID, err := svc.ResolveTemplateID(cmd.Context(), workspaceID, args[0])
+			if err != nil {
+				return err
+			}
+			if err := svc.DeleteTemplate(cmd.Context(), workspaceID, templateID); err != nil {
+				return err
+			}
+			if !cmdutil.IsQuiet(cmd) {
+				_, err := fmt.Fprintf(cmd.ErrOrStderr(), "Deleted template %s\n", templateID)
+				return err
+			}
+			return nil
+		},
+	}
+}
+
+// readTemplateSpec reads a TemplateSpec from path. "-" reads from stdin.
+// Extra fields (id, created_at, etc.) are ignored — encoding/json drops
+// them naturally — so view-output can be piped straight back in.
+func readTemplateSpec(stdin io.Reader, path string) (internalrde.TemplateSpec, error) {
+	var data []byte
+	var err error
+	if path == "-" {
+		data, err = io.ReadAll(stdin)
+	} else {
+		data, err = os.ReadFile(path)
+	}
+	if err != nil {
+		return internalrde.TemplateSpec{}, fmt.Errorf("read template spec: %w", err)
+	}
+	var spec internalrde.TemplateSpec
+	if err := json.Unmarshal(data, &spec); err != nil {
+		return internalrde.TemplateSpec{}, fmt.Errorf("parse template spec: %w", err)
+	}
+	return spec, nil
+}

--- a/cli/rde/template/crud_test.go
+++ b/cli/rde/template/crud_test.go
@@ -1,0 +1,190 @@
+package template
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/bitrise-io/bitrise/v2/cli/cmdtest"
+)
+
+// uuidTemplateID is a UUID-shaped template arg. Real RDE template IDs are
+// UUIDs, so passing one exercises the ResolveTemplateID short-circuit (no
+// extra ListTemplates call) — the path production hits when a user pastes an
+// ID rather than a name.
+const uuidTemplateID = "33333333-4444-4444-8444-555555555555"
+
+func TestCreateCmd_HappyPath(t *testing.T) {
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/v1/workspaces/ws-1/templates" {
+			t.Errorf("unexpected: %s %s", r.Method, r.URL.Path)
+		}
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		_, _ = io.WriteString(w, `{"template":{"id":"t-new","name":"Dev","stackId":"linux-ubuntu-24.04","machineType":"standard"}}`)
+	}))
+	defer srv.Close()
+
+	stdout, _, err := cmdtest.Run(t, newCreateCmd(), cmdtest.Opts{
+		RDEAPIBaseURL:      srv.URL,
+		DefaultWorkspaceID: "ws-1",
+		Args:               []string{"--file", "-"},
+		Stdin:              `{"name":"Dev","stack_id":"linux-ubuntu-24.04","machine_type":"standard","session_inputs":[{"key":"repo","required":true}]}`,
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	// The spec's snake_case fields must map onto the camelCase wire body.
+	if gotBody["name"] != "Dev" || gotBody["stackId"] != "linux-ubuntu-24.04" || gotBody["machineType"] != "standard" {
+		t.Errorf("unexpected create body: %v", gotBody)
+	}
+	if !strings.Contains(stdout, "t-new") {
+		t.Errorf("stdout missing new template ID:\n%s", stdout)
+	}
+}
+
+func TestCreateCmd_RequiresFile(t *testing.T) {
+	_, _, err := cmdtest.Run(t, newCreateCmd(), cmdtest.Opts{RDEAPIBaseURL: "http://unused", DefaultWorkspaceID: "ws-1"})
+	if err == nil || !strings.Contains(err.Error(), "--file") {
+		t.Errorf("error = %v, want --file required", err)
+	}
+}
+
+func TestCreateCmd_MissingRequiredSpecField(t *testing.T) {
+	// machine_type is required by the service; the spec omits it, so the
+	// command must fail before any HTTP call.
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		t.Error("server should not be hit when the spec is invalid")
+	}))
+	defer srv.Close()
+
+	_, _, err := cmdtest.Run(t, newCreateCmd(), cmdtest.Opts{
+		RDEAPIBaseURL:      srv.URL,
+		DefaultWorkspaceID: "ws-1",
+		Args:               []string{"--file", "-"},
+		Stdin:              `{"name":"Dev","stack_id":"linux-ubuntu-24.04"}`,
+	})
+	if err == nil || !strings.Contains(err.Error(), "machine_type") {
+		t.Errorf("error = %v, want machine_type-required", err)
+	}
+}
+
+func TestCreateCmd_MalformedJSON(t *testing.T) {
+	_, _, err := cmdtest.Run(t, newCreateCmd(), cmdtest.Opts{
+		RDEAPIBaseURL:      "http://unused",
+		DefaultWorkspaceID: "ws-1",
+		Args:               []string{"--file", "-"},
+		Stdin:              `{not json`,
+	})
+	if err == nil || !strings.Contains(err.Error(), "parse template spec") {
+		t.Errorf("error = %v, want parse error", err)
+	}
+}
+
+func TestUpdateCmd_SendsReplaceFlagForArrays(t *testing.T) {
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPatch || r.URL.Path != "/v1/workspaces/ws-1/templates/"+uuidTemplateID {
+			t.Errorf("unexpected: %s %s", r.Method, r.URL.Path)
+		}
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		_, _ = io.WriteString(w, `{"template":{"id":"t-1","name":"Renamed"}}`)
+	}))
+	defer srv.Close()
+
+	_, _, err := cmdtest.Run(t, newUpdateCmd(), cmdtest.Opts{
+		RDEAPIBaseURL:      srv.URL,
+		DefaultWorkspaceID: "ws-1",
+		Args:               []string{uuidTemplateID, "--file", "-"},
+		Stdin:              `{"name":"Renamed","session_inputs":[{"key":"repo"}]}`,
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if gotBody["name"] != "Renamed" {
+		t.Errorf("name = %v, want Renamed", gotBody["name"])
+	}
+	// A present array field must carry its updateXxx replace flag so the
+	// server replaces (not merges) the list.
+	if gotBody["updateSessionInputs"] != true {
+		t.Errorf("updateSessionInputs = %v, want true (body=%v)", gotBody["updateSessionInputs"], gotBody)
+	}
+	// An absent array field must not trigger its flag.
+	if _, ok := gotBody["updateFeatureFlags"]; ok {
+		t.Errorf("updateFeatureFlags should be absent, body=%v", gotBody)
+	}
+}
+
+func TestUpdateCmd_RequiresFile(t *testing.T) {
+	_, _, err := cmdtest.Run(t, newUpdateCmd(), cmdtest.Opts{RDEAPIBaseURL: "http://unused", DefaultWorkspaceID: "ws-1", Args: []string{"t-1"}})
+	if err == nil || !strings.Contains(err.Error(), "--file") {
+		t.Errorf("error = %v, want --file required", err)
+	}
+}
+
+func TestUpdateCmd_RequiresArg(t *testing.T) {
+	_, _, err := cmdtest.Run(t, newUpdateCmd(), cmdtest.Opts{RDEAPIBaseURL: "http://unused", DefaultWorkspaceID: "ws-1", Args: []string{"--file", "-"}})
+	if err == nil {
+		t.Fatal("expected error when TEMPLATE_ID is missing")
+	}
+}
+
+func TestDeleteCmd_HappyPath(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete || r.URL.Path != "/v1/workspaces/ws-1/templates/"+uuidTemplateID {
+			t.Errorf("unexpected: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	stdout, stderr, err := cmdtest.Run(t, newDeleteCmd(), cmdtest.Opts{RDEAPIBaseURL: srv.URL, DefaultWorkspaceID: "ws-1", Args: []string{uuidTemplateID}})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	// Confirmation goes to stderr, never stdout.
+	if !strings.Contains(stderr, "Deleted template "+uuidTemplateID) {
+		t.Errorf("stderr missing confirmation: %q", stderr)
+	}
+	if stdout != "" {
+		t.Errorf("stdout should be empty for delete, got: %q", stdout)
+	}
+}
+
+// TestDeleteCmd_ResolvesName covers name → ID resolution: a non-UUID arg is
+// treated as a template name, looked up via ListTemplates, and the resolved ID
+// is what gets deleted.
+func TestDeleteCmd_ResolvesName(t *testing.T) {
+	var deletedPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/workspaces/ws-1/templates":
+			_, _ = io.WriteString(w, `{"templates":[{"id":"t-9","name":"Linux Dev"},{"id":"t-7","name":"macOS Dev"}]}`)
+		case r.Method == http.MethodDelete:
+			deletedPath = r.URL.Path
+		default:
+			t.Errorf("unexpected: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	_, stderr, err := cmdtest.Run(t, newDeleteCmd(), cmdtest.Opts{RDEAPIBaseURL: srv.URL, DefaultWorkspaceID: "ws-1", Args: []string{"Linux Dev"}})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if deletedPath != "/v1/workspaces/ws-1/templates/t-9" {
+		t.Errorf("deleted path = %q, want the resolved id t-9", deletedPath)
+	}
+	if !strings.Contains(stderr, "Deleted template t-9") {
+		t.Errorf("stderr should confirm deletion of the resolved id: %q", stderr)
+	}
+}
+
+func TestDeleteCmd_RequiresArg(t *testing.T) {
+	_, _, err := cmdtest.Run(t, newDeleteCmd(), cmdtest.Opts{RDEAPIBaseURL: "http://unused", DefaultWorkspaceID: "ws-1"})
+	if err == nil {
+		t.Fatal("expected error when TEMPLATE_ID is missing")
+	}
+}

--- a/cli/rde/template/list.go
+++ b/cli/rde/template/list.go
@@ -1,0 +1,72 @@
+package template
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/bitrise-io/bitrise/v2/cli/cmdutil"
+	internalrde "github.com/bitrise-io/bitrise/v2/internal/rde"
+	"github.com/bitrise-io/bitrise/v2/internal/style"
+	"github.com/bitrise-io/bitrise/v2/output"
+)
+
+type listResult struct {
+	Items []internalrde.Template `json:"items" yaml:"items"`
+}
+
+func newListCmd() *cobra.Command {
+	var format string
+	c := &cobra.Command{
+		Use:   "list",
+		Short: "List RDE templates in the workspace",
+		Example: `  bitrise rde template list
+  bitrise rde template list --format json | jq '.items[].id'`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cmdutil.LogCommandParameters(cmd)
+
+			if err := output.ConfigureOutputFormat(format); err != nil {
+				return fmt.Errorf("failed to configure output format: %w", err)
+			}
+
+			workspaceID, err := cmdutil.ResolveWorkspaceID(cmd)
+			if err != nil {
+				return err
+			}
+			client, err := cmdutil.NewRDEClient(cmd)
+			if err != nil {
+				return err
+			}
+			items, err := internalrde.NewService(client).ListTemplates(cmd.Context(), workspaceID)
+			if err != nil {
+				return err
+			}
+			return output.Render(cmd.OutOrStdout(), output.Format, listResult{Items: items}, renderList)
+		},
+	}
+	c.Flags().StringVarP(&format, cmdutil.FormatKey, "f", "", "Output format. Accepted: raw (default), json, yml")
+	return c
+}
+
+func renderList(w io.Writer, res listResult) error {
+	if len(res.Items) == 0 {
+		_, err := fmt.Fprintln(w, "No templates found.")
+		return err
+	}
+	s := style.New(w)
+	headers := []string{"NAME", "STACK", "MACHINE", "OWNER", "ID"}
+	rows := make([][]string, 0, len(res.Items))
+	for _, t := range res.Items {
+		rows = append(rows, []string{t.Name, t.StackID, t.MachineType, t.CreatedByEmail, t.ID})
+	}
+	const colID = 4
+	styler := func(_, col int, content string) string {
+		if col == colID {
+			return s.Slug.Render(content)
+		}
+		return content
+	}
+	return style.Table(w, headers, rows, s.Header, styler)
+}

--- a/cli/rde/template/main_test.go
+++ b/cli/rde/template/main_test.go
@@ -1,0 +1,10 @@
+package template
+
+import (
+	"os"
+	"testing"
+
+	"github.com/bitrise-io/bitrise/v2/cli/cmdtest"
+)
+
+func TestMain(m *testing.M) { os.Exit(cmdtest.RunIsolated(m)) }

--- a/cli/rde/template/template_test.go
+++ b/cli/rde/template/template_test.go
@@ -1,0 +1,127 @@
+package template
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/bitrise-io/bitrise/v2/cli/cmdtest"
+	"github.com/bitrise-io/bitrise/v2/output"
+)
+
+func TestListCmd_HappyPath(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/workspaces/ws-1/templates" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		_, _ = io.WriteString(w, `{"templates":[
+			{"id":"t-1","name":"Linux Dev","stackId":"linux-ubuntu-24.04","machineType":"standard","createdByEmail":"a@b.io"}
+		]}`)
+	}))
+	defer srv.Close()
+
+	stdout, _, err := cmdtest.Run(t, newListCmd(), cmdtest.Opts{RDEAPIBaseURL: srv.URL, DefaultWorkspaceID: "ws-1"})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	for _, want := range []string{"Linux Dev", "linux-ubuntu-24.04", "standard", "a@b.io", "t-1"} {
+		if !strings.Contains(stdout, want) {
+			t.Errorf("stdout missing %q:\n%s", want, stdout)
+		}
+	}
+}
+
+func TestListCmd_JSONOutput(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `{"templates":[
+			{"id":"t-1","name":"Linux Dev","stackId":"linux-ubuntu-24.04","machineType":"standard"}
+		]}`)
+	}))
+	defer srv.Close()
+
+	stdout, _, err := cmdtest.Run(t, newListCmd(), cmdtest.Opts{RDEAPIBaseURL: srv.URL, DefaultWorkspaceID: "ws-1", Format: output.FormatJSON})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	var got struct {
+		Items []struct {
+			ID          string `json:"id"`
+			Name        string `json:"name"`
+			MachineType string `json:"machine_type"`
+		} `json:"items"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &got); err != nil {
+		t.Fatalf("unmarshal JSON output: %v\n%s", err, stdout)
+	}
+	if len(got.Items) != 1 || got.Items[0].ID != "t-1" || got.Items[0].MachineType != "standard" {
+		t.Errorf("unexpected JSON items: %+v", got.Items)
+	}
+}
+
+func TestListCmd_EmptyHuman(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `{"templates":[]}`)
+	}))
+	defer srv.Close()
+
+	stdout, _, err := cmdtest.Run(t, newListCmd(), cmdtest.Opts{RDEAPIBaseURL: srv.URL, DefaultWorkspaceID: "ws-1"})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !strings.Contains(stdout, "No templates found.") {
+		t.Errorf("expected empty-state message, got: %q", stdout)
+	}
+}
+
+func TestViewCmd_HappyPath(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/workspaces/ws-1/templates/"+uuidTemplateID {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		_, _ = io.WriteString(w, `{"template":{
+			"id":"t-1","name":"Linux Dev","stackId":"linux-ubuntu-24.04","machineType":"standard",
+			"sessionInputs":[{"key":"repo","required":true,"description":"Repo to clone"}],
+			"templateVariables":[{"key":"TOKEN","isSecret":true}]
+		}}`)
+	}))
+	defer srv.Close()
+
+	stdout, _, err := cmdtest.Run(t, newViewCmd(), cmdtest.Opts{RDEAPIBaseURL: srv.URL, DefaultWorkspaceID: "ws-1", Args: []string{uuidTemplateID}})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	for _, want := range []string{"Linux Dev", "t-1", "linux-ubuntu-24.04", "repo", "(required)", "TOKEN", "(secret)"} {
+		if !strings.Contains(stdout, want) {
+			t.Errorf("stdout missing %q:\n%s", want, stdout)
+		}
+	}
+}
+
+func TestViewCmd_JSONOutput(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `{"template":{"id":"t-1","name":"Linux Dev","machineType":"standard"}}`)
+	}))
+	defer srv.Close()
+
+	stdout, _, err := cmdtest.Run(t, newViewCmd(), cmdtest.Opts{RDEAPIBaseURL: srv.URL, DefaultWorkspaceID: "ws-1", Args: []string{uuidTemplateID}, Format: output.FormatJSON})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal([]byte(stdout), &got); err != nil {
+		t.Fatalf("unmarshal JSON output: %v\n%s", err, stdout)
+	}
+	if got["id"] != "t-1" || got["machine_type"] != "standard" {
+		t.Errorf("unexpected JSON: %v", got)
+	}
+}
+
+func TestViewCmd_RequiresArg(t *testing.T) {
+	_, _, err := cmdtest.Run(t, newViewCmd(), cmdtest.Opts{RDEAPIBaseURL: "http://unused", DefaultWorkspaceID: "ws-1"})
+	if err == nil {
+		t.Fatal("expected error when TEMPLATE_ID is missing")
+	}
+}

--- a/cli/rde/template/view.go
+++ b/cli/rde/template/view.go
@@ -1,0 +1,110 @@
+package template
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/bitrise-io/bitrise/v2/cli/cmdutil"
+	internalrde "github.com/bitrise-io/bitrise/v2/internal/rde"
+	"github.com/bitrise-io/bitrise/v2/internal/style"
+	"github.com/bitrise-io/bitrise/v2/output"
+)
+
+func newViewCmd() *cobra.Command {
+	var format string
+	c := &cobra.Command{
+		Use:   "view TEMPLATE_ID",
+		Short: "Show details of a single template",
+		Args:  cmdutil.RequireArgs("TEMPLATE_ID"),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cmdutil.LogCommandParameters(cmd)
+
+			if err := output.ConfigureOutputFormat(format); err != nil {
+				return fmt.Errorf("failed to configure output format: %w", err)
+			}
+
+			workspaceID, err := cmdutil.ResolveWorkspaceID(cmd)
+			if err != nil {
+				return err
+			}
+			client, err := cmdutil.NewRDEClient(cmd)
+			if err != nil {
+				return err
+			}
+			svc := internalrde.NewService(client)
+			templateID, err := svc.ResolveTemplateID(cmd.Context(), workspaceID, args[0])
+			if err != nil {
+				return err
+			}
+			t, err := svc.GetTemplate(cmd.Context(), workspaceID, templateID)
+			if err != nil {
+				return err
+			}
+			return output.Render(cmd.OutOrStdout(), output.Format, t, renderDetail)
+		},
+	}
+	c.Flags().StringVarP(&format, cmdutil.FormatKey, "f", "", "Output format. Accepted: raw (default), json, yml")
+	return c
+}
+
+func renderDetail(w io.Writer, t internalrde.Template) error {
+	s := style.New(w)
+	ew := cmdutil.NewErrWriter(w)
+	lbl := func(label string) string { return s.Label.Render(fmt.Sprintf("%-18s", label)) }
+
+	ew.F("%s%s\n", lbl("Name:"), t.Name)
+	ew.F("%s%s\n", lbl("ID:"), s.Slug.Render(t.ID))
+	if t.Description != "" {
+		ew.F("%s%s\n", lbl("Description:"), t.Description)
+	}
+	if t.StackID != "" {
+		ew.F("%s%s\n", lbl("Stack:"), t.StackID)
+	}
+	if t.MachineType != "" {
+		ew.F("%s%s\n", lbl("Machine type:"), t.MachineType)
+	}
+	if t.WorkingDirectory != "" {
+		ew.F("%s%s\n", lbl("Working dir:"), t.WorkingDirectory)
+	}
+	if t.CreatedByEmail != "" {
+		ew.F("%s%s\n", lbl("Owner:"), t.CreatedByEmail)
+	}
+	if t.UpdatedAt != nil {
+		ew.F("%s%s\n", lbl("Updated:"), t.UpdatedAt.UTC().Format("2006-01-02 15:04 UTC"))
+	}
+	if len(t.SessionInputs) > 0 {
+		ew.Ln()
+		ew.Ln(s.Dim.Render("Session inputs"))
+		for _, i := range t.SessionInputs {
+			req := ""
+			if i.Required {
+				req = " (required)"
+			}
+			ew.F("  %s%s\n", i.Key, req)
+			if i.Description != "" {
+				ew.F("    %s\n", s.Dim.Render(i.Description))
+			}
+		}
+	}
+	if len(t.FeatureFlags) > 0 {
+		ew.Ln()
+		ew.Ln(s.Dim.Render("Feature flags"))
+		for _, f := range t.FeatureFlags {
+			ew.F("  %s\n", f.Name)
+		}
+	}
+	if len(t.TemplateVariables) > 0 {
+		ew.Ln()
+		ew.Ln(s.Dim.Render("Template variables"))
+		for _, v := range t.TemplateVariables {
+			label := v.Key
+			if v.IsSecret {
+				label += " (secret)"
+			}
+			ew.F("  %s\n", label)
+		}
+	}
+	return ew.Err
+}


### PR DESCRIPTION
Adds the last two rde CRUD groups: `rde template` (list, view, create, update, delete — create/update read a JSON spec file via --file, with "-" meaning stdin) and `rde saved-input` (list, view, create, update, delete, plus the `saved-inputs` alias, the only alias in the tree). Pure CLI-layer port on top of internal/rde's Template and SavedInput service methods, which landed in PR 7; nothing below cli/ changes.

Saved inputs are user-scoped, not workspace-scoped, so that package never calls ResolveWorkspaceID. Secret masking is already service-side — savedInputFromAPI blanks Value whenever IsSecret, on every method including create and update, since the backend echoes the submitted value back — so the renderers only choose display text and the json/yml paths rely on the blanked field plus omitempty.

Five deliberate divergences from the reference implementation:

- Both parent commands get `Args: cobra.NoArgs`. The reference omits it, and because DelegateToList invokes list's RunE directly, cobra's unknown-command check never fires there — `rde template viwe` silently lists templates. The session, stack and machine-type parents in this repo all carry it already.
- Per-command --format, following PRs 9-12: with the -f shorthand on template list/view and all four rendering saved-input commands; without it on template create/update, which own --file/-f; and not at all on either delete, which renders no result object.
- template delete returns its stderr-write error rather than discarding it. The reference has `_, _ =` there but `return err` in savedinput/delete.go; this matches cli/rde/session/delete.go.
- Dropped the //nolint:gosec on crud.go's os.ReadFile — gosec isn't in this repo's .golangci.yml — along with its justification comment, which only restated the signature once the suppression was gone.
- No counterpart to the reference's TestListCmd_MissingWorkspace: PR 4 moved that path into cmdutil.ResolveWorkspaceID, covered by ten tests in cli/cmdutil/workspace_test.go.

The listResult wrappers carry yaml tags alongside their json tags, since this repo has a third output format the reference doesn't. Verified against a stub server that --format yml and --format json produce identical keys and values for all eight rendering commands, that secret values appear as "(hidden)" in raw and are absent entirely from json and yml, and that the root -o is honoured while a per-command -f overrides it. Also checked by hand: both parents list when bare (including via the saved-inputs alias) and reject an unknown subcommand, -q silences both delete confirmations with stdout left empty, --value-stdin and a literal --value - both round-trip, --value with --value-stdin is rejected, and template name-to-ID resolution works including the not-found error.