### PR TITLE
RDE 15 - rde claude support files

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,6 +19,9 @@ linters:
       - linters:
           - staticcheck
         text: QF1003 # https://staticcheck.dev/docs/checks#QF1003
+      - linters:
+          - unused
+        path: ^cli/rde/claude/ # PR 15 pre-stages files with no caller yet; PR 16's cmd.go/resume.go wire them up — remove this rule then
     paths:
       - examples$
 formatters:

--- a/cli/rde/claude/claudeauth.go
+++ b/cli/rde/claude/claudeauth.go
@@ -1,0 +1,175 @@
+package claude
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	internalrde "github.com/bitrise-io/bitrise/v2/internal/rde"
+)
+
+// Claude Code auth env-var names — also the saved-input keys the RDE control
+// plane uses for a configured Subscription Token / API Key.
+const (
+	envOAuthToken = "CLAUDE_CODE_OAUTH_TOKEN"
+	envAPIKey     = "ANTHROPIC_API_KEY"
+)
+
+// sourceSetupToken labels a credential freshly minted by `claude setup-token`.
+const sourceSetupToken = "claude setup-token"
+
+// forwardCred is a local Claude Code credential to save on the control plane.
+type forwardCred struct {
+	EnvVar string // saved-input key (CLAUDE_CODE_OAUTH_TOKEN / ANTHROPIC_API_KEY)
+	Value  string // the token/key value
+	Source string // short human-readable origin, for logging
+}
+
+// controlPlaneHasClaudeToken reports whether the user has a Claude Code token
+// configured on the control plane — i.e. a saved input keyed
+// CLAUDE_CODE_OAUTH_TOKEN or ANTHROPIC_API_KEY. Saved inputs are user-scoped,
+// so no workspace is needed.
+func controlPlaneHasClaudeToken(ctx context.Context, svc *internalrde.Service) (bool, error) {
+	inputs, err := svc.ListSavedInputs(ctx)
+	if err != nil {
+		return false, err
+	}
+	for _, in := range inputs {
+		if in.Key == envOAuthToken || in.Key == envAPIKey {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// existingLocalCredential resolves a Claude Code credential already present on
+// the machine, without any interaction. Precedence mirrors how `claude` itself
+// resolves auth: an explicit env var wins, then the credentials file. Returns
+// ok=false when nothing is found (the caller may then mint one).
+func existingLocalCredential() (forwardCred, bool) {
+	if v := os.Getenv(envOAuthToken); v != "" {
+		return forwardCred{EnvVar: envOAuthToken, Value: v, Source: "$" + envOAuthToken}, true
+	}
+	if v := os.Getenv(envAPIKey); v != "" {
+		return forwardCred{EnvVar: envAPIKey, Value: v, Source: "$" + envAPIKey}, true
+	}
+	if v, ok := credentialsFileToken(); ok {
+		return forwardCred{EnvVar: envOAuthToken, Value: v, Source: credentialsFilePath()}, true
+	}
+	return forwardCred{}, false
+}
+
+// mintSetupToken runs `claude setup-token` to obtain a long-lived OAuth token.
+// It's interactive (browser auth): stdin/stderr stay wired to the terminal so
+// the user can complete the flow; the token is read from stdout.
+func mintSetupToken(ctx context.Context) (forwardCred, bool) {
+	c := exec.CommandContext(ctx, "claude", "setup-token")
+	c.Stdin = os.Stdin
+	c.Stderr = os.Stderr
+	out, err := c.Output()
+	if err != nil {
+		return forwardCred{}, false
+	}
+	token := extractToken(string(out))
+	if token == "" {
+		return forwardCred{}, false
+	}
+	return forwardCred{EnvVar: envOAuthToken, Value: token, Source: sourceSetupToken}, true
+}
+
+var (
+	// ansiSeqRe matches the terminal escape sequences (CSI and OSC) that
+	// `claude setup-token` interleaves with its output.
+	ansiSeqRe = regexp.MustCompile(`\x1b\[[0-?]*[ -/]*[@-~]|\x1b\][^\x07]*\x07`)
+	// tokenRe matches an Anthropic token by its stable prefix.
+	tokenRe = regexp.MustCompile(`sk-ant-[A-Za-z0-9._-]{10,}`)
+	// fallbackTokenRe accepts a lone token-shaped line if the prefix ever
+	// changes — strict enough to reject stray escape-sequence fragments.
+	fallbackTokenRe = regexp.MustCompile(`^[A-Za-z0-9._-]{20,}$`)
+)
+
+// extractToken pulls the OAuth token out of `claude setup-token` output, which
+// interleaves the token with terminal escape sequences (so the naive "last
+// line" is often a terminal-restore sequence like ESC[?2004l). It strips ANSI
+// and control sequences, then matches the token by its sk-ant- prefix, falling
+// back to a single token-shaped line.
+func extractToken(out string) string {
+	clean := ansiSeqRe.ReplaceAllString(out, "")
+	clean = strings.Map(func(r rune) rune {
+		if r == '\n' || r == '\t' {
+			return r
+		}
+		if r < 0x20 || r == 0x7f { // drop remaining control chars (incl. lone ESC)
+			return -1
+		}
+		return r
+	}, clean)
+
+	if m := tokenRe.FindString(clean); m != "" {
+		return m
+	}
+	if line := lastNonEmptyLine(clean); fallbackTokenRe.MatchString(line) {
+		return line
+	}
+	return ""
+}
+
+// lastNonEmptyLine returns the last non-blank, trimmed line of s.
+func lastNonEmptyLine(s string) string {
+	lines := strings.Split(s, "\n")
+	for i := len(lines) - 1; i >= 0; i-- {
+		if t := strings.TrimSpace(lines[i]); t != "" {
+			return t
+		}
+	}
+	return ""
+}
+
+// credentialsFilePath returns the path to Claude Code's credentials file,
+// honoring $CLAUDE_CONFIG_DIR and falling back to ~/.claude.
+func credentialsFilePath() string {
+	dir := os.Getenv("CLAUDE_CONFIG_DIR")
+	if dir == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return ""
+		}
+		dir = filepath.Join(home, ".claude")
+	}
+	return filepath.Join(dir, ".credentials.json")
+}
+
+func credentialsFileToken() (string, bool) {
+	p := credentialsFilePath()
+	if p == "" {
+		return "", false
+	}
+	// p is the user's own Claude Code credentials file under $HOME/$CLAUDE_CONFIG_DIR
+	data, err := os.ReadFile(p)
+	if err != nil {
+		return "", false
+	}
+	return parseClaudeAccessToken(data)
+}
+
+// parseClaudeAccessToken extracts the OAuth access token from a Claude Code
+// credentials blob ({"claudeAiOauth":{"accessToken":…}}). If the blob isn't
+// that JSON shape, the trimmed raw bytes are treated as a bare token.
+func parseClaudeAccessToken(data []byte) (string, bool) {
+	var creds struct {
+		ClaudeAiOauth struct {
+			AccessToken string `json:"accessToken"`
+		} `json:"claudeAiOauth"`
+	}
+	if err := json.Unmarshal(data, &creds); err == nil && creds.ClaudeAiOauth.AccessToken != "" {
+		return creds.ClaudeAiOauth.AccessToken, true
+	}
+	if raw := strings.TrimSpace(string(data)); raw != "" && !strings.HasPrefix(raw, "{") {
+		return raw, true
+	}
+	return "", false
+}

--- a/cli/rde/claude/claudeauth.go
+++ b/cli/rde/claude/claudeauth.go
@@ -87,16 +87,17 @@ var (
 	ansiSeqRe = regexp.MustCompile(`\x1b\[[0-?]*[ -/]*[@-~]|\x1b\][^\x07]*\x07`)
 	// tokenRe matches an Anthropic token by its stable prefix.
 	tokenRe = regexp.MustCompile(`sk-ant-[A-Za-z0-9._-]{10,}`)
-	// fallbackTokenRe accepts a lone token-shaped line if the prefix ever
-	// changes — strict enough to reject stray escape-sequence fragments.
-	fallbackTokenRe = regexp.MustCompile(`^[A-Za-z0-9._-]{20,}$`)
 )
 
 // extractToken pulls the OAuth token out of `claude setup-token` output, which
 // interleaves the token with terminal escape sequences (so the naive "last
 // line" is often a terminal-restore sequence like ESC[?2004l). It strips ANSI
-// and control sequences, then matches the token by its sk-ant- prefix, falling
-// back to a single token-shaped line.
+// and control sequences, then matches the token by its sk-ant- prefix.
+//
+// Matching only the known prefix is deliberate: a looser "last token-shaped
+// line" fallback would, on unexpected output, persist a diagnostic line as a
+// secret on the control plane and fail confusingly in-session. Returning ""
+// instead surfaces ensureClaudeAuth's actionable "no token available" error.
 func extractToken(out string) string {
 	clean := ansiSeqRe.ReplaceAllString(out, "")
 	clean = strings.Map(func(r rune) rune {
@@ -109,24 +110,7 @@ func extractToken(out string) string {
 		return r
 	}, clean)
 
-	if m := tokenRe.FindString(clean); m != "" {
-		return m
-	}
-	if line := lastNonEmptyLine(clean); fallbackTokenRe.MatchString(line) {
-		return line
-	}
-	return ""
-}
-
-// lastNonEmptyLine returns the last non-blank, trimmed line of s.
-func lastNonEmptyLine(s string) string {
-	lines := strings.Split(s, "\n")
-	for i := len(lines) - 1; i >= 0; i-- {
-		if t := strings.TrimSpace(lines[i]); t != "" {
-			return t
-		}
-	}
-	return ""
+	return tokenRe.FindString(clean)
 }
 
 // credentialsFilePath returns the path to Claude Code's credentials file,

--- a/cli/rde/claude/claudeauth_test.go
+++ b/cli/rde/claude/claudeauth_test.go
@@ -1,0 +1,52 @@
+package claude
+
+import (
+	"testing"
+)
+
+func TestParseClaudeAccessToken(t *testing.T) {
+	if got, ok := parseClaudeAccessToken([]byte(`{"claudeAiOauth":{"accessToken":"tok-123","refreshToken":"r"}}`)); !ok || got != "tok-123" {
+		t.Errorf("json blob: got %q ok=%v, want tok-123 true", got, ok)
+	}
+	if got, ok := parseClaudeAccessToken([]byte("  bare-token\n")); !ok || got != "bare-token" {
+		t.Errorf("bare token: got %q ok=%v, want bare-token true", got, ok)
+	}
+	if _, ok := parseClaudeAccessToken([]byte(`{"claudeAiOauth":{"accessToken":""}}`)); ok {
+		t.Error("empty accessToken JSON should not be ok")
+	}
+	if _, ok := parseClaudeAccessToken([]byte("")); ok {
+		t.Error("empty input should not be ok")
+	}
+}
+
+func TestExistingLocalCredentialEnv(t *testing.T) {
+	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "oauth-tok")
+	t.Setenv("ANTHROPIC_API_KEY", "api-key")
+	cred, ok := existingLocalCredential()
+	if !ok || cred.EnvVar != "CLAUDE_CODE_OAUTH_TOKEN" || cred.Value != "oauth-tok" {
+		t.Errorf("oauth env should win: %+v ok=%v", cred, ok)
+	}
+
+	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "")
+	cred, ok = existingLocalCredential()
+	if !ok || cred.EnvVar != "ANTHROPIC_API_KEY" || cred.Value != "api-key" {
+		t.Errorf("api key fallback: %+v ok=%v", cred, ok)
+	}
+}
+
+func TestExtractToken(t *testing.T) {
+	// Token surrounded by escape sequences, with terminal-restore codes as the
+	// trailing output (the case that previously got saved as the "token").
+	withEscapes := "\x1b[?2004hPaste here:\x1b[0m\nsk-ant-oat01-abc_DEF-123.xyz\n\x1b[>4m\x1b[<u\x1b[?1004l\x1b[?2031l\x1b[?2004l"
+	if got := extractToken(withEscapes); got != "sk-ant-oat01-abc_DEF-123.xyz" {
+		t.Errorf("with escapes: got %q", got)
+	}
+	// Pure escape-sequence garbage must not be mistaken for a token.
+	if got := extractToken("\x1b[>4m\x1b[<u\x1b[?1004l\x1b[?2031l\x1b[?2004l"); got != "" {
+		t.Errorf("escape-only: got %q, want empty", got)
+	}
+	// Fallback: a clean token-shaped final line with no sk-ant prefix.
+	if got := extractToken("info\nABCDEF0123456789abcdefXYZ\n"); got != "ABCDEF0123456789abcdefXYZ" {
+		t.Errorf("fallback: got %q", got)
+	}
+}

