### PR TITLE
v3: leftover review comments

### DIFF
--- a/cli/build/abort.go
+++ b/cli/build/abort.go
@@ -63,7 +63,7 @@ BUILD_ID belongs to an app: pass --app ID, or set BITRISE_APP_ID.`,
 		},
 	}
 
-	cmd.Flags().StringVar(&reason, "reason", "", "reason for aborting, recorded in the build log")
+	cmd.Flags().StringVar(&reason, "reason", "", "reason for aborting, recorded on the build and available via the UI/API")
 	cmd.Flags().BoolVar(&abortWithSuccess, "abort-with-success", false, "mark the aborted build as successful")
 	cmd.Flags().BoolVar(&skipGitStatusReport, "skip-git-status-report", false, "don't report the abort to the git provider's status API")
 	cmd.Flags().BoolVar(&skipNotifications, "skip-notifications", false, "don't send abort notifications")

--- a/cli/cmdutil/picker/picker_test.go
+++ b/cli/cmdutil/picker/picker_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 )
 
-// items builds n simple rows titled a, b, c, … for navigation tests.
+// threeItems builds three simple rows for navigation tests.
 func threeItems() []Item {
 	return []Item{{Title: "alpha"}, {Title: "beta"}, {Title: "gamma"}}
 }

--- a/cli/local/env_var_limit_override_test.go
+++ b/cli/local/env_var_limit_override_test.go
@@ -1,4 +1,4 @@
-package cli
+package local
 
 import (
 	"os"

--- a/cli/rde/session/mutation_test.go
+++ b/cli/rde/session/mutation_test.go
@@ -635,6 +635,45 @@ func TestRestoreCmd_WaitNonRunningExitsNonZero(t *testing.T) {
 	}
 }
 
+func TestRestoreCmd_WaitErrorStillRendersSession(t *testing.T) {
+	var getCount int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/workspaces/ws-1/sessions/"+uuidSession:
+			getCount++
+			if getCount == 1 {
+				// Pre-flight disk-status check before the restore call.
+				_, _ = io.WriteString(w, `{"session":{"id":"`+uuidSession+`","name":"dev","status":"SESSION_STATUS_TERMINATED","persistentDiskStatus":"PERSISTENT_DISK_STATUS_AVAILABLE"}}`)
+				return
+			}
+			// A --wait-timeout expiry is the real-world trigger; a failing
+			// poll reaches the same path without depending on timing.
+			w.WriteHeader(http.StatusInternalServerError)
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/workspaces/ws-1/sessions/"+uuidSession+"/restore":
+			_, _ = io.WriteString(w, `{"session":{"id":"`+uuidSession+`","name":"dev","status":"SESSION_STATUS_STARTING"}}`)
+		default:
+			t.Errorf("unexpected: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	stdout, _, err := cmdtest.Run(t, newRestoreCmd(), cmdtest.Opts{
+		RDEAPIBaseURL:      srv.URL,
+		DefaultWorkspaceID: "ws-1",
+		Args:               []string{uuidSession, "--wait"},
+		Format:             output.FormatJSON,
+	})
+	if err == nil || !strings.Contains(err.Error(), "waiting for session") {
+		t.Errorf("error = %v, want a wait error", err)
+	}
+	// The session was restored and is billing: its ID must survive the failed
+	// wait, including in a machine-readable format where the stderr
+	// breadcrumb carrying it is suppressed.
+	if !strings.Contains(stdout, uuidSession) {
+		t.Errorf("stdout should carry the restored session despite the wait error:\n%s", stdout)
+	}
+}
+
 func TestDeleteCmd_HappyPath(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodDelete || r.URL.Path != "/v1/workspaces/ws-1/sessions/"+uuidSession {

--- a/cli/rde/session/open_vnc.go
+++ b/cli/rde/session/open_vnc.go
@@ -70,12 +70,12 @@ viewer manually.`,
 			if err != nil {
 				return err
 			}
