### PR TITLE
Remove experimental=true flag for nixpkgs custom backend

### DIFF
--- a/toolprovider/mise/install.go
+++ b/toolprovider/mise/install.go
@@ -42,14 +42,6 @@ func canBeInstalledWithNix(tool provider.ToolRequest, execEnv execenv.ExecEnv, u
 		return false
 	}
 
-	// Enable experimental settings for custom backend
-	if _, err := execEnv.RunMise("settings", "experimental=true"); err != nil {
-		if !silent {
-			log.Warnf("Error while enabling experimental settings: %v.", err)
-		}
-		return forceNix
-	}
-
 	// If the plugin is already installed, Mise will not throw an error.
 	_, err := execEnv.RunMisePlugin("install", nixpkgs.PluginName, nixpkgs.PluginGitURL)
 	if err != nil {

--- a/toolprovider/mise/install_test.go
+++ b/toolprovider/mise/install_test.go
@@ -130,7 +130,6 @@ func TestCanBeInstalledWithNix(t *testing.T) {
 			version:            "3.3.9",
 			resolutionStrategy: provider.ResolutionStrategyStrict,
 			setupFake: func(m *fakeExecEnv) {
-				m.setResponse("settings experimental=true", "")
 				m.setResponse(fmt.Sprintf("plugin install %s %s", nixpkgs.PluginName, nixpkgs.PluginGitURL), "")
 				m.setResponse(fmt.Sprintf("plugin update %s", nixpkgs.PluginName), "")
 				m.setResponse("ls --installed --json --quiet ruby", "[]")
@@ -144,7 +143,6 @@ func TestCanBeInstalledWithNix(t *testing.T) {
 			version:            "3.3",
 			resolutionStrategy: provider.ResolutionStrategyLatestReleased,
 			setupFake: func(m *fakeExecEnv) {
-				m.setResponse("settings experimental=true", "")
 				m.setResponse(fmt.Sprintf("plugin install %s %s", nixpkgs.PluginName, nixpkgs.PluginGitURL), "")
 				m.setResponse(fmt.Sprintf("plugin update %s", nixpkgs.PluginName), "")
 				m.setResponse("ls --installed --json --quiet ruby", "[]")
@@ -158,7 +156,6 @@ func TestCanBeInstalledWithNix(t *testing.T) {
 			version:            "0.0.1",
 			resolutionStrategy: provider.ResolutionStrategyStrict,
 			setupFake: func(m *fakeExecEnv) {
-				m.setResponse("settings experimental=true", "")
 				m.setResponse(fmt.Sprintf("plugin install %s %s", nixpkgs.PluginName, nixpkgs.PluginGitURL), "")
 				m.setResponse(fmt.Sprintf("plugin update %s", nixpkgs.PluginName), "")
 				m.setResponse("ls --installed --json --quiet ruby", "[]")
@@ -172,7 +169,6 @@ func TestCanBeInstalledWithNix(t *testing.T) {
 			version:            "3.3.9",
 			resolutionStrategy: provider.ResolutionStrategyStrict,
 			setupFake: func(m *fakeExecEnv) {
-				m.setResponse("settings experimental=true", "")
 				m.setError(fmt.Sprintf("plugin install %s %s", nixpkgs.PluginName, nixpkgs.PluginGitURL), fmt.Errorf("fake error"))
 			},
 			want: false,
@@ -183,7 +179,6 @@ func TestCanBeInstalledWithNix(t *testing.T) {
 			version:            "3.3.9",
 			resolutionStrategy: provider.ResolutionStrategyStrict,
 			setupFake: func(m *fakeExecEnv) {
-				m.setResponse("settings experimental=true", "")
 				m.setResponse(fmt.Sprintf("plugin install %s %s", nixpkgs.PluginName, nixpkgs.PluginGitURL), "")
 				m.setResponse(fmt.Sprintf("plugin update %s", nixpkgs.PluginName), "")
 				m.setResponse("ls --installed --json --quiet ruby", "[]")


### PR DESCRIPTION
### Checklist

- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-io/bitrise/blob/master/.github/CONTRIBUTING.md)
- [ ] `README.md` is updated with the changes (if needed)
- [ ] I've run `go mod tidy` both in root and in `integrationtests/` if any dependencies have changed. <!-- Integration tests are treated separate. See `integrationtests/README.md` -->

### Version

Requires a *MAJOR/**MINOR**/PATCH* [version update](https://semver.org/)

### Context

Fast tool setup is achieved with a custom Mise backend, that supplies prebuilt Ruby versions with Nix. Since this backend is our own implementation Mise could only handle it in case we used it in experimental mode. However this is no longer required for custom backends, so we can remove the general switch for experimental features.

### Changes

- Avoid calling `mise settings experimental=true`
- The experimental flag is no longer set to `true` in the project

### Investigation details

- Backends were graduated from experimental: https://github.com/jdx/mise/releases/tag/v2026.6.6

### Decisions


---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>