--- a/cli/rde/claude/claudeauth_test.go
+++ b/cli/rde/claude/claudeauth_test.go
@@ -45,8 +45,9 @@ func TestExtractToken(t *testing.T) {
 	if got := extractToken("\x1b[>4m\x1b[<u\x1b[?1004l\x1b[?2031l\x1b[?2004l"); got != "" {
 		t.Errorf("escape-only: got %q, want empty", got)
 	}
-	// Fallback: a clean token-shaped final line with no sk-ant prefix.
-	if got := extractToken("info\nABCDEF0123456789abcdefXYZ\n"); got != "ABCDEF0123456789abcdefXYZ" {
-		t.Errorf("fallback: got %q", got)
+	// Only the sk-ant- prefix counts. A token-shaped diagnostic line is
+	// rejected rather than persisted as a credential on the control plane.
+	if got := extractToken("info\nABCDEF0123456789abcdefXYZ\n"); got != "" {
+		t.Errorf("unprefixed line: got %q, want empty", got)
 	}
 }

--- a/cli/rde/claude/log.go
+++ b/cli/rde/claude/log.go
@@ -1,0 +1,102 @@
+package claude
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/bitrise-io/bitrise/v2/cli/cmdutil"
+	"github.com/bitrise-io/bitrise/v2/internal/style"
+)
+
+// stepLogger writes the command's grouped progress to stderr: a bold group
+// title, indented step lines, and a green "✓" confirmation when a group
+// completes. Warnings use the yellow Warn style. Everything is a diagnostic —
+// it never touches stdout.
+type stepLogger struct {
+	w       io.Writer
+	s       style.Styles
+	quiet   bool
+	grouped bool // whether a group has been printed yet (for separator spacing)
+}
+
+func newStepLogger(cmd *cobra.Command) *stepLogger {
+	w := cmd.ErrOrStderr()
+	return &stepLogger{w: w, s: style.New(w), quiet: cmdutil.IsQuiet(cmd)}
+}
+
+// group starts a new section with a bold title, separated from the previous
+// group by a blank line (omitted before the first group).
+func (l *stepLogger) group(title string) {
+	if l.quiet {
+		return
+	}
+	sep := "\n"
+	if !l.grouped {
+		sep = ""
+		l.grouped = true
+	}
+	_, _ = fmt.Fprintf(l.w, "%s%s\n", sep, l.s.Bold.Render(title))
+}
+
+// step reports an in-progress action within the current group (indented, dim).
+func (l *stepLogger) step(format string, a ...any) {
+	if l.quiet {
+		return
+	}
+	_, _ = fmt.Fprintf(l.w, "  %s\n", l.s.Dim.Render(fmt.Sprintf(format, a...)))
+}
+
+// done confirms a completed group with the green "✓" success marker.
+func (l *stepLogger) done(format string, a ...any) {
+	if l.quiet {
+		return
+	}
+	_, _ = fmt.Fprintf(l.w, "%s %s\n", l.s.Success.Render("✓"), fmt.Sprintf(format, a...))
+}
+
+// warn emits a yellow warning. Unlike group/step/done, warnings are not
+// suppressed by --quiet.
+func (l *stepLogger) warn(format string, a ...any) {
+	_, _ = fmt.Fprintf(l.w, "  %s\n", l.s.Warn.Render(fmt.Sprintf(format, a...)))
+}
+
+// stepIndent is the prefix step lines use; indentWriter reuses it so streamed
+// remote output (e.g. git clone progress) lines up under its group.
+const stepIndent = "  "
+
+// indentWriter prefixes every line written through it with a fixed indent, so
+// a remote command's streamed output aligns with the logger's step lines. It
+// tracks line starts across writes and treats both "\n" and "\r" as line
+// boundaries, so carriage-return progress redraws (git's "Receiving objects…")
+// stay indented too. It is NOT suitable for full-screen TUIs that position the
+// cursor absolutely (e.g. Claude Code itself) — only for line-oriented output.
+type indentWriter struct {
+	w           io.Writer
+	prefix      string
+	atLineStart bool
+}
+
+// newIndentWriter wraps w so each output line is prefixed with stepIndent.
+func newIndentWriter(w io.Writer) *indentWriter {
+	return &indentWriter{w: w, prefix: stepIndent, atLineStart: true}
+}
+
+func (iw *indentWriter) Write(p []byte) (int, error) {
+	var buf []byte
+	for _, b := range p {
+		if iw.atLineStart && b != '\n' && b != '\r' {
+			buf = append(buf, iw.prefix...)
+			iw.atLineStart = false
+		}
+		buf = append(buf, b)
+		if b == '\n' || b == '\r' {
+			iw.atLineStart = true
+		}
+	}
+	if _, err := iw.w.Write(buf); err != nil {
+		return 0, err
+	}
+	return len(p), nil
+}

