### PR TITLE
Fix Node+Corepack+pnpm incompatibility in tests

### DIFF
--- a/integrationtests/toolprovider/asdf/install_nodejs_test.go
+++ b/integrationtests/toolprovider/asdf/install_nodejs_test.go
@@ -62,19 +62,19 @@ func TestCorepackWithNewNodeInstall(t *testing.T) {
 	}
 	request := provider.ToolRequest{
 		ToolName:        "nodejs",
-		UnparsedVersion: "22.17.0",
+		UnparsedVersion: "24.20.0",
 	}
 	result, err := asdfProvider.InstallTool(request)
 	require.NoError(t, err)
 	require.Equal(t, provider.ToolID("nodejs"), result.ToolName)
-	require.Equal(t, "22.17.0", result.ConcreteVersion)
+	require.Equal(t, "24.20.0", result.ConcreteVersion)
 	require.False(t, result.IsAlreadyInstalled)
 
 	extraEnvs := map[string]string{
 		// Simulate the activated environment
-		"ASDF_NODEJS_VERSION": "22.17.0",
+		"ASDF_NODEJS_VERSION": "24.20.0",
 	}
 	out, err := testEnv.runCommand(extraEnvs, "pnpm", "--help")
 	require.NoError(t, err)
-	require.Contains(t, out, "Usage: pnpm [command] [flags]")
+	require.Contains(t, out, "Usage: pnpm [OPTIONS] <COMMAND>")
 }


### PR DESCRIPTION
<!--
  Thanks for contributing to the Bitrise CLI!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [ ] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-io/bitrise/blob/master/.github/CONTRIBUTING.md)
- [ ] `README.md` is updated with the changes (if needed)
- [ ] I've run `go mod tidy` both in root and in `integrationtests/` if any dependencies have changed. <!-- Integration tests are treated separate. See `integrationtests/README.md` -->

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *MAJOR/MINOR/PATCH* [version update](https://semver.org/)

### Context

`TestCorepackWithNewNodeInstall` started suddenly failing.


<details>
<summary>LLM investigation summary</summary>
pnpm v12's switch to a native (Rust) executable broke `corepack use pnpm@<v12>` with `MODULE_NOT_FOUND`, because Corepack's package-manager support depends on packaging assumptions that no longer held ([nodejs/corepack#873](https://github.com/nodejs/corepack/issues/873), [pnpm/pnpm#13018](https://github.com/pnpm/pnpm/issues/13018)). Fixing it needed changes on both sides: pnpm restored compatibility starting at `12.0.0-rc.6`, and Corepack needed a matching update, shipped in `0.34.6`; since Corepack is bundled with Node.js, the Node version in an environment determines which Corepack version — and therefore which pnpm v12 releases — actually work, independent of the pnpm version pinned in the project itself.
</details>

### Changes

Bump the Node version in tests high enough that it ships a Corepack version with the fix.