### PR TITLE
RDE 17 - `rde usage` command

### DIFF
--- a/cli/rde/cmd.go
+++ b/cli/rde/cmd.go
@@ -10,6 +10,7 @@ import (
 	"github.com/bitrise-io/bitrise/v2/cli/rde/session"
 	"github.com/bitrise-io/bitrise/v2/cli/rde/stack"
 	"github.com/bitrise-io/bitrise/v2/cli/rde/template"
+	"github.com/bitrise-io/bitrise/v2/cli/rde/usage"
 )
 
 // NewCmd returns the `bitrise rde` parent command.
@@ -42,6 +43,7 @@ Saved inputs are user-scoped — they do not require --workspace.`,
 		session.NewCmd(),
 		template.NewCmd(),
 		savedinput.NewCmd(),
+		usage.NewCmd(),
 	)
 	return c
 }

--- a/cli/rde/usage/cmd.go
+++ b/cli/rde/usage/cmd.go
@@ -1,0 +1,170 @@
+package usage
+
+import (
+	"fmt"
+	"io"
+	"strconv"
+
+	"github.com/spf13/cobra"
+
+	"github.com/bitrise-io/bitrise/v2/cli/cmdutil"
+	internalrde "github.com/bitrise-io/bitrise/v2/internal/rde"
+	"github.com/bitrise-io/bitrise/v2/internal/style"
+	"github.com/bitrise-io/bitrise/v2/output"
+)
+
+// NewCmd returns the `rde usage` command. A leaf command, not a noun with
+// subcommands: the report is a single summary, not a listable collection.
+func NewCmd() *cobra.Command {
+	var format string
+	c := &cobra.Command{
+		Use:   "usage",
+		Short: "Show the workspace's active session and resource usage",
+		Long: `Show a point-in-time snapshot of the workspace's active remote dev sessions:
+session counts and vCPU/memory totals split by OS, workspace-wide and per user.
+
+This reports sessions currently consuming resources; it is not a historical or
+billing-period report. Requires the workspace's billing-view permission
+(workspace owners and billing-managing custom roles).`,
+		Example: `  bitrise rde usage
+  bitrise rde usage --format json | jq '.totals'`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cmdutil.LogCommandParameters(cmd)
+
+			if err := output.ConfigureOutputFormat(format); err != nil {
+				return fmt.Errorf("failed to configure output format: %w", err)
+			}
+
+			workspaceID, err := cmdutil.ResolveWorkspaceID(cmd)
+			if err != nil {
+				return err
+			}
+			client, err := cmdutil.NewRDEClient(cmd)
+			if err != nil {
+				return err
+			}
+			res, err := internalrde.NewService(client).GetWorkspaceUsage(cmd.Context(), workspaceID)
+			if err != nil {
+				return err
+			}
+			if err := output.Render(cmd.OutOrStdout(), output.Format, res, renderUsage); err != nil {
+				return err
+			}
+			// Diagnostics go to stderr so piped stdout stays parse-safe; the
+			// JSON shape carries unknown_machine_type_count as data anyway.
+			if res.UnknownMachineTypeCount > 0 {
+				s := style.New(cmd.ErrOrStderr())
+				ew := cmdutil.NewErrWriter(cmd.ErrOrStderr())
+				ew.F("%s active sessions with unrecognized machine types contribute 0 vCPU/memory to the totals, so the sums may undercount (%d affected)\n",
+					s.Warn.Render("Warning:"), res.UnknownMachineTypeCount)
+				return ew.Err
+			}
+			return nil
+		},
+	}
+	c.Flags().StringVarP(&format, cmdutil.FormatKey, "f", "", "Output format. Accepted: raw (default), json, yml")
+	return c
+}
+
+func renderUsage(w io.Writer, res internalrde.WorkspaceUsage) error {
+	total := sumBuckets(res.Totals)
+	if total.SessionCount == 0 {
+		_, err := fmt.Fprintln(w, "No active sessions.")
+		return err
+	}
+
+	s := style.New(w)
+	ew := cmdutil.NewErrWriter(w)
+	lbl := func(label string) string {
+		return s.Label.Render(fmt.Sprintf("%-12s", label))
+	}
+	ew.F("%s%-6d%s\n", lbl("Sessions:"), total.SessionCount, osSplit(res.Totals, func(p internalrde.PlatformUsage) int32 { return p.SessionCount }))
+	ew.F("%s%-6d%s\n", lbl("vCPU:"), total.VCPU, osSplit(res.Totals, func(p internalrde.PlatformUsage) int32 { return p.VCPU }))
+	ew.F("%s%-6d%s\n", lbl("Memory GB:"), total.MemoryGB, osSplit(res.Totals, func(p internalrde.PlatformUsage) int32 { return p.MemoryGB }))
+
+	if len(res.Users) > 0 {
+		ew.F("\n")
+		if err := renderUserTable(w, s, res.Users); err != nil {
+			return err
+		}
+	}
+	return ew.Err
+}
+
+// sumBuckets folds the linux/macos/unknown buckets into one grand total.
+func sumBuckets(t internalrde.UsageTotals) internalrde.PlatformUsage {
+	return internalrde.PlatformUsage{
+		SessionCount: t.Linux.SessionCount + t.Macos.SessionCount + t.Unknown.SessionCount,
+		VCPU:         t.Linux.VCPU + t.Macos.VCPU + t.Unknown.VCPU,
+		MemoryGB:     t.Linux.MemoryGB + t.Macos.MemoryGB + t.Unknown.MemoryGB,
+	}
+}
+
+// osSplit renders the per-OS breakdown of one metric, e.g.
+// "(Linux 64, macOS 24)"; the unknown bucket appears only when non-zero.
+func osSplit(t internalrde.UsageTotals, metric func(internalrde.PlatformUsage) int32) string {
+	out := fmt.Sprintf("(Linux %d, macOS %d", metric(t.Linux), metric(t.Macos))
+	if v := metric(t.Unknown); v != 0 {
+		out += fmt.Sprintf(", unknown %d", v)
+	}
+	return out + ")"
+}
+
+func renderUserTable(w io.Writer, s style.Styles, users []internalrde.UserUsage) error {
+	const colUser = 0
+	// The unknown-OS column appears only when some row needs it, so the
+	// common all-known case stays narrow — but when present it lets every
+	// row's session total reconcile with its per-OS resources.
+	showUnknown := false
+	for _, u := range users {
+		if u.Totals.Unknown != (internalrde.PlatformUsage{}) {
+			showUnknown = true
+			break
+		}
+	}
+	headers := []string{"USER", "SESSIONS", "LINUX VCPU/GB", "MACOS VCPU/GB"}
+	if showUnknown {
+		headers = append(headers, "UNKNOWN VCPU/GB")
+	}
+	rows := make([][]string, 0, len(users))
+	for _, u := range users {
+		row := []string{
+			userLabel(u),
+			strconv.Itoa(int(sumBuckets(u.Totals).SessionCount)),
+			vcpuGB(u.Totals.Linux),
+			vcpuGB(u.Totals.Macos),
+		}
+		if showUnknown {
+			row = append(row, vcpuGB(u.Totals.Unknown))
+		}
+		rows = append(rows, row)
+	}
+	styler := func(row, col int, content string) string {
+		if col == colUser && users[row].IsWorkspace {
+			return s.Dim.Render(content)
+		}
+		return content
+	}
+	return style.Table(w, headers, rows, s.Header, styler)
+}
+
+// userLabel identifies a breakdown row: email when known, the workspace
+// bucket as "(workspace)", with username/ID fallbacks for user rows
+// missing an email.
+func userLabel(u internalrde.UserUsage) string {
+	switch {
+	case u.IsWorkspace:
+		return "(workspace)"
+	case u.Email != "":
+		return u.Email
+	case u.Username != "":
+		return u.Username
+	default:
+		return u.UserID
+	}
+}
+
+func vcpuGB(p internalrde.PlatformUsage) string {
+	return fmt.Sprintf("%d / %d", p.VCPU, p.MemoryGB)
+}

--- a/cli/rde/usage/cmd_test.go
+++ b/cli/rde/usage/cmd_test.go
@@ -1,0 +1,200 @@
+package usage
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/bitrise-io/bitrise/v2/cli/cmdtest"
+	"github.com/bitrise-io/bitrise/v2/cli/cmdutil"
+	"github.com/bitrise-io/bitrise/v2/output"
+)
+
+// sparseReport mimics the backend's proto3 JSON: zero-valued fields and empty
+// bucket objects omitted. Alice runs 1 linux (2 vCPU / 8 GB) + 1 macos
+// (4 / 6); the workspace bucket runs 1 session of unknown machine type.
+const sparseReport = `{
+	"totals": {
+		"linux": {"sessionCount": 1, "vcpu": 2, "memoryGb": 8},
+		"macos": {"sessionCount": 1, "vcpu": 4, "memoryGb": 6},
+		"unknown": {"sessionCount": 1}
+	},
+	"users": [
+		{
+			"userId": "u-1", "userSlug": "alice-slug", "email": "alice@example.com", "username": "alice",
+			"totals": {
+				"linux": {"sessionCount": 1, "vcpu": 2, "memoryGb": 8},
+				"macos": {"sessionCount": 1, "vcpu": 4, "memoryGb": 6}
+			}
+		},
+		{
+			"isWorkspace": true,
+			"totals": {"unknown": {"sessionCount": 1}}
+		}
+	],
+	"unknownMachineTypeCount": 1
+}`
+
+func TestUsageCmd_Human(t *testing.T) {
+	srv := usageServer(t, http.StatusOK, sparseReport)
+	defer srv.Close()
+
+	stdout, stderr, err := cmdtest.Run(t, NewCmd(), cmdtest.Opts{RDEAPIBaseURL: srv.URL, DefaultWorkspaceID: "ws-1"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, want := range []string{
+		"Sessions:", "3", "(Linux 1, macOS 1, unknown 1)",
+		"vCPU:", "6", "(Linux 2, macOS 4)",
+		"Memory GB:", "14", "(Linux 8, macOS 6)",
+		"alice@example.com", "(workspace)",
+		"2 / 8", "4 / 6",
+		"UNKNOWN VCPU/GB",
+	} {
+		if !strings.Contains(stdout, want) {
+			t.Errorf("stdout missing %q:\n%s", want, stdout)
+		}
+	}
+	if strings.Contains(stdout, "Warning") {
+		t.Errorf("diagnostics leaked into stdout:\n%s", stdout)
+	}
+	if !strings.Contains(stderr, "Warning:") || !strings.Contains(stderr, "(1 affected)") {
+		t.Errorf("stderr missing the undercount warning:\n%s", stderr)
+	}
+}
+
+func TestUsageCmd_JSON_Densified(t *testing.T) {
+	srv := usageServer(t, http.StatusOK, sparseReport)
+	defer srv.Close()
+
+	stdout, _, err := cmdtest.Run(t, NewCmd(), cmdtest.Opts{RDEAPIBaseURL: srv.URL, DefaultWorkspaceID: "ws-1", Format: output.FormatJSON})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal([]byte(stdout), &got); err != nil {
+		t.Fatalf("stdout is not JSON: %v\n%s", err, stdout)
+	}
+
+	totals, ok := got["totals"].(map[string]any)
+	if !ok {
+		t.Fatalf("totals missing: %s", stdout)
+	}
+	// The wire omitted vcpu/memoryGb on the unknown bucket; the stable shape
+	// promises them as explicit zeros.
+	unknown, ok := totals["unknown"].(map[string]any)
+	if !ok {
+		t.Fatalf("totals.unknown missing: %s", stdout)
+	}
+	for key, want := range map[string]float64{"session_count": 1, "vcpu": 0, "memory_gb": 0} {
+		if unknown[key] != want {
+			t.Errorf("totals.unknown[%q] = %v, want %v", key, unknown[key], want)
+		}
+	}
+
+	users, ok := got["users"].([]any)
+	if !ok || len(users) != 2 {
+		t.Fatalf("users = %v, want 2 rows", got["users"])
+	}
+	// The stable shape's user_id is the Bitrise user ID (the wire's slug);
+	// the backend's internal UUID (wire userId) is not exposed.
+	alice := users[0].(map[string]any)
+	if alice["user_id"] != "alice-slug" {
+		t.Errorf("users[0].user_id = %v, want alice-slug", alice["user_id"])
+	}
+	if _, leaked := alice["user_slug"]; leaked {
+		t.Errorf("users[0] leaks user_slug: %v", alice)
+	}
+	if got["unknown_machine_type_count"] != float64(1) {
+		t.Errorf("unknown_machine_type_count = %v, want 1", got["unknown_machine_type_count"])
+	}
+}
+
+func TestUsageCmd_Human_NoUnknownColumnWhenAllKnown(t *testing.T) {
+	srv := usageServer(t, http.StatusOK, `{
+		"totals": {"linux": {"sessionCount": 1, "vcpu": 2, "memoryGb": 8}},
+		"users": [{
+			"userSlug": "alice-slug", "email": "alice@example.com",
+			"totals": {"linux": {"sessionCount": 1, "vcpu": 2, "memoryGb": 8}}
+		}]
+	}`)
+	defer srv.Close()
+
+	stdout, stderr, err := cmdtest.Run(t, NewCmd(), cmdtest.Opts{RDEAPIBaseURL: srv.URL, DefaultWorkspaceID: "ws-1"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.Contains(stdout, "UNKNOWN") || strings.Contains(stdout, "unknown") {
+		t.Errorf("unknown column/split rendered with nothing unknown:\n%s", stdout)
+	}
+	if stderr != "" {
+		t.Errorf("stderr = %q, want no diagnostics", stderr)
+	}
+}
+
+func TestUsageCmd_Empty(t *testing.T) {
+	srv := usageServer(t, http.StatusOK, `{}`)
+	defer srv.Close()
+
+	stdout, _, err := cmdtest.Run(t, NewCmd(), cmdtest.Opts{RDEAPIBaseURL: srv.URL, DefaultWorkspaceID: "ws-1"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(stdout, "No active sessions.") {
+		t.Errorf("stdout = %q, want the empty-report sentence", stdout)
+	}
+}
+
+func TestUsageCmd_PermissionDenied(t *testing.T) {
+	srv := usageServer(t, http.StatusForbidden, `{"code":7,"message":"you are not allowed to view usage of this workspace"}`)
+	defer srv.Close()
+
+	_, _, err := cmdtest.Run(t, NewCmd(), cmdtest.Opts{RDEAPIBaseURL: srv.URL, DefaultWorkspaceID: "ws-1"})
+	if err == nil || !strings.Contains(err.Error(), "not allowed to view usage") {
+		t.Fatalf("error = %v, want the backend's permission message", err)
+	}
+}
+
+// TestUsageCmd_QuietKeepsWarning attaches the persistent --quiet flag to the
+// command under test (cmdutil.IsQuiet reads it off cmd.Root(), which for a
+// standalone command is the command itself): the undercount warning survives
+// -q, per the output scheme's rule that warnings ignore --quiet.
+func TestUsageCmd_QuietKeepsWarning(t *testing.T) {
+	srv := usageServer(t, http.StatusOK, sparseReport)
+	defer srv.Close()
+
+	cmd := NewCmd()
+	cmd.PersistentFlags().BoolP(cmdutil.FlagQuiet, "q", false, "quiet")
+
+	stdout, stderr, err := cmdtest.Run(t, cmd, cmdtest.Opts{
+		RDEAPIBaseURL:      srv.URL,
+		DefaultWorkspaceID: "ws-1",
+		Args:               []string{"-q"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(stderr, "Warning:") || !strings.Contains(stderr, "(1 affected)") {
+		t.Errorf("-q must not suppress the undercount warning:\n%s", stderr)
+	}
+	if !strings.Contains(stdout, "Sessions:") {
+		t.Errorf("-q must not affect the report itself:\n%s", stdout)
+	}
+}
+
+// usageServer serves GET /v1/workspaces/ws-1/usage with a fixed body/status.
+func usageServer(t *testing.T, status int, body string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/workspaces/ws-1/usage" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+			http.NotFound(w, r)
+			return
+		}
+		w.WriteHeader(status)
+		_, _ = io.WriteString(w, body)
+	}))
+}

--- a/cli/rde/usage/main_test.go
+++ b/cli/rde/usage/main_test.go
@@ -1,0 +1,10 @@
+package usage
+
+import (
+	"os"
+	"testing"
+
+	"github.com/bitrise-io/bitrise/v2/cli/cmdtest"
+)
+
+func TestMain(m *testing.M) { os.Exit(cmdtest.RunIsolated(m)) }

--- a/internal/rde/usage.go
+++ b/internal/rde/usage.go
@@ -1,0 +1,107 @@
+package rde
+
+import (
+	"context"
+
+	"github.com/bitrise-io/bitrise/v2/internal/rdeapi"
+)
+
+// PlatformUsage aggregates active sessions on one OS platform. Always dense:
+// fields the backend omitted are 0.
+type PlatformUsage struct {
+	SessionCount int32 `json:"session_count" yaml:"session_count"`
+	VCPU         int32 `json:"vcpu" yaml:"vcpu"`
+	MemoryGB     int32 `json:"memory_gb" yaml:"memory_gb"`
+}
+
+// UsageTotals splits active-session usage by OS platform. Unknown holds
+// sessions whose OS could not be determined.
+type UsageTotals struct {
+	Linux   PlatformUsage `json:"linux" yaml:"linux"`
+	Macos   PlatformUsage `json:"macos" yaml:"macos"`
+	Unknown PlatformUsage `json:"unknown" yaml:"unknown"`
+}
+
+// UserUsage is one row of the per-user usage breakdown. The single
+// workspace-owned bucket row (IsWorkspace true) carries no user identity.
+//
+// UserID is the user's Bitrise ID (the wire's slug — the identifier other
+// Bitrise surfaces use; the backend's internal user UUID is not exposed).
+// Best-effort: may be empty, so detect the workspace bucket via IsWorkspace,
+// never via an empty UserID.
+type UserUsage struct {
+	UserID      string      `json:"user_id,omitempty" yaml:"user_id,omitempty"`
+	Email       string      `json:"email,omitempty" yaml:"email,omitempty"`
+	Username    string      `json:"username,omitempty" yaml:"username,omitempty"`
+	IsWorkspace bool        `json:"is_workspace,omitempty" yaml:"is_workspace,omitempty"`
+	Totals      UsageTotals `json:"totals" yaml:"totals"`
+}
+
+// WorkspaceUsage is a point-in-time snapshot of the sessions currently
+// consuming resources in the workspace, split by OS and by user. It is not a
+// historical or billing-period report.
+type WorkspaceUsage struct {
+	Totals UsageTotals `json:"totals" yaml:"totals"`
+	Users  []UserUsage `json:"users" yaml:"users"`
+	// UnknownMachineTypeCount counts active sessions whose machine type had
+	// no resolvable vCPU/RAM spec; they contribute 0 to the sums, so totals
+	// may undercount when this is non-zero.
+	UnknownMachineTypeCount int32 `json:"unknown_machine_type_count" yaml:"unknown_machine_type_count"`
+}
+
+// GetWorkspaceUsage returns the workspace's active-session usage snapshot.
+// Requires the workspace's billing-view permission (workspace owners and
+// billing-managing custom roles).
+func (s *Service) GetWorkspaceUsage(ctx context.Context, workspaceID string) (WorkspaceUsage, error) {
+	if s.client == nil {
+		return WorkspaceUsage{}, errClient()
+	}
+	wire, err := s.client.GetWorkspaceUsage(ctx, workspaceID)
+	if err != nil {
+		return WorkspaceUsage{}, err
+	}
+	return usageFromAPI(wire), nil
+}
+
+// usageFromAPI densifies the wire report: the backend omits zero-valued
+// fields and empty bucket objects, and the stable shape promises every
+// bucket present with explicit zeros.
+func usageFromAPI(w rdeapi.WorkspaceUsage) WorkspaceUsage {
+	out := WorkspaceUsage{
+		Totals:                  usageTotalsFromAPI(w.Totals),
+		Users:                   make([]UserUsage, 0, len(w.Users)),
+		UnknownMachineTypeCount: w.UnknownMachineTypeCount,
+	}
+	for _, u := range w.Users {
+		out.Users = append(out.Users, UserUsage{
+			UserID:      u.UserSlug,
+			Email:       u.Email,
+			Username:    u.Username,
+			IsWorkspace: u.IsWorkspace,
+			Totals:      usageTotalsFromAPI(u.Totals),
+		})
+	}
+	return out
+}
+
+func usageTotalsFromAPI(w *rdeapi.UsageTotals) UsageTotals {
+	if w == nil {
+		return UsageTotals{}
+	}
+	return UsageTotals{
+		Linux:   platformUsageFromAPI(w.Linux),
+		Macos:   platformUsageFromAPI(w.Macos),
+		Unknown: platformUsageFromAPI(w.Unknown),
+	}
+}
+
+func platformUsageFromAPI(w *rdeapi.PlatformUsage) PlatformUsage {
+	if w == nil {
+		return PlatformUsage{}
+	}
+	return PlatformUsage{
+		SessionCount: w.SessionCount,
+		VCPU:         w.VCPU,
+		MemoryGB:     w.MemoryGB,
+	}
+}

--- a/internal/rdeapi/usage.go
+++ b/internal/rdeapi/usage.go
@@ -1,0 +1,59 @@
+package rdeapi
+
+import (
+	"context"
+	"fmt"
+)
+
+// PlatformUsage aggregates active sessions on one OS platform. The backend
+// omits zero-valued fields from the JSON, so absent means 0.
+type PlatformUsage struct {
+	SessionCount int32 `json:"sessionCount"`
+	VCPU         int32 `json:"vcpu"`
+	MemoryGB     int32 `json:"memoryGb"`
+}
+
+// UsageTotals splits active-session usage by OS platform. Buckets are
+// pointers because the backend may omit an empty bucket object entirely.
+type UsageTotals struct {
+	Linux   *PlatformUsage `json:"linux"`
+	Macos   *PlatformUsage `json:"macos"`
+	Unknown *PlatformUsage `json:"unknown"`
+}
+
+// UserUsage is one row of the per-user usage breakdown. The workspace-owned
+// bucket row (IsWorkspace) carries no user identity.
+type UserUsage struct {
+	UserID      string       `json:"userId"`
+	UserSlug    string       `json:"userSlug"`
+	Email       string       `json:"email"`
+	Username    string       `json:"username"`
+	IsWorkspace bool         `json:"isWorkspace"`
+	Totals      *UsageTotals `json:"totals"`
+}
+
+// WorkspaceUsage is the workspace usage report: a point-in-time snapshot of
+// the sessions currently consuming resources, split by OS and by user.
+type WorkspaceUsage struct {
+	Totals *UsageTotals `json:"totals"`
+	Users  []UserUsage  `json:"users"`
+	// UnknownMachineTypeCount is the number of active sessions whose machine
+	// type had no resolvable vCPU/RAM spec; they contribute 0 to the sums, so
+	// totals may undercount when this is non-zero.
+	UnknownMachineTypeCount int32 `json:"unknownMachineTypeCount"`
+}
+
+// GetWorkspaceUsage returns the workspace's active-session usage snapshot.
+// Requires the workspace's billing-view permission (workspace owners and
+// billing-managing custom roles); other members get a permission error.
+// Endpoint: GET /v1/workspaces/{workspaceId}/usage.
+func (c *Client) GetWorkspaceUsage(ctx context.Context, workspaceID string) (WorkspaceUsage, error) {
+	if workspaceID == "" {
+		return WorkspaceUsage{}, fmt.Errorf("workspace ID is required")
+	}
+	var resp WorkspaceUsage
+	if err := c.getJSON(ctx, wsPath(workspaceID, "/usage"), &resp); err != nil {
+		return WorkspaceUsage{}, err
+	}
+	return resp, nil
+}

--- a/internal/rdeapi/usage_test.go
+++ b/internal/rdeapi/usage_test.go
@@ -1,0 +1,50 @@
+package rdeapi
+
+import (
+	"context"
+	"testing"
+)
+
+func TestGetWorkspaceUsage_PathAndParse(t *testing.T) {
+	rs := newRecordingServer(t, `{
+		"totals": {"linux": {"sessionCount": 2, "vcpu": 4, "memoryGb": 16}},
+		"users": [{
+			"userId": "u-1", "userSlug": "alice-slug", "email": "alice@example.com",
+			"totals": {"linux": {"sessionCount": 2, "vcpu": 4, "memoryGb": 16}}
+		}],
+		"unknownMachineTypeCount": 1
+	}`)
+
+	usage, err := rs.client().GetWorkspaceUsage(context.Background(), "ws-1")
+	if err != nil {
+		t.Fatalf("GetWorkspaceUsage: %v", err)
+	}
+	if want := "/v1/workspaces/ws-1/usage"; rs.lastPath != want {
+		t.Errorf("path = %s, want %s", rs.lastPath, want)
+	}
+	if usage.Totals == nil || usage.Totals.Linux == nil || usage.Totals.Linux.VCPU != 4 || usage.Totals.Linux.MemoryGB != 16 {
+		t.Errorf("totals = %+v", usage.Totals)
+	}
+	// The backend omits empty bucket objects; absent buckets stay nil here
+	// (the service layer densifies).
+	if usage.Totals.Macos != nil {
+		t.Errorf("macos bucket = %+v, want nil for an omitted bucket", usage.Totals.Macos)
+	}
+	if len(usage.Users) != 1 || usage.Users[0].UserSlug != "alice-slug" || usage.Users[0].UserID != "u-1" {
+		t.Errorf("users = %+v", usage.Users)
+	}
+	if usage.UnknownMachineTypeCount != 1 {
+		t.Errorf("unknownMachineTypeCount = %d, want 1", usage.UnknownMachineTypeCount)
+	}
+}
+
+func TestGetWorkspaceUsage_ValidationGuard(t *testing.T) {
+	rs := newRecordingServer(t, `{}`)
+
+	if _, err := rs.client().GetWorkspaceUsage(context.Background(), ""); err == nil {
+		t.Error("expected validation error, got nil")
+	}
+	if rs.hits != 0 {
+		t.Errorf("validation guard made %d HTTP call(s); should short-circuit", rs.hits)
+	}
+}


### PR DESCRIPTION
This command was implemented in the Platform CLI during the migration, let's not leave it behind.