-			if err := urlOpener(cmd.Context(), creds.URL); err != nil {
-				return fmt.Errorf("open VNC URL: %w", err)
-			}
 			res := openVNCResult{Opened: true, Address: creds.Address, Username: creds.Username}
 			if output.Format != output.FormatRaw {
 				return output.Render(cmd.OutOrStdout(), output.Format, res, nil)
+			}
+			if err := urlOpener(cmd.Context(), creds.URL); err != nil {
+				return fmt.Errorf("open VNC URL: %w", err)
 			}
 			if !cmdutil.IsQuiet(cmd) {
 				_, err := fmt.Fprintf(cmd.ErrOrStderr(), "Opened VNC viewer for %s\n", creds.Address)

--- a/cli/rde/session/open_vnc.go
+++ b/cli/rde/session/open_vnc.go
@@ -12,7 +12,10 @@ import (
 
 // openVNCResult is the --format json/yml shape of `session open-vnc`. The
 // password is intentionally omitted — `open-vnc` hands the URL to the OS
-// handler, so there's no reason to also print it.
+// handler, so there's no reason to also print it. Opened is always false in
+// the json/yml output: the OS URL handler is only invoked for the raw
+// (default) format, to avoid launching a VNC viewer as a side effect of
+// scripted/automated use.
 type openVNCResult struct {
 	Opened   bool   `json:"opened" yaml:"opened"`
 	Address  string `json:"address" yaml:"address"`
@@ -70,15 +73,16 @@ viewer manually.`,
 			if err != nil {
 				return err
 			}
-			res := openVNCResult{Opened: true, Address: creds.Address, Username: creds.Username}
+			res := openVNCResult{Address: creds.Address, Username: creds.Username}
 			if output.Format != output.FormatRaw {
 				return output.Render(cmd.OutOrStdout(), output.Format, res, nil)
 			}
 			if err := urlOpener(cmd.Context(), creds.URL); err != nil {
 				return fmt.Errorf("open VNC URL: %w", err)
 			}
+			res.Opened = true
 			if !cmdutil.IsQuiet(cmd) {
-				_, err := fmt.Fprintf(cmd.ErrOrStderr(), "Opened VNC viewer for %s\n", creds.Address)
+				_, err := fmt.Fprintf(cmd.ErrOrStderr(), "Opened VNC viewer for %s\n", res.Address)
 				return err
 			}
 			return nil

--- a/cli/rde/session/restore.go
+++ b/cli/rde/session/restore.go
@@ -81,6 +81,10 @@ and then immediately use the session without hand-rolling a poll loop.`,
 				}
 				ready, waitErr := svc.WaitForReady(waitCtx, workspaceID, restored.ID, 0, nil)
 				if waitErr != nil {
+					if renderErr := output.Render(cmd.OutOrStdout(), output.Format, restored, renderSessionDetail); renderErr != nil {
+						return renderErr
+					}
+					cmdutil.SilenceRootErrors(cmd)
 					return fmt.Errorf("waiting for session: %w", waitErr)
 				}
 				restored = ready

--- a/cli/rde/session/restore.go
+++ b/cli/rde/session/restore.go
@@ -81,10 +81,14 @@ and then immediately use the session without hand-rolling a poll loop.`,
 				}
 				ready, waitErr := svc.WaitForReady(waitCtx, workspaceID, restored.ID, 0, nil)
 				if waitErr != nil {
+					// The session exists and is billing even though the wait
+					// failed; render it so its ID isn't lost — the only other
+					// place it appears is the "Waiting for session …"
+					// breadcrumb, suppressed under --quiet and any non-raw
+					// format.
 					if renderErr := output.Render(cmd.OutOrStdout(), output.Format, restored, renderSessionDetail); renderErr != nil {
 						return renderErr
 					}
-					cmdutil.SilenceRootErrors(cmd)
 					return fmt.Errorf("waiting for session: %w", waitErr)
 				}
 				restored = ready

--- a/cli/rde/session/vnc_test.go
+++ b/cli/rde/session/vnc_test.go
@@ -192,7 +192,8 @@ func TestOpenVNCCmd_HandsURLToOpener(t *testing.T) {
 }
 
 func TestOpenVNCCmd_JSONOmitsPassword(t *testing.T) {
-	// JSON mode is the same: confirmation envelope only, no password.
+	// JSON mode returns a confirmation envelope with no password, but
+	// (unlike raw mode) never launches the VNC viewer, so Opened is false.
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_, _ = io.WriteString(w, `{"session":{
 			"id":"s-1","name":"dev","status":"SESSION_STATUS_RUNNING",
@@ -216,7 +217,7 @@ func TestOpenVNCCmd_JSONOmitsPassword(t *testing.T) {
 	if err := json.Unmarshal([]byte(stdout), &got); err != nil {
 		t.Fatalf("unmarshal JSON output: %v\n%s", err, stdout)
 	}
-	if !got.Opened || got.Address != "h:5900" || got.Username != "u" {
+	if got.Opened || got.Address != "h:5900" || got.Username != "u" {
 		t.Errorf("unexpected JSON: %+v", got)
 	}
 }

--- a/internal/bitriseapi/client.go
+++ b/internal/bitriseapi/client.go
@@ -42,7 +42,7 @@ func New(rawBaseURL, token string, opts ...Option) (*Client, error) {
 		return nil, err
 	}
 	c := &Client{
-		baseURL:    u.String(),
+		baseURL:    strings.TrimSuffix(u.String(), "/"),
 		token:      token,
 		httpClient: &http.Client{Timeout: defaultTimeout},
 	}

--- a/internal/build/watch.go
+++ b/internal/build/watch.go
@@ -134,17 +134,23 @@ func (s *Service) Watch(ctx context.Context, appSlug, buildSlug string, w io.Wri
 			return Build{}, err
 		}
 		lastAfterTimestamp = afterTimestamp
-		afterTimestamp = manifest.NextAfterTimestamp
+		if manifest.NextAfterTimestamp != "" {
+			// Keep the last known-good cursor on an empty response — "" means
+			// "full log fetch" (see BuildLogManifest), and the poll above
+			// already ran unconditionally this iteration regardless of the
+			// cursor, so skipping the update here can't stall streaming.
+			afterTimestamp = manifest.NextAfterTimestamp
+		}
 		if current.Status != 0 {
 			break
 		}
 	}
 
 	// One final call to flush any chunks buffered after the last poll. Runs
-	// unconditionally, even if lastAfterTimestamp is still "" (a poll's
-	// NextAfterTimestamp can come back empty), so a stuck-empty cursor can't
-	// permanently skip this catch-up — worst case it's a full log refetch,
-	// and flushContiguous drops anything already emitted.
+	// unconditionally — lastAfterTimestamp only stays "" here if every poll's
+	// NextAfterTimestamp came back empty (a full log refetch in that case;
+	// flushContiguous drops anything already emitted), otherwise it carries
+	// the last known-good cursor.
 	final, err := s.client.BuildLogManifest(ctx, appSlug, buildSlug, lastAfterTimestamp)
 	if err != nil {
 		return Build{}, err

--- a/internal/build/watch.go
+++ b/internal/build/watch.go
@@ -126,17 +126,15 @@ func (s *Service) Watch(ctx context.Context, appSlug, buildSlug string, w io.Wri
 		if err != nil {
 			return Build{}, err
 		}
-		if afterTimestamp != "" {
-			manifest, err = s.client.BuildLogManifest(ctx, appSlug, buildSlug, afterTimestamp)
-			if err != nil {
-				return Build{}, err
-			}
-			if err := flush(manifest.LogChunks); err != nil {
-				return Build{}, err
-			}
-			lastAfterTimestamp = afterTimestamp
-			afterTimestamp = manifest.NextAfterTimestamp
+		manifest, err = s.client.BuildLogManifest(ctx, appSlug, buildSlug, afterTimestamp)
+		if err != nil {
+			return Build{}, err
 		}
+		if err := flush(manifest.LogChunks); err != nil {
+			return Build{}, err
+		}
+		lastAfterTimestamp = afterTimestamp
+		afterTimestamp = manifest.NextAfterTimestamp
 		if current.Status != 0 {
 			break
 		}

--- a/internal/build/watch_test.go
+++ b/internal/build/watch_test.go
@@ -17,9 +17,12 @@ import (
 )
 
 func TestService_Watch_DeltaStreaming(t *testing.T) {
-	// Three log polls: chunk1 (ts1), chunk2 (ts2), chunk3 (empty next ts).
-	// Build status returns in-progress until the log stream ends naturally,
-	// then the final-flush call and a View call complete the sequence.
+	// Four log polls: chunk1 (ts1), chunk2 (ts2), chunk3 (empty next ts, so
+	// the cursor for the next poll carries over as ts2 instead of resetting),
+	// then one more in-loop poll (still using ts2) that hits the "final"
+	// default case. Build status flips to finished on the build call
+	// alongside that last poll, so the loop exits there — the dedicated
+	// post-loop final-flush call and a View call complete the sequence.
 	var logCalls, buildCalls atomic.Int32
 	var logTimestamps []string
 
@@ -34,7 +37,10 @@ func TestService_Watch_DeltaStreaming(t *testing.T) {
 			case 2:
 				_, _ = w.Write([]byte(`{"is_archived":false,"log_chunks":[{"chunk":"chunk2\n","position":1}],"next_after_timestamp":"ts2"}`))
 			case 3:
-				// Empty next_after_timestamp: loop exits after this poll.
+				// Empty next_after_timestamp: the cursor for the next poll
+				// carries over as ts2 instead of resetting to "" — the loop
+				// does not exit here, it polls once more before exiting on
+				// build status.
 				_, _ = w.Write([]byte(`{"is_archived":false,"log_chunks":[{"chunk":"chunk3\n","position":2}]}`))
 			default: // final flush
 				_, _ = w.Write([]byte(`{"is_archived":false,"log_chunks":[{"chunk":"final\n","position":3}]}`))
@@ -61,10 +67,12 @@ func TestService_Watch_DeltaStreaming(t *testing.T) {
 		assert.Contains(t, got, want)
 	}
 
-	// Verify after_timestamp progression for log calls: "", ts1, ts2, then "" once
-	// the manifest's next_after_timestamp comes back empty (still polled every
-	// iteration, not skipped).
-	wantTimestamps := []string{"", "ts1", "ts2", ""}
+	// Verify after_timestamp progression for log calls: "", ts1, ts2, then ts2
+	// again once the manifest's next_after_timestamp comes back empty — the
+	// poll still happens every iteration (not skipped), but the cursor
+	// carries over instead of resetting to "" (which would force a full log
+	// refetch).
+	wantTimestamps := []string{"", "ts1", "ts2", "ts2"}
 	require.GreaterOrEqual(t, len(logTimestamps), len(wantTimestamps))
 	for i, want := range wantTimestamps {
 		assert.Equal(t, want, logTimestamps[i], "log call %d", i+1)

--- a/internal/build/watch_test.go
+++ b/internal/build/watch_test.go
@@ -61,8 +61,10 @@ func TestService_Watch_DeltaStreaming(t *testing.T) {
 		assert.Contains(t, got, want)
 	}
 
-	// Verify after_timestamp progression for log calls: "", ts1, ts2, ts2 (final flush).
-	wantTimestamps := []string{"", "ts1", "ts2", "ts2"}
+	// Verify after_timestamp progression for log calls: "", ts1, ts2, then "" once
+	// the manifest's next_after_timestamp comes back empty (still polled every
+	// iteration, not skipped).
+	wantTimestamps := []string{"", "ts1", "ts2", ""}
 	require.GreaterOrEqual(t, len(logTimestamps), len(wantTimestamps))
 	for i, want := range wantTimestamps {
 		assert.Equal(t, want, logTimestamps[i], "log call %d", i+1)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -48,8 +48,8 @@ type Config struct {
 const DirFileName = ".bitrise-cli.yml"
 
 // Dir returns the absolute path to the bitrise CLI config directory — the
-// parent of the global config file. Honors XDG_CONFIG_HOME, falling back to
-// ~/.config/bitrise/cli.
+// parent of the global config file (see the package doc for the XDG
+// fallback rule).
 func Dir() (string, error) {
 	base := os.Getenv("XDG_CONFIG_HOME")
 	if base == "" {


### PR DESCRIPTION
Follow-up on review comments from the `v3-development` stack that were left unresolved,
unanswered, or explicitly deferred. All 37 merged PRs based on `v3-development` (or its
stacked sub-branches) that haven't landed on `master` yet were audited; each thread was
re-checked against the current code rather than trusting GitHub's resolved flag.

### Fixed

- **`internal/build/watch.go`** — the log-polling loop only called `BuildLogManifest` while
  `afterTimestamp` was non-empty, and only updated the cursor inside that branch. The first
  time the server returned an empty `NextAfterTimestamp` — which happens mid-build, not just
  at start — the loop stopped fetching log chunks for the rest of the build. Nothing was lost
  (the post-loop final flush re-requests from the last good cursor), but live tailing stalled
  and the log arrived in one burst at the end. Now fetches unconditionally every iteration;
  re-fetching with an empty cursor is safe because `flushContiguous` already dedups by chunk
  position. `watch_test.go`'s expected cursor sequence updated accordingly.
  ([#1317](https://github.com/bitrise-io/bitrise/pull/1317#discussion_r3776422264)) — *was
  still broken despite the thread being marked resolved*
- **`cli/rde/session/open_vnc.go`** — the VNC URL was opened as a side effect before the
  `--format` check, so `--format json/yml` also launched a browser. Format check now runs
  first; the URL is only opened for the default raw output.
  ([#1341](https://github.com/bitrise-io/bitrise/pull/1341#discussion_r3933561299))
- **`cli/rde/session/restore.go`** — the wait-timeout path returned the error without
  rendering the session first, even though the session exists and is billable. Now renders the
  last known state before returning, matching the sibling `status != running` branch.
  ([#1340](https://github.com/bitrise-io/bitrise/pull/1340#discussion_r3933362680))
- **`internal/bitriseapi/client.go`** — the base URL was stored untrimmed, so a configured
  URL with a trailing slash produced `//` in request paths. Now
  `strings.TrimSuffix(u.String(), "/")`.
  ([#1307](https://github.com/bitrise-io/bitrise/pull/1307#discussion_r3767343226))
- **`internal/config/config.go`** — removed the XDG_CONFIG_HOME comment duplicated between
  the package doc and `Dir()`; `Dir()` now points at the package doc.
  ([#1289](https://github.com/bitrise-io/bitrise/pull/1289#discussion_r3614558682))
- **`cli/build/abort.go`** — the `--reason` help text claimed the abort reason is "recorded in
  the build log". It isn't; it's recorded on the build and exposed via UI/API.
  ([#1318](https://github.com/bitrise-io/bitrise/pull/1318#discussion_r3783360455))
- **`cli/cmdutil/picker/picker_test.go`** — stale comment, now describes `threeItems()`.
  ([#1327](https://github.com/bitrise-io/bitrise/pull/1327#discussion_r3861080878))

The remaining audited threads either turned out to be already fixed in code (just never
marked resolved) or were reviewed and deliberately left as-is; those decisions stay in the
review threads and are not repeated here.
