### PR TITLE
feat(tool setup): [BE-2184] Enable precompiled Ruby binaries explicitly

### DIFF
--- a/toolprovider/mise/install.go
+++ b/toolprovider/mise/install.go
@@ -99,6 +99,9 @@ func (m *MiseToolProvider) installToolVersion(toolName provider.ToolID, concrete
 	if key, value := workarounds.GetPythonPrecompiledFlavorEnv(toolName, concreteVersion, GetMiseVersion(), m.Silent); key != "" {
 		extraEnvs[key] = value
 	}
+	if key, value := workarounds.GetRubyPrecompiledEnv(toolName, GetMiseVersion(), m.Silent); key != "" {
+		extraEnvs[key] = value
+	}
 
 	output, err := m.ExecEnv.RunMiseWithTimeoutAndEnvs(execenv.InstallTimeout, extraEnvs, "install", "--yes", versionString)
 	if !m.Silent && os.Getenv("MISE_LOG_LEVEL") != "" {

--- a/toolprovider/mise/workarounds/ruby_precompiled.go
+++ b/toolprovider/mise/workarounds/ruby_precompiled.go
@@ -1,0 +1,55 @@
+package workarounds
+
+import (
+	"strings"
+
+	"github.com/bitrise-io/bitrise/v2/log"
+	"github.com/bitrise-io/bitrise/v2/toolprovider/provider"
+	"github.com/hashicorp/go-version"
+)
+
+// First mise release where precompiled Ruby is the default. Older releases support it, but
+// only behind the global experimental flag.
+const rubyPrecompiledDefaultMiseVersion = "2026.8.0"
+
+// GetRubyPrecompiledEnv returns the env var that lets mise install Ruby from a precompiled
+// binary instead of building it with ruby-build. Returns empty strings when not needed.
+//
+// This matters more than install time: on macOS 26.6 with Xcode 27 a ruby-build source build
+// segfaults, so the fallback is a dead path there, not just a slow one.
+//
+// Not ruby.compile=false, which also ungates precompiled binaries but turns a missing binary
+// into a hard failure instead of a source build. jdx/ruby publishes no 3.1.x, so that would
+// break every 3.1.x install.
+//
+// Without this the precompiled path is reached only as a side effect of canBeInstalledWithNix()
+// persisting experimental=true for the nixpkgs backend, which needs macOS plus nix and so never
+// happens on Linux. See https://mise.jdx.dev/lang/ruby.html
+func GetRubyPrecompiledEnv(toolName provider.ToolID, miseVersion string, silent bool) (string, string) {
+	if !ShouldEnableRubyPrecompiled(toolName, miseVersion) {
+		return "", ""
+	}
+
+	if !silent {
+		log.Debugf("[TOOLPROVIDER] Enabling mise experimental mode to allow precompiled Ruby binaries")
+	}
+
+	return "MISE_EXPERIMENTAL", "true"
+}
+
+// ShouldEnableRubyPrecompiled reports whether MISE_EXPERIMENTAL is needed for a Ruby install.
+// Mise versions predating the feature entirely ignore the flag, so the upper bound is the only
+// condition worth checking.
+func ShouldEnableRubyPrecompiled(toolName provider.ToolID, miseVersion string) bool {
+	// Matches "ruby" and the backend qualified "nixpkgs:ruby".
+	if !strings.HasSuffix(string(toolName), "ruby") {
+		return false
+	}
+
+	miseVer, err := version.NewVersion(strings.TrimPrefix(miseVersion, "v"))
+	if err != nil {
+		return false
+	}
+
+	return miseVer.LessThan(version.Must(version.NewVersion(rubyPrecompiledDefaultMiseVersion)))
+}

--- a/toolprovider/mise/workarounds/ruby_precompiled_test.go
+++ b/toolprovider/mise/workarounds/ruby_precompiled_test.go
@@ -1,0 +1,93 @@
+package workarounds
+
+import (
+	"testing"
+
+	"github.com/bitrise-io/bitrise/v2/toolprovider/provider"
+	"github.com/stretchr/testify/require"
+)
+
+func TestShouldEnableRubyPrecompiled(t *testing.T) {
+	tests := []struct {
+		name        string
+		toolName    provider.ToolID
+		miseVersion string
+		want        bool
+	}{
+		{
+			name:        "Ruby with the stable pin (precompiled gated behind experimental) - should set",
+			toolName:    "ruby",
+			miseVersion: "v2026.5.12",
+			want:        true,
+		},
+		{
+			name:        "Ruby with a mise version where precompiled is the default - should not set",
+			toolName:    "ruby",
+			miseVersion: "v2026.8.0",
+			want:        false,
+		},
+		{
+			name:        "Ruby with a newer mise version - should not set",
+			toolName:    "ruby",
+			miseVersion: "v2026.9.1",
+			want:        false,
+		},
+		{
+			name:        "Ruby with a mise version predating the feature - should set, harmless no-op",
+			toolName:    "ruby",
+			miseVersion: "v2026.3.16",
+			want:        true,
+		},
+		{
+			name:        "nixpkgs-prefixed Ruby - should set",
+			toolName:    "nixpkgs:ruby",
+			miseVersion: "v2026.5.12",
+			want:        true,
+		},
+		{
+			name:        "Another tool - should not set",
+			toolName:    "nodejs",
+			miseVersion: "v2026.5.12",
+			want:        false,
+		},
+		{
+			name:        "Python is unaffected - should not set",
+			toolName:    "python",
+			miseVersion: "v2026.5.12",
+			want:        false,
+		},
+		{
+			name:        "Mise version without the v prefix - should set",
+			toolName:    "ruby",
+			miseVersion: "2026.5.12",
+			want:        true,
+		},
+		{
+			name:        "Unparseable mise version - should not set",
+			toolName:    "ruby",
+			miseVersion: "not-a-version",
+			want:        false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ShouldEnableRubyPrecompiled(tt.toolName, tt.miseVersion)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestGetRubyPrecompiledEnv(t *testing.T) {
+	key, value := GetRubyPrecompiledEnv("ruby", "v2026.5.12", true)
+	require.Equal(t, "MISE_EXPERIMENTAL", key)
+	require.Equal(t, "true", value)
+
+	key, value = GetRubyPrecompiledEnv("ruby", "v2026.9.1", true)
+	require.Empty(t, key)
+	require.Empty(t, value)
+
+	key, value = GetRubyPrecompiledEnv("nodejs", "v2026.5.12", true)
+	require.Empty(t, key)
+	require.Empty(t, value)
+}


### PR DESCRIPTION
### Checklist
- [ ] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-io/bitrise/blob/master/.github/CONTRIBUTING.md)
- [ ] `README.md` is updated with the changes (if needed)
- [x] I've run `go mod tidy` both in root and in `integrationtests/` if any dependencies have changed. <!-- Integration tests are treated separate. See `integrationtests/README.md` -->

### Version
Requires a *MAJOR/MINOR/**PATCH*** [version update](https://semver.org/)

### Context

Follow up to #1343 updating Mise stable version.

Ruby gets compiled from source on Linux and stable stacks, because Mise's precompiled Ruby is only allowed on macOS stacks with nix: because of the backend, `canBeInstalledWithNix()` sets `experimental=true`. This also allows precompiled Ruby as a side effect.

On macOS 26.6.1 with Xcode 27 a ruby-build source build fails, so precompiled or preinstalled binaries are the only working path as of now.

### Changes

- New entry in workarounds for Ruby
  - Env `MISE_EXPERIMENTAL=true` for Ruby installs of Mise older than 2026.8.0 (precompiled becomes default)
- Unit tests

### Investigation details

Installing ruby 3.3.12 with a token, per mise version:

| mise | default | with `MISE_EXPERIMENTAL=true` |
| --- | --- | --- |
| v2025.10.8 | compile | compile, feature absent |
| v2026.3.16 | compile | precompiled, 11s |
| v2026.5.12 (new stable pin) | compile | precompiled, 5s |
| v2026.8.0 and newer | precompiled | same |

How to achieve failure:
- `tool_config: fast_install: false`
- `tools: ruby: 3.4.9`
- result: failing after 96s:

```
make: *** [builtin_binary.inc] Segmentation fault: 11
BUILD FAILED (macOS 26.6.1 on arm64 using ruby-build 20260902)
```

### Decisions

- Use `MISE_EXPERIMENTAL` instead of `ruby.compile=false`, this avoids hard failures
- A per install env var rather than a config write
- Leave `settings experimental=true` for `plugin` and `ls-remote` (which are before the install)
- Verify only that we are below `2025.10.8`, older Mise versions will ignore the flag and the feature will outdate itself eventually