--- a/cli/rde/claude/main_test.go
+++ b/cli/rde/claude/main_test.go
@@ -1,0 +1,10 @@
+package claude
+
+import (
+	"os"
+	"testing"
+
+	"github.com/bitrise-io/bitrise/v2/cli/cmdtest"
+)
+
+func TestMain(m *testing.M) { os.Exit(cmdtest.RunIsolated(m)) }

--- a/cli/rde/claude/metadata.go
+++ b/cli/rde/claude/metadata.go
@@ -1,0 +1,125 @@
+package claude
+
+import (
+	"context"
+	"crypto/rand"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// generateClaudeSessionID returns a random UUIDv4 to pass to
+// `claude --session-id`. Generating it ourselves means we know the in-session
+// Claude session ID up front: we can store it immediately, find its transcript
+// to read the AI title, and resume it reliably with `claude --resume <id>`.
+// Built from crypto/rand to avoid a UUID dependency.
+func generateClaudeSessionID() (string, error) {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("generate claude session id: %w", err)
+	}
+	b[6] = (b[6] & 0x0f) | 0x40 // version 4
+	b[8] = (b[8] & 0x3f) | 0x80 // variant 10
+	return fmt.Sprintf("%x-%x-%x-%x-%x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:16]), nil
+}
+
+// newDescriber returns a function that builds the session description from the
+// local repo context. It's a function (not a fixed string) because the PR can
+// appear after the session starts, so the metadata monitor re-evaluates it
+// each tick.
+func newDescriber(repoSlug, branch string) func(context.Context) string {
+	return func(ctx context.Context) string {
+		return buildDescription(repoSlug, branch, ghPRURL(ctx, branch))
+	}
+}
+
+// buildDescription assembles the session description: "owner/repo @ branch"
+// with the pull-request URL on its own line. Empty parts are omitted. The URL
+// is kept bare so URL-detecting UIs render it as a link.
+func buildDescription(repoSlug, branch, prURL string) string {
+	desc := repoSlug
+	if branch != "" {
+		if desc != "" {
+			desc += " @ " + branch
+		} else {
+			desc = branch
+		}
+	}
+	if prURL != "" {
+		if desc != "" {
+			desc += "\n" + prURL
+		} else {
+			desc = prURL
+		}
+	}
+	return strings.TrimSpace(desc)
+}
+
+// ghPRURL returns the URL of the open pull request for branch, best-effort via
+// the `gh` CLI. Returns "" when gh isn't installed, isn't authenticated, or the
+// branch has no associated PR.
+func ghPRURL(ctx context.Context, branch string) string {
+	if branch == "" {
+		return ""
+	}
+	if _, err := exec.LookPath("gh"); err != nil {
+		return ""
+	}
+	// branch comes from the local repo's checked-out HEAD, passed as its own argv element — no shell, no injection
+	out, err := exec.CommandContext(ctx, "gh", "pr", "view", branch, "--json", "url", "-q", ".url").Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// repoRootPath returns the absolute path of the current repo's root (the
+// project key for the local session store). Falls back to the working
+// directory, then "".
+func repoRootPath(ctx context.Context) string {
+	if out, err := exec.CommandContext(ctx, "git", "rev-parse", "--show-toplevel").Output(); err == nil {
+		if p := strings.TrimSpace(string(out)); p != "" {
+			return p
+		}
+	}
+	if wd, err := os.Getwd(); err == nil {
+		return wd
+	}
+	return ""
+}
+
+// repoSlugFromURL extracts "owner/repo" from a clone URL (ssh, scp-like, or
+// https), trimming any ".git" suffix. Returns "" when it can't parse one.
+func repoSlugFromURL(raw string) string {
+	s := strings.TrimSpace(raw)
+	scheme := false
+	for _, p := range []string{"ssh://", "https://", "http://", "git://"} {
+		if rest, ok := strings.CutPrefix(s, p); ok {
+			s = rest
+			scheme = true
+			break
+		}
+	}
+	if _, after, ok := strings.Cut(s, "@"); ok {
+		s = after
+	}
+	var path string
+	if scheme {
+		// host[:port]/owner/repo
+		_, p, ok := strings.Cut(s, "/")
+		if !ok {
+			return ""
+		}
+		path = p
+	} else {
+		// scp-like: host:owner/repo
+		_, p, ok := strings.Cut(s, ":")
+		if !ok {
+			return ""
+		}
+		path = p
+	}
+	path = strings.TrimSuffix(path, ".git")
+	return strings.Trim(path, "/")
+}

--- a/cli/rde/claude/metadata_test.go
+++ b/cli/rde/claude/metadata_test.go
@@ -1,0 +1,58 @@
+package claude
+
+import (
+	"regexp"
+	"testing"
+)
+
+func TestRepoSlugFromURL(t *testing.T) {
+	for _, tc := range []struct {
+		in, want string
+	}{
+		{"git@github.com:org/repo.git", "org/repo"},
+		{"git@github.com:org/repo", "org/repo"},
+		{"https://github.com/org/repo.git", "org/repo"},
+		{"https://github.com/org/repo", "org/repo"},
+		{"ssh://git@github.com/org/repo.git", "org/repo"},
+		{"git@gitlab.com:grp/sub/repo.git", "grp/sub/repo"},
+		{"https://user@github.com/org/repo.git", "org/repo"},
+		{"not a url", ""},
+		{"", ""},
+	} {
+		if got := repoSlugFromURL(tc.in); got != tc.want {
+			t.Errorf("repoSlugFromURL(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestBuildDescription(t *testing.T) {
+	for _, tc := range []struct {
+		slug, branch, prURL, want string
+	}{
+		{"org/repo", "main", "", "org/repo @ main"},
+		{"org/repo", "main", "https://example.com/pull/7", "org/repo @ main\nhttps://example.com/pull/7"},
+		{"org/repo", "", "", "org/repo"},
+		{"", "main", "", "main"},
+		{"", "", "https://example.com/pull/7", "https://example.com/pull/7"},
+		{"", "", "", ""},
+	} {
+		if got := buildDescription(tc.slug, tc.branch, tc.prURL); got != tc.want {
+			t.Errorf("buildDescription(%q,%q,%q) = %q, want %q", tc.slug, tc.branch, tc.prURL, got, tc.want)
+		}
+	}
+}
+
+func TestGenerateClaudeSessionID(t *testing.T) {
+	uuidRe := regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$`)
+	a, err := generateClaudeSessionID()
+	if err != nil {
+		t.Fatalf("generateClaudeSessionID: %v", err)
+	}
+	if !uuidRe.MatchString(a) {
+		t.Errorf("not a v4 UUID: %q", a)
+	}
+	b, _ := generateClaudeSessionID()
+	if a == b {
+		t.Errorf("expected distinct UUIDs, got %q twice", a)
+	}
+}

--- a/cli/rde/claude/spinner.go
+++ b/cli/rde/claude/spinner.go
@@ -1,0 +1,170 @@
+package claude
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/bubbles/spinner"
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/bitrise-io/bitrise/v2/cli/cmdutil"
+	"github.com/bitrise-io/bitrise/v2/internal/style"
+)
+
+// await runs fn while showing an animated spinner line for a long, otherwise
+// silent wait (e.g. the session boot). The spinner shows the elapsed time and
+// an optional live sub-status that fn reports through the status callback. On
+// success it leaves a settled "✓ <settled> (<elapsed>)" line in the scrollback;
+// on failure it returns fn's error and prints nothing extra.
+//
+// It degrades to a plain static step line — today's behavior — whenever the
+// output isn't an interactive color terminal or --quiet is set, so piped,
+// redirected and CI output stays animation-free. Like the rest of stepLogger
+// it only ever writes to stderr.
+//
+// await is synchronous: the spinner program is fully torn down (and the
+// terminal restored) before it returns, so a following step that takes over
+// the terminal — the git clone or the Claude Code attach — starts from a
+// clean slate.
+func (l *stepLogger) await(ctx context.Context, label, settled string, fn func(ctx context.Context, status func(string)) error) error {
+	if l.quiet || !cmdutil.IsTerminalWriter(l.w) || !l.s.HasColor() {
+		l.step("%s", label)
+		return fn(ctx, func(string) {})
+	}
+
+	// A child context so cancelling here (e.g. on a render failure) also stops
+	// fn, and an outer cancel (Ctrl-C) stops both the program and fn together.
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	start := time.Now()
+	p := tea.NewProgram(
+		newSpinnerModel(label, l.s),
+		tea.WithContext(ctx),
+		// No stdin: the spinner needs no keys, and reading stdin here could
+		// swallow input meant for the step that follows. Ctrl-C still works
+		// through the command's signal-aware context.
+		tea.WithInput(bytes.NewReader(nil)),
+		tea.WithOutput(l.w),
+	)
+
+	errCh := make(chan error, 1)
+	go func() {
+		err := fn(ctx, func(status string) { p.Send(statusMsg(status)) })
+		p.Send(doneMsg{err: err})
+		errCh <- err
+	}()
+
+	_, runErr := p.Run()
+	cancel()
+	err := <-errCh
+	if err != nil {
+		return err
+	}
+	// The wait succeeded; a render failure (rare) just means no settled line.
+	if runErr == nil {
+		l.settled(settled, time.Since(start))
+	}
+	return nil
+}
+
+// settled prints the indented, green-checked confirmation a finished await
+// leaves behind: "  ✓ Session booted (1m31s)".
+func (l *stepLogger) settled(label string, d time.Duration) {
+	if l.quiet {
+		return
+	}
+	_, _ = fmt.Fprintf(l.w, "%s%s %s\n", stepIndent,
+		l.s.Success.Render("✓"),
+		l.s.Dim.Render(fmt.Sprintf("%s (%s)", label, d.Round(time.Second))))
+}
+
+// statusMsg updates the spinner's live sub-status (e.g. "starting").
+type statusMsg string
+
+// doneMsg ends the spinner once the awaited work returns.
+type doneMsg struct{ err error }
+
+// tickMsg drives a once-a-second redraw so the elapsed counter advances even
+// while the awaited work is quiet.
+type tickMsg time.Time
+
+func elapsedTick() tea.Cmd {
+	return tea.Tick(time.Second, func(t time.Time) tea.Msg { return tickMsg(t) })
+}
+
+// spinnerModel renders a single in-progress line: a brand-purple spinner, a
+// label, the elapsed time, and an optional live sub-status. It collapses to ""
+// once finished so the caller's settled line is what stays in the scrollback —
+// the same disappearing-frame approach the picker uses.
+type spinnerModel struct {
+	spinner   spinner.Model
+	label     string
+	status    string
+	startedAt time.Time
+	finished  bool
+	s         style.Styles
+}
+
+func newSpinnerModel(label string, s style.Styles) spinnerModel {
+	sp := spinner.New()
+	sp.Spinner = spinner.Dot
+	sp.Style = s.Brand
+	return spinnerModel{
+		spinner:   sp,
+		label:     label,
+		startedAt: time.Now(),
+		s:         s,
+	}
+}
+
+func (m spinnerModel) Init() tea.Cmd {
+	return tea.Batch(m.spinner.Tick, elapsedTick())
+}
+
+func (m spinnerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case spinner.TickMsg:
+		var cmd tea.Cmd
+		m.spinner, cmd = m.spinner.Update(msg)
+		return m, cmd
+	case tickMsg:
+		if m.finished {
+			return m, nil
+		}
+		return m, elapsedTick()
+	case statusMsg:
+		m.status = string(msg)
+		return m, nil
+	case doneMsg:
+		m.finished = true
+		return m, tea.Quit
+	case tea.KeyMsg:
+		if msg.Type == tea.KeyCtrlC {
+			return m, tea.Quit
+		}
+	}
+	return m, nil
+}
+
+func (m spinnerModel) View() string {
+	if m.finished {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString(stepIndent)
+	b.WriteString(m.spinner.View()) // brand-purple frame, includes a trailing space
+	b.WriteString(m.label)
+	b.WriteString(m.s.Dim.Render("  " + m.elapsed()))
+	if m.status != "" {
+		b.WriteString(m.s.Dim.Render("  (" + m.status + ")"))
+	}
+	return b.String()
+}
+
+func (m spinnerModel) elapsed() string {
+	return time.Since(m.startedAt).Round(time.Second).String()
+}

--- a/cli/rde/claude/spinner_test.go
+++ b/cli/rde/claude/spinner_test.go
@@ -1,0 +1,96 @@
+package claude
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/bitrise-io/bitrise/v2/internal/style"
+)
+
+func TestSpinnerModel_ViewShowsLabelAndStatus(t *testing.T) {
+	m := newSpinnerModel("Booting session…", style.New(&bytes.Buffer{}))
+
+	view := m.View()
+	if !strings.Contains(view, "Booting session…") {
+		t.Errorf("view %q does not contain the label", view)
+	}
+
+	updated, _ := m.Update(statusMsg("starting"))
+	m = updated.(spinnerModel)
+	if !strings.Contains(m.View(), "(starting)") {
+		t.Errorf("view %q does not show the live status", m.View())
+	}
+}
+
+func TestSpinnerModel_CollapsesWhenDone(t *testing.T) {
+	m := newSpinnerModel("Booting session…", style.New(&bytes.Buffer{}))
+
+	updated, cmd := m.Update(doneMsg{})
+	m = updated.(spinnerModel)
+	if !m.finished {
+		t.Error("model not marked finished after doneMsg")
+	}
+	if cmd == nil {
+		t.Error("doneMsg should return a quit command")
+	}
+	if m.View() != "" {
+		t.Errorf("finished view = %q, want empty (collapsed)", m.View())
+	}
+}
+
+func TestAwait_FallbackRunsFnAndSkipsAnimation(t *testing.T) {
+	// A bytes.Buffer is not a TTY, so await takes the plain-line fallback.
+	var buf bytes.Buffer
+	log := &stepLogger{w: &buf, s: style.New(&buf)}
+
+	ran := false
+	err := log.await(context.Background(), "Booting session…", "Session booted",
+		func(_ context.Context, status func(string)) error {
+			ran = true
+			status("starting") // must be a safe no-op in the fallback
+			return nil
+		})
+	if err != nil {
+		t.Fatalf("await: %v", err)
+	}
+	if !ran {
+		t.Error("fn was not run")
+	}
+	out := buf.String()
+	if !strings.Contains(out, "Booting session…") {
+		t.Errorf("output %q does not contain the label", out)
+	}
+	// The fallback keeps today's behavior: a plain step line, no settled "✓".
+	if strings.Contains(out, "✓") {
+		t.Errorf("output %q unexpectedly contains a settled check", out)
+	}
+}
+
+func TestAwait_FallbackPropagatesError(t *testing.T) {
+	var buf bytes.Buffer
+	log := &stepLogger{w: &buf, s: style.New(&buf)}
+
+	want := errors.New("boom")
+	err := log.await(context.Background(), "Booting session…", "Session booted",
+		func(_ context.Context, _ func(string)) error { return want })
+	if !errors.Is(err, want) {
+		t.Errorf("await error = %v, want %v", err, want)
+	}
+}
+
+func TestAwait_QuietSuppressesOutput(t *testing.T) {
+	var buf bytes.Buffer
+	log := &stepLogger{w: &buf, s: style.New(&buf), quiet: true}
+
+	err := log.await(context.Background(), "Booting session…", "Session booted",
+		func(_ context.Context, _ func(string)) error { return nil })
+	if err != nil {
+		t.Fatalf("await: %v", err)
+	}
+	if buf.Len() != 0 {
+		t.Errorf("quiet await wrote %q, want nothing", buf.String())
+	}
+}

--- a/cli/rde/claude/sshagent.go
+++ b/cli/rde/claude/sshagent.go
@@ -1,0 +1,263 @@
+package claude
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/bitrise-io/bitrise/v2/cli/cmdutil"
+)
+
+// ensureAgentHasKey is an rde-claude-only convenience. The in-session git
+// clone authenticates via the forwarded local SSH agent (see exec_ssh.go), so
+// an agent with no keys loaded means a private clone fails. It:
+//   - starts a temporary agent if none is running (and returns a cleanup that
+//     kills it on exit);
+//   - adds a key when the agent is empty — chosen from the SSH config for the
+//     clone host (via `ssh -G`, which also yields the built-in defaults),
+//     falling back to the default key files.
+//
+// Entirely best-effort: any failure just means the clone may prompt or fail,
+// which the user sees live. The returned cleanup is never nil; auth is a short
+// description of the resulting git-clone auth method, for display; haveKey
+// reports whether the forwarded agent ends up with a usable key (the caller
+// falls back to HTTPS for the clone when it doesn't).
+func ensureAgentHasKey(ctx context.Context, log *stepLogger, cloneURL string) (cleanup func(), auth string, haveKey bool) {
+	cleanup = func() {}
+
+	// Agent forwarding only helps SSH remotes; HTTPS clones don't use it.
+	if !isSSHCloneURL(cloneURL) {
+		return cleanup, "HTTPS remote (no SSH key forwarding)", false
+	}
+	// ssh-add may prompt for a passphrase, so only attempt it with a real
+	// terminal (the rest of rde claude needs one anyway).
+	if !cmdutil.IsTerminal(os.Stdin) {
+		desc, have := forwardedAgentDesc(ctx)
+		return cleanup, desc, have
+	}
+
+	switch agentState(ctx) {
+	case agentHasKeys, agentUnknown:
+		desc, have := forwardedAgentDesc(ctx)
+		return cleanup, desc, have
+	case agentNoAgent:
+		c, err := startAgent(ctx)
+		if err != nil {
+			log.warn("No SSH agent running and could not start one (%v).", err)
+			desc, have := forwardedAgentDesc(ctx)
+			return cleanup, desc, have
+		}
+		log.step("Started a temporary SSH agent")
+		cleanup = c
+		// fall through to add a key to the fresh agent
+	case agentEmpty:
+		// fall through to add a key
+	}
+
+	key := pickIdentityFile(ctx, sshHostFromURL(cloneURL))
+	if key == "" {
+		log.warn("SSH agent has no keys and no key file was found to add.")
+		desc, have := forwardedAgentDesc(ctx)
+		return cleanup, desc, have
+	}
+	log.step("Adding SSH key %s to the agent…", key)
+	// Indent ssh-add's output (e.g. "Identity added: …") under the group, like
+	// the clone. ssh-add writes prompts/results to stderr, so point stdout
+	// there too; using one shared writer makes exec serialize writes to it (no
+	// concurrent-write race on the indenter).
+	out := newIndentWriter(os.Stderr)
+	// key is a local key-file path (from ssh -G or default files), passed as its own argv element — no shell, no injection
+	add := exec.CommandContext(ctx, "ssh-add", key)
+	add.Stdin = os.Stdin
+	add.Stdout = out
+	add.Stderr = out
+	_ = add.Run() // best-effort; the clone surfaces any remaining auth error
+	desc, have := forwardedAgentDesc(ctx)
+	return cleanup, desc, have
+}
+
+// forwardedAgentDesc describes the git-clone auth method based on what the
+// local SSH agent currently holds (and will therefore forward into the VM), and
+// reports whether it holds at least one key.
+func forwardedAgentDesc(ctx context.Context) (desc string, haveKey bool) {
+	switch n := agentKeyCount(ctx); {
+	case n == 1:
+		return "forwarded SSH agent (1 key)", true
+	case n > 1:
+		return fmt.Sprintf("forwarded SSH agent (%d keys)", n), true
+	default:
+		return "no forwarded SSH agent keys", false
+	}
+}
+
+// agentKeyCount returns how many identities the local SSH agent holds, or 0
+// when no agent is reachable / it's empty (`ssh-add -l` exits non-zero).
+func agentKeyCount(ctx context.Context) int {
+	out, err := exec.CommandContext(ctx, "ssh-add", "-l").Output()
+	if err != nil {
+		return 0
+	}
+	n := 0
+	for line := range strings.SplitSeq(string(out), "\n") {
+		if strings.TrimSpace(line) != "" {
+			n++
+		}
+	}
+	return n
+}
+
+// startAgent launches a temporary `ssh-agent`, exports its socket (and PID)
+// into this process's environment so ssh-add and our own agent forwarding
+// (dialLocalAgent reads $SSH_AUTH_SOCK) use it, and returns a cleanup that
+// terminates the agent. The agent must outlive both the clone and the
+// interactive claude session, so the caller defers cleanup to process exit.
+func startAgent(ctx context.Context) (func(), error) {
+	out, err := exec.CommandContext(ctx, "ssh-agent", "-s").Output()
+	if err != nil {
+		return nil, err
+	}
+	sock := parseAgentVar(string(out), "SSH_AUTH_SOCK")
+	if sock == "" {
+		return nil, errors.New("ssh-agent did not report a socket path")
+	}
+	if err := os.Setenv("SSH_AUTH_SOCK", sock); err != nil {
+		return nil, err
+	}
+	if pid := parseAgentVar(string(out), "SSH_AGENT_PID"); pid != "" {
+		_ = os.Setenv("SSH_AGENT_PID", pid)
+	}
+	return func() {
+		// `ssh-agent -k` reads SSH_AGENT_PID/SSH_AUTH_SOCK from the env we just
+		// set and kills the agent + removes its socket. Not ctx-bound: ctx is
+		// likely already cancelled by the time cleanup runs.
+		_ = exec.Command("ssh-agent", "-k").Run()
+	}, nil
+}
+
+// parseAgentVar extracts NAME's value from `ssh-agent -s` output, whose lines
+// look like `SSH_AUTH_SOCK=/tmp/…/agent.123; export SSH_AUTH_SOCK;`.
+func parseAgentVar(out, name string) string {
+	for line := range strings.SplitSeq(out, "\n") {
+		for field := range strings.SplitSeq(line, ";") {
+			if rest, ok := strings.CutPrefix(strings.TrimSpace(field), name+"="); ok {
+				return rest
+			}
+		}
+	}
+	return ""
+}
+
+type agentStatus int
+
+const (
+	agentHasKeys agentStatus = iota
+	agentEmpty
+	agentNoAgent
+	agentUnknown
+)
+
+// agentState classifies `ssh-add -l`: exit 0 = has identities, exit 1 = agent
+// reachable but empty, exit 2 = no agent reachable.
+func agentState(ctx context.Context) agentStatus {
+	err := exec.CommandContext(ctx, "ssh-add", "-l").Run()
+	if err == nil {
+		return agentHasKeys
+	}
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		switch exitErr.ExitCode() {
+		case 1:
+			return agentEmpty
+		case 2:
+			return agentNoAgent
+		}
+	}
+	return agentUnknown
+}
+
+// pickIdentityFile returns the first existing private key ssh would use for
+// host (from `ssh -G`, which lists configured IdentityFile entries followed by
+// the built-in defaults), falling back to the default key files directly when
+// `ssh -G` is unavailable.
+func pickIdentityFile(ctx context.Context, host string) string {
+	var candidates []string
+	if host != "" {
+		candidates = append(candidates, sshConfigIdentityFiles(ctx, host)...)
+	}
+	candidates = append(candidates, defaultKeyFiles()...)
+	for _, c := range candidates {
+		if c != "" && fileExists(c) {
+			return c
+		}
+	}
+	return ""
+}
+
+// sshConfigIdentityFiles asks `ssh -G git@host` for the identity files ssh
+// would try for that host, in order. Paths are returned with ~ expanded.
+func sshConfigIdentityFiles(ctx context.Context, host string) []string {
+	// host comes from the repo's git remote, passed as its own argv element — no shell, no injection
+	out, err := exec.CommandContext(ctx, "ssh", "-G", "git@"+host).Output()
+	if err != nil {
+		return nil
+	}
+	var files []string
+	for line := range strings.SplitSeq(string(out), "\n") {
+		if rest, ok := strings.CutPrefix(line, "identityfile "); ok {
+			files = append(files, expandHome(strings.TrimSpace(rest)))
+		}
+	}
+	return files
+}
+
+func defaultKeyFiles() []string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil
+	}
+	names := []string{"id_ed25519", "id_ecdsa", "id_rsa"}
+	files := make([]string, 0, len(names))
+	for _, n := range names {
+		files = append(files, filepath.Join(home, ".ssh", n))
+	}
+	return files
+}
+
+// isSSHCloneURL reports whether u is an SSH-form git URL (git@host:… or
+// ssh://…), the only form the forwarded agent can authenticate.
+func isSSHCloneURL(u string) bool {
+	return strings.HasPrefix(u, "git@") || strings.HasPrefix(u, "ssh://")
+}
+
+// sshHostFromURL extracts the host from a git clone URL (ssh or https form).
+func sshHostFromURL(u string) string {
+	s := u
+	for _, p := range []string{"ssh://", "https://", "http://", "git://"} {
+		s = strings.TrimPrefix(s, p)
+	}
+	if _, after, ok := strings.Cut(s, "@"); ok {
+		s = after
+	}
+	if i := strings.IndexAny(s, ":/"); i >= 0 {
+		s = s[:i]
+	}
+	return s
+}
+
+func expandHome(p string) string {
+	if p == "~" || strings.HasPrefix(p, "~/") {
+		if home, err := os.UserHomeDir(); err == nil {
+			return filepath.Join(home, strings.TrimPrefix(strings.TrimPrefix(p, "~"), "/"))
+		}
+	}
+	return p
+}
+
+func fileExists(p string) bool {
+	info, err := os.Stat(p)
+	return err == nil && !info.IsDir()
+}

--- a/cli/rde/claude/sshagent.go
+++ b/cli/rde/claude/sshagent.go
@@ -116,26 +116,40 @@ func agentKeyCount(ctx context.Context) int {
 // terminates the agent. The agent must outlive both the clone and the
 // interactive claude session, so the caller defers cleanup to process exit.
 func startAgent(ctx context.Context) (func(), error) {
+	// `ssh-agent -s` forks a daemon and exits, so from here on every error path
+	// has an agent to clean up — killAgent, not a bare return.
 	out, err := exec.CommandContext(ctx, "ssh-agent", "-s").Output()
 	if err != nil {
 		return nil, err
 	}
 	sock := parseAgentVar(string(out), "SSH_AUTH_SOCK")
+	pid := parseAgentVar(string(out), "SSH_AGENT_PID")
 	if sock == "" {
+		killAgent(pid, sock)
 		return nil, errors.New("ssh-agent did not report a socket path")
 	}
 	if err := os.Setenv("SSH_AUTH_SOCK", sock); err != nil {
+		killAgent(pid, sock)
 		return nil, err
 	}
-	if pid := parseAgentVar(string(out), "SSH_AGENT_PID"); pid != "" {
+	if pid != "" {
 		_ = os.Setenv("SSH_AGENT_PID", pid)
 	}
-	return func() {
-		// `ssh-agent -k` reads SSH_AGENT_PID/SSH_AUTH_SOCK from the env we just
-		// set and kills the agent + removes its socket. Not ctx-bound: ctx is
-		// likely already cancelled by the time cleanup runs.
-		_ = exec.Command("ssh-agent", "-k").Run()
-	}, nil
+	return func() { killAgent(pid, sock) }, nil
+}
+
+// killAgent terminates the agent we started and removes its socket. The env is
+// passed explicitly rather than inherited: `ssh-agent -k` reads SSH_AGENT_PID/
+// SSH_AUTH_SOCK, and on the failure paths above we have not set them on the
+// process yet. Not ctx-bound — ctx is likely already cancelled by the time the
+// success path's cleanup runs.
+func killAgent(pid, sock string) {
+	if pid == "" && sock == "" {
+		return
+	}
+	c := exec.Command("ssh-agent", "-k")
+	c.Env = append(os.Environ(), "SSH_AGENT_PID="+pid, "SSH_AUTH_SOCK="+sock)
+	_ = c.Run()
 }
 
 // parseAgentVar extracts NAME's value from `ssh-agent -s` output, whose lines

--- a/cli/rde/claude/sshagent_test.go
+++ b/cli/rde/claude/sshagent_test.go
@@ -1,0 +1,56 @@
+package claude
+
+import (
+	"testing"
+)
+
+func TestSSHHostFromURL(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"ssh scp form", "git@github.com:org/repo.git", "github.com"},
+		{"ssh scheme", "ssh://git@github.com/org/repo.git", "github.com"},
+		{"https form", "https://gitlab.com/group/repo.git", "gitlab.com"},
+		{"https with user", "https://user@github.com/org/repo", "github.com"},
+		{"git scheme", "git://example.com/repo.git", "example.com"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := sshHostFromURL(tc.in); got != tc.want {
+				t.Errorf("sshHostFromURL(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIsSSHCloneURL(t *testing.T) {
+	for _, tc := range []struct {
+		in   string
+		want bool
+	}{
+		{"git@github.com:org/repo.git", true},
+		{"ssh://git@github.com/org/repo.git", true},
+		{"https://github.com/org/repo.git", false},
+		{"git://example.com/repo.git", false},
+	} {
+		if got := isSSHCloneURL(tc.in); got != tc.want {
+			t.Errorf("isSSHCloneURL(%q) = %v, want %v", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestParseAgentVar(t *testing.T) {
+	out := "SSH_AUTH_SOCK=/tmp/ssh-abc/agent.123; export SSH_AUTH_SOCK;\n" +
+		"SSH_AGENT_PID=456; export SSH_AGENT_PID;\n" +
+		"echo Agent pid 456;\n"
+	if got := parseAgentVar(out, "SSH_AUTH_SOCK"); got != "/tmp/ssh-abc/agent.123" {
+		t.Errorf("SSH_AUTH_SOCK = %q, want /tmp/ssh-abc/agent.123", got)
+	}
+	if got := parseAgentVar(out, "SSH_AGENT_PID"); got != "456" {
+		t.Errorf("SSH_AGENT_PID = %q, want 456", got)
+	}
+	if got := parseAgentVar(out, "MISSING"); got != "" {
+		t.Errorf("MISSING = %q, want empty", got)
+	}
+}


### PR DESCRIPTION
Port cli/rde/claude's shared helpers (step logger, spinner, session metadata, Claude auth, SSH agent management) ahead of PR 16's cmd.go/ resume.go, which will be the first callers.

Temporarily excludes cli/rde/claude from golangci-lint's unused check, since most of this package has no caller until PR 16 lands; removed there.