### PR TITLE
v3 cleanup 1 - auth and config handling fixes

### DIFF
--- a/cli/auth/login.go
+++ b/cli/auth/login.go
@@ -84,6 +84,13 @@ logout' to clear).`,
 			case passwordStdin:
 				return fmt.Errorf("--password-stdin requires --email (token login reads the token, not a password)")
 			case cmdutil.IsTerminal(cmd.InOrStdin()):
+				if cmdutil.IsSSHSession() {
+					// Browser OAuth can't complete over SSH (the loopback
+					// redirect can't reach this machine); fall through to
+					// the token prompt like it used to, instead of picking
+					// OAuth here and immediately hard-erroring inside it.
+					return runTokenLogin(cmd)
+				}
 				// Interactive and no mode chosen: default to browser OAuth.
 				return runOAuthLogin(cmd)
 			default:
@@ -114,8 +121,9 @@ logout' to clear).`,
 }
 
 // runTokenLogin reads the token from stdin, or prompts for it (masked) when
-// stdin is a terminal. The prompt is only reachable via an explicit
-// --with-token, since a bare interactive `auth login` defaults to OAuth.
+// stdin is a terminal. The prompt is reachable via an explicit --with-token,
+// or a bare interactive `auth login` over SSH (browser OAuth can't complete
+// there); otherwise a bare interactive `auth login` defaults to OAuth.
 func runTokenLogin(cmd *cobra.Command) error {
 	tok, err := cmdutil.ReadSecretInput(cmd.InOrStdin(), cmd.ErrOrStderr(), "Token: ", false)
 	if err != nil {

--- a/cli/auth/login.go
+++ b/cli/auth/login.go
@@ -124,6 +124,11 @@ func runTokenLogin(cmd *cobra.Command) error {
 	if tok == "" {
 		return fmt.Errorf("token is empty")
 	}
+	unlock, err := auth.Lock(cmd.Context())
+	if err != nil {
+		return err
+	}
+	defer unlock()
 	if err := auth.Save(auth.Auth{Token: tok}); err != nil {
 		return err
 	}
@@ -158,6 +163,11 @@ func runEmailLogin(cmd *cobra.Command, email string, passwordStdin bool) error {
 		}
 		return err
 	}
+	unlock, err := auth.Lock(cmd.Context())
+	if err != nil {
+		return err
+	}
+	defer unlock()
 	if err := auth.Save(auth.Auth{Token: tok}); err != nil {
 		return err
 	}
@@ -179,6 +189,11 @@ func doOAuthLogin(cmd *cobra.Command, openBrowser func(string) error) error {
 	if err != nil {
 		return err
 	}
+	unlock, err := auth.Lock(cmd.Context())
+	if err != nil {
+		return err
+	}
+	defer unlock()
 	if err := auth.Save(a); err != nil {
 		return err
 	}

--- a/cli/auth/login_test.go
+++ b/cli/auth/login_test.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
@@ -27,6 +28,27 @@ func TestRunTokenLogin_SavesToken(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "bitpat_faketoken", saved.Token)
 	assert.False(t, saved.IsOAuthManaged())
+}
+
+// TestRunTokenLogin_BlocksWhileAuthLockHeld covers all three auth.Save call
+// sites at once, since runTokenLogin, runEmailLogin, and doOAuthLogin now
+// wrap the same auth.Lock — without it, a login racing a background token
+// refresh (internal/oauth.EnsureFreshPAT) could clobber the refreshed
+// credentials.
+func TestRunTokenLogin_BlocksWhileAuthLockHeld(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	unlock, err := auth.Lock(context.Background())
+	require.NoError(t, err)
+	defer unlock()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	cmd := newTestCmd(t, "bitpat_faketoken\n")
+	cmd.SetContext(ctx)
+
+	err = runTokenLogin(cmd)
+	require.Error(t, err, "the save must wait for the auth lock, not race a concurrent refresh")
 }
 
 func TestRunTokenLogin_EmptyTokenErrors(t *testing.T) {

--- a/cli/auth/login_test.go
+++ b/cli/auth/login_test.go
@@ -194,6 +194,32 @@ func TestDoOAuthLogin_FailsFastOverSSH(t *testing.T) {
 	assert.False(t, browserCalled, "should fail before ever trying to open a browser")
 }
 
+// TestAuthLogin_SSHSessionDefaultsToTokenPrompt guards the regression: an
+// interactive terminal with no mode flag over SSH used to still pick browser
+// OAuth (which then hard-errors inside doOAuthLogin) instead of falling
+// through to the token prompt like a bare `auth login` used to before OAuth
+// existed.
+func TestAuthLogin_SSHSessionDefaultsToTokenPrompt(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("SSH_CONNECTION", "10.0.0.1 1234 10.0.0.2 22")
+
+	orig := cmdutil.IsTerminal
+	cmdutil.IsTerminal = func(io.Reader) bool { return true }
+	t.Cleanup(func() { cmdutil.IsTerminal = orig })
+
+	cmd := NewLoginCommand()
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	cmd.SetIn(strings.NewReader("bitpat_sshuser\n"))
+	cmd.SetArgs(nil)
+
+	require.NoError(t, cmd.Execute())
+
+	saved, err := auth.Load()
+	require.NoError(t, err)
+	assert.Equal(t, "bitpat_sshuser", saved.Token)
+}
+
 // The tests below exercise NewLoginCommand()'s actual cobra dispatch (flag
 // parsing, mutual exclusivity, and the interactive-vs-piped default) end to
 // end, rather than calling the run*Login functions directly.

--- a/cli/auth/status.go
+++ b/cli/auth/status.go
@@ -79,7 +79,7 @@ func resolveTokenAndSource() (token, source string, err error) {
 // currentStatus is kept separate from NewStatusCommand's RunE so it can be
 // tested directly.
 func currentStatus() (authStatus, error) {
-	p, err := auth.Path()
+	p, err := auth.ActivePath()
 	if err != nil {
 		return authStatus{}, err
 	}

--- a/cli/auth/status_test.go
+++ b/cli/auth/status_test.go
@@ -95,6 +95,25 @@ func TestCurrentStatus_PastedToken(t *testing.T) {
 	assert.Empty(t, s.TokenExpiry)
 }
 
+// TestCurrentStatus_ReportsPredecessorPathWhileFallbackLive guards the same
+// class of bug fixed for `bitrise config path`: currentStatus used to call
+// auth.Path() directly, so during the fallback window it reported a file
+// that didn't exist instead of the predecessor auth.yaml actually in use.
+func TestCurrentStatus_ReportsPredecessorPathWhileFallbackLive(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	t.Setenv("BITRISE_TOKEN", "")
+	predecessorDir := filepath.Join(dir, "bitrise")
+	require.NoError(t, os.MkdirAll(predecessorDir, 0o700))
+	predecessorFile := filepath.Join(predecessorDir, "auth.yaml")
+	require.NoError(t, os.WriteFile(predecessorFile, []byte("token: bitpat_predecessor\n"), 0o600))
+
+	s, err := currentStatus()
+	require.NoError(t, err)
+	assert.True(t, s.HasToken)
+	assert.Equal(t, predecessorFile, s.Path)
+}
+
 func TestCurrentStatus_OAuthManagedShowsExpiry(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	t.Setenv("BITRISE_TOKEN", "")

--- a/cli/cmdtest/cmdtest.go
+++ b/cli/cmdtest/cmdtest.go
@@ -52,6 +52,8 @@ func RunIsolated(m *testing.M) int {
 		cmdutil.EnvOutput,
 		cmdutil.EnvTheme,
 		cmdutil.EnvRDEAPIBaseURL,
+		cmdutil.EnvAPIBaseURL,
+		cmdutil.EnvWebBaseURL,
 	} {
 		if err := os.Unsetenv(key); err != nil {
 			panic(err)

--- a/cli/cmdutil/apibase.go
+++ b/cli/cmdutil/apibase.go
@@ -1,0 +1,29 @@
+package cmdutil
+
+import (
+	"os"
+	"strings"
+
+	"github.com/bitrise-io/bitrise/v2/internal/config"
+	"github.com/spf13/cobra"
+)
+
+// EnvAPIBaseURL overrides the API base URL — rarely changed, mostly for
+// pointing at a non-prod environment. Exported since tests set it directly.
+const EnvAPIBaseURL = "BITRISE_API_BASE_URL"
+
+// ResolveAPIBaseURL returns the resolved API base URL: BITRISE_API_BASE_URL,
+// then the api_base_url set via `bitrise config set` (global config file only
+// — never a per-dir .bitrise-cli.yml, see internal/config.Resolve), then the
+// built-in default — matching ResolveWebBaseURL/ResolveRDEAPIBaseURL. Any
+// trailing slash is trimmed here, once, so every caller can concatenate a
+// path onto the result without producing a double slash.
+func ResolveAPIBaseURL(cmd *cobra.Command) string {
+	if v := os.Getenv(EnvAPIBaseURL); v != "" {
+		return strings.TrimSuffix(v, "/")
+	}
+	if v := config.FromContext(cmd.Context()).APIBaseURL; v != "" {
+		return strings.TrimSuffix(v, "/")
+	}
+	return config.DefaultAPIBaseURL
+}

--- a/cli/cmdutil/apibase_test.go
+++ b/cli/cmdutil/apibase_test.go
@@ -1,0 +1,49 @@
+package cmdutil
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/bitrise-io/bitrise/v2/internal/config"
+)
+
+func TestResolveAPIBaseURL_EnvWinsOverContext(t *testing.T) {
+	t.Setenv(EnvAPIBaseURL, "https://env.example")
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(config.WithResolved(t.Context(), config.Resolved{Config: config.Config{APIBaseURL: "https://ctx.example"}}))
+
+	assert.Equal(t, "https://env.example", ResolveAPIBaseURL(cmd))
+}
+
+func TestResolveAPIBaseURL_ContextWinsOverDefault(t *testing.T) {
+	cmd := &cobra.Command{}
+	cmd.SetContext(config.WithResolved(t.Context(), config.Resolved{Config: config.Config{APIBaseURL: "https://ctx.example"}}))
+
+	assert.Equal(t, "https://ctx.example", ResolveAPIBaseURL(cmd))
+}
+
+func TestResolveAPIBaseURL_NilContextFallsBackToDefault(t *testing.T) {
+	cmd := &cobra.Command{}
+
+	assert.Equal(t, config.DefaultAPIBaseURL, ResolveAPIBaseURL(cmd))
+}
+
+func TestResolveAPIBaseURL_EmptyResolvedContextFallsBackToDefault(t *testing.T) {
+	cmd := &cobra.Command{}
+	cmd.SetContext(t.Context())
+
+	assert.Equal(t, config.DefaultAPIBaseURL, ResolveAPIBaseURL(cmd))
+}
+
+func TestResolveAPIBaseURL_TrimsTrailingSlash(t *testing.T) {
+	t.Setenv(EnvAPIBaseURL, "https://env.example/")
+	cmd := &cobra.Command{}
+	assert.Equal(t, "https://env.example", ResolveAPIBaseURL(cmd), "callers concatenate a path onto the result and must not get a double slash")
+
+	t.Setenv(EnvAPIBaseURL, "")
+	cmd.SetContext(config.WithResolved(t.Context(), config.Resolved{Config: config.Config{APIBaseURL: "https://ctx.example/"}}))
+	assert.Equal(t, "https://ctx.example", ResolveAPIBaseURL(cmd))
+}

--- a/cli/cmdutil/client.go
+++ b/cli/cmdutil/client.go
@@ -6,21 +6,19 @@ import (
 
 	"github.com/bitrise-io/bitrise/v2/internal/auth"
 	"github.com/bitrise-io/bitrise/v2/internal/bitriseapi"
-	"github.com/bitrise-io/bitrise/v2/internal/config"
 	"github.com/spf13/cobra"
 )
 
 var ErrNoToken = errors.New("no Bitrise access token configured (run 'bitrise auth login' or set BITRISE_TOKEN)")
 
 // NewAPIClient builds a *bitriseapi.Client using the token resolved by
-// liveToken and the configured API base URL.
+// liveToken and the resolved API base URL.
 func NewAPIClient(cmd *cobra.Command) (*bitriseapi.Client, error) {
 	tok, err := liveToken(cmd)
 	if err != nil {
 		return nil, err
 	}
-	r := config.FromContext(cmd.Context())
-	return bitriseapi.New(r.APIBaseURL, tok)
+	return bitriseapi.New(ResolveAPIBaseURL(cmd), tok)
 }
 
 // ResolveToken returns the configured token and whether it came from the

--- a/cli/cmdutil/client_test.go
+++ b/cli/cmdutil/client_test.go
@@ -54,6 +54,32 @@ func TestNewAPIClient_FallsBackToAuthFile(t *testing.T) {
 	assert.Equal(t, "token file-token", gotAuth)
 }
 
+// TestNewAPIClient_EnvAPIBaseURLOverridesContext covers the item that fixed
+// "the only key with no env override": NewAPIClient used to read the
+// resolved config's APIBaseURL directly, with no BITRISE_API_BASE_URL layer
+// at all, unlike the web/RDE base URL resolvers.
+func TestNewAPIClient_EnvAPIBaseURLOverridesContext(t *testing.T) {
+	var hitEnvServer bool
+	envSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hitEnvServer = true
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	t.Cleanup(envSrv.Close)
+
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	require.NoError(t, auth.Save(auth.Auth{Token: "file-token"}))
+	t.Setenv(EnvAPIBaseURL, envSrv.URL)
+
+	// The context carries a different (unreachable) base URL — the env var
+	// must win.
+	client, err := NewAPIClient(newTestCmd(t, "http://127.0.0.1:1"))
+	require.NoError(t, err)
+
+	_, err = client.SearchSteps(context.Background(), bitriseapi.StepSearchOptions{})
+	require.NoError(t, err)
+	assert.True(t, hitEnvServer, "BITRISE_API_BASE_URL should override the context-resolved base URL")
+}
+
 func TestNewAPIClient_ErrNoToken(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 

--- a/cli/cmdutil/terminal.go
+++ b/cli/cmdutil/terminal.go
@@ -22,7 +22,11 @@ func TerminalFd(stream any) (fd int, isTerminal bool) {
 // IsTerminal reports whether r is an interactive terminal. Pipes and buffers
 // never are, so callers can pick an interactive default (e.g. browser login)
 // while keeping non-interactive stdin (CI, pipes) working.
-func IsTerminal(r io.Reader) bool {
+//
+// It's a var, not a func, so tests can substitute it to exercise branches
+// that depend on an actual TTY (e.g. cli/auth/login.go's SSH-vs-browser
+// default) without one.
+var IsTerminal = func(r io.Reader) bool {
 	_, ok := TerminalFd(r)
 	return ok
 }

--- a/cli/config/cmd.go
+++ b/cli/config/cmd.go
@@ -25,8 +25,8 @@ Storage:
 Recognized keys: %s
 
 api_base_url, web_base_url, and rde_api_base_url resolve as: global file >
-built-in default. web_base_url and rde_api_base_url are additionally
-overridable via $%s and $%s, which win over the global file. They
+built-in default. All three are additionally overridable via $%s, $%s and
+$%s, which win over the global file. They
 deliberately ignore the per-directory .bitrise-cli.yml — each names a host
 that receives credentials, and a repo you merely clone and run 'bitrise'
 inside of must not be able to silently redirect them.
@@ -55,7 +55,8 @@ app_id/default_workspace_id above — neither is a credential or a URL. Note
 files must be edited by hand.
 
 To manage your access token, use 'bitrise auth login/logout/status'.`,
-			strings.Join(internalconfig.Keys, ", "), cmdutil.EnvWebBaseURL, cmdutil.EnvRDEAPIBaseURL,
+			strings.Join(internalconfig.Keys, ", "),
+			cmdutil.EnvAPIBaseURL, cmdutil.EnvWebBaseURL, cmdutil.EnvRDEAPIBaseURL,
 			cmdutil.EnvOutput, cmdutil.EnvTheme,
 		),
 		RunE: cmdutil.RequireKnownSubcommand,

--- a/cli/config/list.go
+++ b/cli/config/list.go
@@ -37,7 +37,7 @@ BITRISE_WORKSPACE_ID are always set.`,
 			if err != nil {
 				return err
 			}
-			p, err := internalconfig.Path()
+			p, err := internalconfig.ActivePath()
 			if err != nil {
 				return err
 			}

--- a/cli/config/list_test.go
+++ b/cli/config/list_test.go
@@ -2,6 +2,8 @@ package config
 
 import (
 	"bytes"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -77,6 +79,28 @@ func TestListCmd_YMLFormat(t *testing.T) {
 	assert.Contains(t, out, `default_workspace_id: ""`)
 	assert.Contains(t, out, `output: ""`)
 	assert.Contains(t, out, `theme: ""`)
+}
+
+// TestListCmd_ReportsPredecessorPathWhileFallbackLive covers the same trap
+// `bitrise config path` had: list printed the new config.yml path
+// unconditionally, so during the fallback window it named a file that does
+// not exist right beside the values it had just read from the legacy one.
+func TestListCmd_ReportsPredecessorPathWhileFallbackLive(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+
+	predecessorDir, err := internalconfig.PredecessorDir()
+	require.NoError(t, err)
+	require.NoError(t, os.MkdirAll(predecessorDir, 0o700))
+	legacyPath := filepath.Join(predecessorDir, "config.yaml")
+	require.NoError(t, os.WriteFile(legacyPath, []byte("theme: dark\n"), 0o600))
+
+	cmd, out := newTestCmd(t, NewListCommand())
+	require.NoError(t, cmd.RunE(cmd, nil))
+
+	got := out.String()
+	assert.Contains(t, got, "Path: "+legacyPath)
+	assert.Contains(t, got, "theme: dark")
 }
 
 func TestListCmd_RejectsPositionalArgs(t *testing.T) {

--- a/cli/config/path.go
+++ b/cli/config/path.go
@@ -18,7 +18,7 @@ func NewPathCommand() *cobra.Command {
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			cmdutil.LogCommandParameters(cmd)
 
-			p, err := internalconfig.Path()
+			p, err := internalconfig.ActivePath()
 			if err != nil {
 				return err
 			}

--- a/cli/config/path_test.go
+++ b/cli/config/path_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"bytes"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -18,6 +19,24 @@ func TestPathCmd_PrintsGlobalConfigPath(t *testing.T) {
 	require.NoError(t, cmd.RunE(cmd, nil))
 
 	assert.Equal(t, filepath.Join(dir, "bitrise", "cli", "config.yml")+"\n", out.String())
+}
+
+// TestPathCmd_PrintsPredecessorPathWhileFallbackLive covers the trap `bitrise
+// config path` used to fall into: it printed the new config.yml path
+// unconditionally, so `cat $(bitrise config path)` failed with "no such
+// file" for anyone still being served by the predecessor CLI's config.yaml
+// fallback.
+func TestPathCmd_PrintsPredecessorPathWhileFallbackLive(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "bitrise"), 0o700))
+	predecessorFile := filepath.Join(dir, "bitrise", "config.yaml")
+	require.NoError(t, os.WriteFile(predecessorFile, []byte("theme: dark\n"), 0o600))
+
+	cmd, out := newTestCmd(t, NewPathCommand())
+	require.NoError(t, cmd.RunE(cmd, nil))
+
+	assert.Equal(t, predecessorFile+"\n", out.String())
 }
 
 func TestPathCmd_RejectsPositionalArgs(t *testing.T) {

--- a/cli/config/set_test.go
+++ b/cli/config/set_test.go
@@ -2,6 +2,8 @@ package config
 
 import (
 	"bytes"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -61,6 +63,49 @@ func TestSetCmd_PreservesOtherKeys(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "https://api.example.com", cfg.APIBaseURL)
 	assert.Equal(t, "https://app.example.com", cfg.WebBaseURL)
+}
+
+// TestSetCmd_CarriesPredecessorConfigForward covers the reason the legacy
+// fallback lives in config.Load rather than only in config.Resolve: set is
+// read-modify-write, so the first set after an upgrade has to read the
+// predecessor CLI's file in full and write all of it forward. Reading only
+// the (absent) new file would persist the one key just set and silently drop
+// the rest, and the new file existing would then stop the fallback firing.
+func TestSetCmd_CarriesPredecessorConfigForward(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	predecessorDir, err := internalconfig.PredecessorDir()
+	require.NoError(t, err)
+	require.NoError(t, os.MkdirAll(predecessorDir, 0o700))
+	legacyPath := filepath.Join(predecessorDir, "config.yaml")
+	// app_slug/default_workspace_slug are the predecessor's pre-rename
+	// spellings, so this also covers the key aliases.
+	require.NoError(t, os.WriteFile(legacyPath, []byte(
+		"app_slug: app-123\ndefault_workspace_slug: ws-456\ntheme: dark\nweb_base_url: https://app.example.com\n",
+	), 0o600))
+
+	cmd, _ := newTestCmd(t, NewSetCommand())
+	cmd.SetErr(&bytes.Buffer{})
+	require.NoError(t, cmd.RunE(cmd, []string{internalconfig.KeyAPIBaseURL, "https://api.example.com"}))
+
+	newPath, err := internalconfig.Path()
+	require.NoError(t, err)
+	require.FileExists(t, newPath)
+
+	cfg, err := internalconfig.Load()
+	require.NoError(t, err)
+	assert.Equal(t, "https://api.example.com", cfg.APIBaseURL)
+	assert.Equal(t, "app-123", cfg.AppID)
+	assert.Equal(t, "ws-456", cfg.DefaultWorkspaceID)
+	assert.Equal(t, "dark", cfg.Theme)
+	assert.Equal(t, "https://app.example.com", cfg.WebBaseURL)
+
+	// The predecessor CLI keeps running after the upgrade, so its file must
+	// survive untouched.
+	assert.FileExists(t, legacyPath)
+	active, err := internalconfig.ActivePath()
+	require.NoError(t, err)
+	assert.Equal(t, newPath, active)
 }
 
 func TestSetCmd_RequiresExactlyTwoArgs(t *testing.T) {

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -79,14 +79,6 @@ func Path() (string, error) {
 	return filepath.Join(dir, "auth.yaml"), nil
 }
 
-func predecessorPath() (string, error) {
-	dir, err := config.PredecessorDir()
-	if err != nil {
-		return "", err
-	}
-	return filepath.Join(dir, "auth.yaml"), nil
-}
-
 // ActivePath returns the auth file Load() actually reads from right now:
 // the predecessor CLI's auth.yaml while that fallback is live, or the
 // current path once anything has written it (or if neither exists yet).
@@ -188,4 +180,12 @@ func Clear() error {
 		return fmt.Errorf("remove %s: %w", pp, err)
 	}
 	return nil
+}
+
+func predecessorPath() (string, error) {
+	dir, err := config.PredecessorDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "auth.yaml"), nil
 }

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -87,6 +87,29 @@ func predecessorPath() (string, error) {
 	return filepath.Join(dir, "auth.yaml"), nil
 }
 
+// ActivePath returns the auth file Load() actually reads from right now:
+// the predecessor CLI's auth.yaml while that fallback is live, or the
+// current path once anything has written it (or if neither exists yet).
+// Used by `bitrise auth status` so its reported path matches reality —
+// Path() alone would name a file that doesn't exist during the fallback
+// window.
+func ActivePath() (string, error) {
+	p, err := Path()
+	if err != nil {
+		return "", err
+	}
+	if _, statErr := os.Stat(p); errors.Is(statErr, fs.ErrNotExist) {
+		pp, err := predecessorPath()
+		if err != nil {
+			return "", err
+		}
+		if _, statErr := os.Stat(pp); statErr == nil {
+			return pp, nil
+		}
+	}
+	return p, nil
+}
+
 // Load reads the auth file. A missing file returns the zero Auth so
 // first-time users don't see failures. When it's absent, Load falls back to
 // reading the predecessor CLI's auth.yaml (see predecessorPath), never

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -113,8 +113,11 @@ func ActivePath() (string, error) {
 // Load reads the auth file. A missing file returns the zero Auth so
 // first-time users don't see failures. When it's absent, Load falls back to
 // reading the predecessor CLI's auth.yaml (see predecessorPath), never
-// writing to it — the Auth shape is identical on both sides, so no key
-// aliasing is needed here (contrast internal/config.Load).
+// writing to it. No key aliasing is needed here, unlike internal/config.Load:
+// the shared keys are spelled the same on both sides. The predecessor also
+// writes refresh_token_expiry, which this Auth has no field for and so drops
+// on read — harmless, since the refresh ladder in internal/oauth tries the
+// refresh token and lets the server reject an expired one.
 func Load() (Auth, error) {
 	p, err := Path()
 	if err != nil {

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -1,9 +1,15 @@
 // Package auth persists and reads the Bitrise access token.
 //
-// Storage: YAML at $XDG_CONFIG_HOME/bitrise/cli/auth.yaml, falling back to
-// ~/.config/bitrise/cli/auth.yaml. Credentials live in their own file,
-// separate from preferences in config.yml, at 0600 permissions. OS-keychain
-// integration is intentionally deferred.
+// Storage: YAML at $XDG_CONFIG_HOME/bitrise/cli/auth.yaml, or
+// ~/.config/bitrise/cli/auth.yaml when XDG_CONFIG_HOME is unset. Credentials
+// live in their own file, separate from preferences in config.yml, at 0600
+// permissions. OS-keychain integration is intentionally deferred.
+//
+// Load also has a read-only fallback to the predecessor standalone CLI's
+// auth.yaml (one directory segment up — see config.PredecessorDir — same
+// filename), so an existing install of that CLI isn't silently logged out
+// by the merge. That file is never written to, but Clear removes it too, so
+// logout can't appear to succeed while a stale token remains discoverable.
 //
 // The Bitrise API accepts both Personal Access Tokens (user-scoped) and
 // Workspace API Tokens (workspace-scoped); they have identical wire format
@@ -15,10 +21,12 @@ package auth
 import (
 	"errors"
 	"fmt"
+	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/bitrise-io/bitrise/v2/internal/config"
@@ -71,14 +79,50 @@ func Path() (string, error) {
 	return filepath.Join(dir, "auth.yaml"), nil
 }
 
+func predecessorPath() (string, error) {
+	dir, err := config.PredecessorDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "auth.yaml"), nil
+}
+
 // Load reads the auth file. A missing file returns the zero Auth so
-// first-time users don't see failures.
+// first-time users don't see failures. When it's absent, Load falls back to
+// reading the predecessor CLI's auth.yaml (see predecessorPath), never
+// writing to it — the Auth shape is identical on both sides, so no key
+// aliasing is needed here (contrast internal/config.Load).
 func Load() (Auth, error) {
 	p, err := Path()
 	if err != nil {
 		return Auth{}, err
 	}
-	return config.LoadYAML[Auth](p)
+	pp, err := predecessorPath()
+	if err != nil {
+		return Auth{}, err
+	}
+	a, usedFallback, err := config.LoadYAMLWithFallback[Auth](p, pp)
+	if err != nil {
+		return Auth{}, err
+	}
+	if usedFallback {
+		announceFallback(pp)
+	}
+	return a, nil
+}
+
+var fallbackAnnounceOnce sync.Once
+
+// fallbackWriter is a var, not a bare os.Stderr use, so tests can capture
+// the one-time announcement. Kept separate from internal/config's own
+// instance of this — sharing one Once would mean whichever file falls back
+// first silently suppresses the announcement for the other.
+var fallbackWriter io.Writer = os.Stderr
+
+func announceFallback(path string) {
+	fallbackAnnounceOnce.Do(func() {
+		fmt.Fprintf(fallbackWriter, "Using the previous bitrise-cli's credentials file at %s (read-only; log in again with this CLI to migrate it)\n", path)
+	})
 }
 
 // Save atomically writes a to disk with 0600 permissions, creating the
@@ -96,7 +140,12 @@ func Save(a Auth) error {
 	return config.SaveYAML(p, a)
 }
 
-// Clear removes the auth file. A non-existent file is not an error.
+// Clear removes the auth file and the predecessor CLI's auth.yaml if it
+// exists. A non-existent file is not an error. Removing both matters: with
+// only the current path cleared, a later Load would fall back to the
+// predecessor file and report the user still logged in — and this doesn't
+// revoke the token server-side either, so leaving that file behind would
+// keep it live.
 func Clear() error {
 	p, err := Path()
 	if err != nil {
@@ -104,6 +153,13 @@ func Clear() error {
 	}
 	if err := os.Remove(p); err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return fmt.Errorf("remove %s: %w", p, err)
+	}
+	pp, err := predecessorPath()
+	if err != nil {
+		return err
+	}
+	if err := os.Remove(pp); err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return fmt.Errorf("remove %s: %w", pp, err)
 	}
 	return nil
 }

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -58,6 +59,61 @@ func TestSaveLoadClear_RoundTrip(t *testing.T) {
 
 	// Clear is idempotent.
 	require.NoError(t, Clear())
+}
+
+func TestLoad_FallsBackToPredecessorAuth(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	predecessorDir := filepath.Join(dir, "bitrise")
+	require.NoError(t, os.MkdirAll(predecessorDir, 0o700))
+	predecessorFile := filepath.Join(predecessorDir, "auth.yaml")
+	require.NoError(t, os.WriteFile(predecessorFile, []byte("token: bitpat_predecessor\n"), 0o600))
+
+	fallbackAnnounceOnce = sync.Once{}
+	var announced strings.Builder
+	origWriter := fallbackWriter
+	fallbackWriter = &announced
+	t.Cleanup(func() { fallbackWriter = origWriter })
+
+	got, err := Load()
+	require.NoError(t, err)
+	assert.Equal(t, "bitpat_predecessor", got.Token)
+
+	_, err = os.ReadFile(predecessorFile)
+	require.NoError(t, err, "the predecessor auth file must survive Load — it's read-only")
+	_, statErr := os.Stat(filepath.Join(dir, "bitrise", "cli", "auth.yaml"))
+	assert.True(t, os.IsNotExist(statErr), "Load must not write the new auth file as a side effect")
+
+	assert.Contains(t, announced.String(), predecessorFile)
+}
+
+func TestLoad_PrefersNewAuthWhenPresent(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "bitrise"), 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "bitrise", "auth.yaml"), []byte("token: bitpat_predecessor\n"), 0o600))
+	require.NoError(t, Save(Auth{Token: "bitpat_new"}))
+
+	got, err := Load()
+	require.NoError(t, err)
+	assert.Equal(t, "bitpat_new", got.Token, "the new file must win once it exists, regardless of the predecessor file")
+}
+
+func TestClear_RemovesBothCurrentAndPredecessorFiles(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "bitrise"), 0o700))
+	predecessorFile := filepath.Join(dir, "bitrise", "auth.yaml")
+	require.NoError(t, os.WriteFile(predecessorFile, []byte("token: bitpat_predecessor\n"), 0o600))
+	require.NoError(t, Save(Auth{Token: "bitpat_new"}))
+
+	require.NoError(t, Clear())
+
+	_, err := os.Stat(predecessorFile)
+	assert.True(t, os.IsNotExist(err), "Clear must remove the predecessor file too, or logout followed by status would fall back and report still logged in")
+	got, err := Load()
+	require.NoError(t, err)
+	assert.Equal(t, Auth{}, got)
 }
 
 func TestSave_RejectsEmptyToken(t *testing.T) {

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -99,6 +99,42 @@ func TestLoad_PrefersNewAuthWhenPresent(t *testing.T) {
 	assert.Equal(t, "bitpat_new", got.Token, "the new file must win once it exists, regardless of the predecessor file")
 }
 
+func TestActivePath_PredecessorWhileFallbackLive(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "bitrise"), 0o700))
+	predecessorFile := filepath.Join(dir, "bitrise", "auth.yaml")
+	require.NoError(t, os.WriteFile(predecessorFile, []byte("token: bitpat_predecessor\n"), 0o600))
+
+	got, err := ActivePath()
+	require.NoError(t, err)
+	assert.Equal(t, predecessorFile, got)
+}
+
+func TestActivePath_NewPathOnceWritten(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "bitrise"), 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "bitrise", "auth.yaml"), []byte("token: bitpat_predecessor\n"), 0o600))
+	require.NoError(t, Save(Auth{Token: "bitpat_new"}))
+
+	got, err := ActivePath()
+	require.NoError(t, err)
+	newPath, err := Path()
+	require.NoError(t, err)
+	assert.Equal(t, newPath, got, "once the new file has been written, ActivePath must name it even though the predecessor file still exists")
+}
+
+func TestActivePath_NewPathWhenNeitherExists(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	got, err := ActivePath()
+	require.NoError(t, err)
+	newPath, err := Path()
+	require.NoError(t, err)
+	assert.Equal(t, newPath, got)
+}
+
 func TestClear_RemovesBothCurrentAndPredecessorFiles(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", dir)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -109,73 +109,21 @@ func predecessorConfigPath() (string, error) {
 // predecessor CLI's pre-rename key spellings (app_slug,
 // default_workspace_slug) as fallbacks, so a fallen-back-to file doesn't
 // silently drop those values either.
+//
+// Config is embedded rather than restated field by field: Load reads through
+// this type and cli/config/set.go is read-modify-write, so a field added to
+// Config but forgotten here would be silently dropped from the file on the
+// next `bitrise config set`.
 type predecessorConfig struct {
-	SetupVersion           string               `yaml:"setup_version"`
-	LastCLIUpdateCheck     time.Time            `yaml:"last_cli_update_check"`
-	LastPluginUpdateChecks map[string]time.Time `yaml:"last_plugin_update_checks"`
-	Output                 string               `yaml:"output"`
-	AppID                  string               `yaml:"app_id"`
-	AppSlugLegacy          string               `yaml:"app_slug"`
-	DefaultWorkspaceID     string               `yaml:"default_workspace_id"`
-	DefaultWorkspaceSlug   string               `yaml:"default_workspace_slug"`
-	APIBaseURL             string               `yaml:"api_base_url"`
-	RDEAPIBaseURL          string               `yaml:"rde_api_base_url"`
-	WebBaseURL             string               `yaml:"web_base_url"`
-	Theme                  string               `yaml:"theme"`
+	Config               `yaml:",inline"`
+	AppSlugLegacy        string `yaml:"app_slug"`
+	DefaultWorkspaceSlug string `yaml:"default_workspace_slug"`
 }
 
-func (p predecessorConfig) toConfig() Config {
-	return Config{
-		SetupVersion:           p.SetupVersion,
-		LastCLIUpdateCheck:     p.LastCLIUpdateCheck,
-		LastPluginUpdateChecks: p.LastPluginUpdateChecks,
-		Output:                 p.Output,
-		AppID:                  FirstNonEmptyString(p.AppID, p.AppSlugLegacy),
-		DefaultWorkspaceID:     FirstNonEmptyString(p.DefaultWorkspaceID, p.DefaultWorkspaceSlug),
-		APIBaseURL:             p.APIBaseURL,
-		RDEAPIBaseURL:          p.RDEAPIBaseURL,
-		WebBaseURL:             p.WebBaseURL,
-		Theme:                  p.Theme,
-	}
-}
-
-var fallbackAnnounceOnce sync.Once
-
-// fallbackWriter is a var, not a bare os.Stderr use, so tests can capture
-// the one-time announcement.
-var fallbackWriter io.Writer = os.Stderr
-
-// announceFallback prints, once per process, that the predecessor CLI's
-// config file is being read as a fallback. internal/auth keeps its own
-// separate instance of this (own sync.Once) for its own file — sharing one
-// Once across both would mean whichever file falls back first silently
-// suppresses the announcement for the other.
-func announceFallback(what, path string) {
-	fallbackAnnounceOnce.Do(func() {
-		fmt.Fprintf(fallbackWriter, "Using the previous bitrise-cli's %s at %s (read-only; save with this CLI to migrate it)\n", what, path)
-	})
-}
-
-// LoadYAML reads and unmarshals the YAML file at path into T. A missing
-// file is not an error — it returns the zero T, so callers can treat "not
-// yet configured" the same as "empty".
-func LoadYAML[T any](path string) (T, error) {
-	var v T
-	data, err := os.ReadFile(path)
-	if errors.Is(err, fs.ErrNotExist) {
-		return v, nil
-	}
-	if err != nil {
-		return v, fmt.Errorf("read %s: %w", path, err)
-	}
-	if err := yaml.Unmarshal(data, &v); err != nil {
-		return v, fmt.Errorf("parse %s: %w", path, err)
-	}
-	return v, nil
-}
-
-// LoadYAMLWithFallback behaves like LoadYAML, but when path is absent it
-// reads fallbackPath instead — never writing to it. ok reports whether
+// LoadYAMLWithFallback reads and unmarshals the YAML file at path into T,
+// falling back to fallbackPath when path is absent and never writing to it.
+// Neither file existing is not an error — it returns the zero T, so callers
+// can treat "not yet configured" the same as "empty". ok reports whether
 // fallbackPath supplied the value, so a caller can announce the fallback.
 func LoadYAMLWithFallback[T any](path, fallbackPath string) (v T, ok bool, err error) {
 	data, err := os.ReadFile(path)
@@ -240,6 +188,30 @@ func Load() (Config, error) {
 		announceFallback("config file", pp)
 	}
 	return pc.toConfig(), nil
+}
+
+func (p predecessorConfig) toConfig() Config {
+	c := p.Config
+	c.AppID = FirstNonEmptyString(c.AppID, p.AppSlugLegacy)
+	c.DefaultWorkspaceID = FirstNonEmptyString(c.DefaultWorkspaceID, p.DefaultWorkspaceSlug)
+	return c
+}
+
+var fallbackAnnounceOnce sync.Once
+
+// fallbackWriter is a var, not a bare os.Stderr use, so tests can capture
+// the one-time announcement.
+var fallbackWriter io.Writer = os.Stderr
+
+// announceFallback prints, once per process, that the predecessor CLI's
+// config file is being read as a fallback. internal/auth keeps its own
+// separate instance of this (own sync.Once) for its own file — sharing one
+// Once across both would mean whichever file falls back first silently
+// suppresses the announcement for the other.
+func announceFallback(what, path string) {
+	fallbackAnnounceOnce.Do(func() {
+		fmt.Fprintf(fallbackWriter, "Using the previous bitrise-cli's %s at %s (read-only; save with this CLI to migrate it)\n", what, path)
+	})
 }
 
 // ActivePath returns the config file Load() actually reads from right now:
@@ -323,7 +295,8 @@ const staleTmpAge = time.Minute
 // renames it into place, so two processes writing the same path concurrently
 // never race the rename with a shared temp name. It fsyncs before the rename
 // so a crash right after can't leave a file that looks written but lost its
-// data on an unclean shutdown, and it sweeps *.tmp siblings older than
+// data on an unclean shutdown, fsyncs the directory afterwards so the rename
+// itself survives the same crash, and it sweeps *.tmp siblings older than
 // staleTmpAge, left behind by a previous call that crashed between create
 // and rename — otherwise those leak forever, and for auth.yaml/config.yml
 // that means a stranded credential-bearing file.
@@ -360,6 +333,14 @@ func writeAtomic(path string, data []byte) error {
 	}
 	if err := os.Rename(tmp, path); err != nil {
 		return fmt.Errorf("install %s: %w", path, err)
+	}
+	// Syncing the file only guarantees its contents; the rename is a
+	// directory operation and needs the directory synced to survive a crash.
+	// A directory that can't be opened or synced (some filesystems refuse) is
+	// not worth failing a completed write over.
+	if d, err := os.Open(dir); err == nil {
+		_ = d.Sync()
+		_ = d.Close()
 	}
 	return nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -96,14 +96,6 @@ func PredecessorDir() (string, error) {
 	return filepath.Dir(dir), nil
 }
 
-func predecessorConfigPath() (string, error) {
-	dir, err := PredecessorDir()
-	if err != nil {
-		return "", err
-	}
-	return filepath.Join(dir, "config.yaml"), nil // note: .yaml, not .yml
-}
-
 // predecessorConfig is a superset of Config: every current field (so
 // unmarshaling the current config.yml through it loses nothing), plus the
 // predecessor CLI's pre-rename key spellings (app_slug,
@@ -232,6 +224,14 @@ func ActivePath() (string, error) {
 		}
 	}
 	return p, nil
+}
+
+func predecessorConfigPath() (string, error) {
+	dir, err := PredecessorDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "config.yaml"), nil // note: .yaml, not .yml
 }
 
 // LoadDir searches the current working directory and its ancestors for a

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -141,13 +141,15 @@ func (p predecessorConfig) toConfig() Config {
 
 var fallbackAnnounceOnce sync.Once
 
-// fallbackWriter is a var, not a const os.Stderr use, so tests can capture
+// fallbackWriter is a var, not a bare os.Stderr use, so tests can capture
 // the one-time announcement.
 var fallbackWriter io.Writer = os.Stderr
 
-// announceFallback prints, once per process, that a predecessor-CLI file is
-// being read as a fallback. Shared by internal/config and internal/auth, so
-// falling back for both files announces both.
+// announceFallback prints, once per process, that the predecessor CLI's
+// config file is being read as a fallback. internal/auth keeps its own
+// separate instance of this (own sync.Once) for its own file — sharing one
+// Once across both would mean whichever file falls back first silently
+// suppresses the announcement for the other.
 func announceFallback(what, path string) {
 	fallbackAnnounceOnce.Do(func() {
 		fmt.Fprintf(fallbackWriter, "Using the previous bitrise-cli's %s at %s (read-only; save with this CLI to migrate it)\n", what, path)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -164,11 +164,34 @@ func Save(c Config) error {
 	return writeAtomic(p, data)
 }
 
+// staleTmpAge bounds how old a *.tmp sibling has to be before writeAtomic
+// sweeps it — comfortably longer than any real write, so a concurrent
+// writer's own in-flight temp file (same glob pattern, near-zero age) is
+// never mistaken for one stranded by a crash.
+const staleTmpAge = time.Minute
+
 // writeAtomic writes data to a uniquely-named temp file beside path and
 // renames it into place, so two processes writing the same path concurrently
-// never race the rename with a shared temp name.
+// never race the rename with a shared temp name. It fsyncs before the rename
+// so a crash right after can't leave a file that looks written but lost its
+// data on an unclean shutdown, and it sweeps *.tmp siblings older than
+// staleTmpAge, left behind by a previous call that crashed between create
+// and rename — otherwise those leak forever, and for auth.yaml/config.yml
+// that means a stranded credential-bearing file.
 func writeAtomic(path string, data []byte) error {
-	f, err := os.CreateTemp(filepath.Dir(path), filepath.Base(path)+".*.tmp")
+	dir := filepath.Dir(path)
+	base := filepath.Base(path)
+
+	if stale, err := filepath.Glob(filepath.Join(dir, base+".*.tmp")); err == nil {
+		now := time.Now()
+		for _, f := range stale {
+			if info, statErr := os.Stat(f); statErr == nil && now.Sub(info.ModTime()) > staleTmpAge {
+				_ = os.Remove(f)
+			}
+		}
+	}
+
+	f, err := os.CreateTemp(dir, base+".*.tmp")
 	if err != nil {
 		return fmt.Errorf("create temp file for %s: %w", path, err)
 	}
@@ -178,6 +201,10 @@ func writeAtomic(path string, data []byte) error {
 	if _, err := f.Write(data); err != nil {
 		_ = f.Close()
 		return fmt.Errorf("write %s: %w", tmp, err)
+	}
+	if err := f.Sync(); err != nil {
+		_ = f.Close()
+		return fmt.Errorf("sync %s: %w", tmp, err)
 	}
 	if err := f.Close(); err != nil {
 		return fmt.Errorf("write %s: %w", tmp, err)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,16 +3,28 @@
 // pre-existing ~/.bitrise/config.json store, which stays authoritative when
 // present (see resolve.go).
 //
-// Storage: YAML at $XDG_CONFIG_HOME/bitrise/cli/config.yml, falling back to
-// ~/.config/bitrise/cli/config.yml. Written with 0600 permissions.
+// Storage: YAML at $XDG_CONFIG_HOME/bitrise/cli/config.yml, or
+// ~/.config/bitrise/cli/config.yml when XDG_CONFIG_HOME is unset.
+// Written with 0600 permissions.
+//
+// Load also has a read-only fallback to the predecessor standalone CLI's
+// config.yaml — one directory segment up (no "cli"), and a .yaml extension
+// — so an existing install of that CLI isn't silently logged out of its
+// settings by the merge. That file is never written to; see
+// PredecessorDir and LoadYAMLWithFallback. (This is a different fallback
+// from the ~/.bitrise/config.json layering above: that one is an
+// always-consulted, higher-precedence layer; this one only fires once the
+// new config.yml doesn't exist yet.)
 package config
 
 import (
 	"errors"
 	"fmt"
+	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
+	"sync"
 	"time"
 
 	"gopkg.in/yaml.v3"
@@ -72,6 +84,76 @@ func Path() (string, error) {
 	return filepath.Join(dir, "config.yml"), nil
 }
 
+// PredecessorDir returns the config directory of the predecessor standalone
+// CLI that this repo merged in — one path segment above Dir(), which this
+// repo added. Read-only fallback target; nothing here is ever written back
+// to it, since that CLI is still in use for a while after this merge.
+func PredecessorDir() (string, error) {
+	dir, err := Dir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Dir(dir), nil
+}
+
+func predecessorConfigPath() (string, error) {
+	dir, err := PredecessorDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "config.yaml"), nil // note: .yaml, not .yml
+}
+
+// predecessorConfig is a superset of Config: every current field (so
+// unmarshaling the current config.yml through it loses nothing), plus the
+// predecessor CLI's pre-rename key spellings (app_slug,
+// default_workspace_slug) as fallbacks, so a fallen-back-to file doesn't
+// silently drop those values either.
+type predecessorConfig struct {
+	SetupVersion           string               `yaml:"setup_version"`
+	LastCLIUpdateCheck     time.Time            `yaml:"last_cli_update_check"`
+	LastPluginUpdateChecks map[string]time.Time `yaml:"last_plugin_update_checks"`
+	Output                 string               `yaml:"output"`
+	AppID                  string               `yaml:"app_id"`
+	AppSlugLegacy          string               `yaml:"app_slug"`
+	DefaultWorkspaceID     string               `yaml:"default_workspace_id"`
+	DefaultWorkspaceSlug   string               `yaml:"default_workspace_slug"`
+	APIBaseURL             string               `yaml:"api_base_url"`
+	RDEAPIBaseURL          string               `yaml:"rde_api_base_url"`
+	WebBaseURL             string               `yaml:"web_base_url"`
+	Theme                  string               `yaml:"theme"`
+}
+
+func (p predecessorConfig) toConfig() Config {
+	return Config{
+		SetupVersion:           p.SetupVersion,
+		LastCLIUpdateCheck:     p.LastCLIUpdateCheck,
+		LastPluginUpdateChecks: p.LastPluginUpdateChecks,
+		Output:                 p.Output,
+		AppID:                  FirstNonEmptyString(p.AppID, p.AppSlugLegacy),
+		DefaultWorkspaceID:     FirstNonEmptyString(p.DefaultWorkspaceID, p.DefaultWorkspaceSlug),
+		APIBaseURL:             p.APIBaseURL,
+		RDEAPIBaseURL:          p.RDEAPIBaseURL,
+		WebBaseURL:             p.WebBaseURL,
+		Theme:                  p.Theme,
+	}
+}
+
+var fallbackAnnounceOnce sync.Once
+
+// fallbackWriter is a var, not a const os.Stderr use, so tests can capture
+// the one-time announcement.
+var fallbackWriter io.Writer = os.Stderr
+
+// announceFallback prints, once per process, that a predecessor-CLI file is
+// being read as a fallback. Shared by internal/config and internal/auth, so
+// falling back for both files announces both.
+func announceFallback(what, path string) {
+	fallbackAnnounceOnce.Do(func() {
+		fmt.Fprintf(fallbackWriter, "Using the previous bitrise-cli's %s at %s (read-only; save with this CLI to migrate it)\n", what, path)
+	})
+}
+
 // LoadYAML reads and unmarshals the YAML file at path into T. A missing
 // file is not an error — it returns the zero T, so callers can treat "not
 // yet configured" the same as "empty".
@@ -90,6 +172,33 @@ func LoadYAML[T any](path string) (T, error) {
 	return v, nil
 }
 
+// LoadYAMLWithFallback behaves like LoadYAML, but when path is absent it
+// reads fallbackPath instead — never writing to it. ok reports whether
+// fallbackPath supplied the value, so a caller can announce the fallback.
+func LoadYAMLWithFallback[T any](path, fallbackPath string) (v T, ok bool, err error) {
+	data, err := os.ReadFile(path)
+	if errors.Is(err, fs.ErrNotExist) {
+		data, err = os.ReadFile(fallbackPath)
+		if errors.Is(err, fs.ErrNotExist) {
+			return v, false, nil
+		}
+		if err != nil {
+			return v, false, fmt.Errorf("read %s: %w", fallbackPath, err)
+		}
+		if uerr := yaml.Unmarshal(data, &v); uerr != nil {
+			return v, false, fmt.Errorf("parse %s: %w", fallbackPath, uerr)
+		}
+		return v, true, nil
+	}
+	if err != nil {
+		return v, false, fmt.Errorf("read %s: %w", path, err)
+	}
+	if uerr := yaml.Unmarshal(data, &v); uerr != nil {
+		return v, false, fmt.Errorf("parse %s: %w", path, uerr)
+	}
+	return v, false, nil
+}
+
 // SaveYAML atomically marshals v to YAML and writes it to path with 0600
 // permissions, creating the parent directory (0700) if missing.
 func SaveYAML[T any](path string, v T) error {
@@ -103,14 +212,52 @@ func SaveYAML[T any](path string, v T) error {
 	return writeAtomic(path, data)
 }
 
-// Load reads the global config file. A missing file is not an error — it
-// returns the zero Config so first-time users don't see failures.
+// Load reads the global config file. When it's absent, Load falls back to
+// reading the predecessor standalone CLI's config.yaml (see PredecessorDir),
+// never writing to it, so an existing install of that CLI doesn't silently
+// lose app_id, default_workspace_id, theme, output and any base-URL
+// overrides to this merge. cli/config/{set,unset}.go are
+// Load-mutate-Save, so the fallback has to live here rather than only in
+// Resolve: the first `config set` reads the fallback content in full and
+// writes it all forward, completing the move on that first write, instead
+// of writing a file holding only the one just-set key and losing the rest.
 func Load() (Config, error) {
 	p, err := Path()
 	if err != nil {
 		return Config{}, err
 	}
-	return LoadYAML[Config](p)
+	pp, err := predecessorConfigPath()
+	if err != nil {
+		return Config{}, err
+	}
+	pc, usedFallback, err := LoadYAMLWithFallback[predecessorConfig](p, pp)
+	if err != nil {
+		return Config{}, err
+	}
+	if usedFallback {
+		announceFallback("config file", pp)
+	}
+	return pc.toConfig(), nil
+}
+
+// ActivePath returns the config file Load() actually reads from right now:
+// the predecessor CLI's config.yaml while that fallback is live, or the new
+// config.yml once anything has written it (or if neither exists yet).
+func ActivePath() (string, error) {
+	p, err := Path()
+	if err != nil {
+		return "", err
+	}
+	if _, statErr := os.Stat(p); errors.Is(statErr, fs.ErrNotExist) {
+		pp, err := predecessorConfigPath()
+		if err != nil {
+			return "", err
+		}
+		if _, statErr := os.Stat(pp); statErr == nil {
+			return pp, nil
+		}
+	}
+	return p, nil
 }
 
 // LoadDir searches the current working directory and its ancestors for a

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -70,6 +70,90 @@ func TestLoad_InvalidYAML(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestLoad_FallsBackToPredecessorConfig(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	predecessorDir := filepath.Join(dir, "bitrise")
+	require.NoError(t, os.MkdirAll(predecessorDir, 0o700))
+	predecessorFile := filepath.Join(predecessorDir, "config.yaml")
+	require.NoError(t, os.WriteFile(predecessorFile, []byte(""+
+		"app_slug: my-app-slug\n"+
+		"default_workspace_slug: my-workspace\n"+
+		"theme: dark\n"+
+		"output: json\n"+
+		"api_base_url: https://api.example.test\n"), 0o600))
+
+	fallbackAnnounceOnce = sync.Once{}
+	var announced strings.Builder
+	origWriter := fallbackWriter
+	fallbackWriter = &announced
+	t.Cleanup(func() { fallbackWriter = origWriter })
+
+	got, err := Load()
+	require.NoError(t, err)
+	assert.Equal(t, "my-app-slug", got.AppID, "app_slug must alias to app_id")
+	assert.Equal(t, "my-workspace", got.DefaultWorkspaceID, "default_workspace_slug must alias to default_workspace_id")
+	assert.Equal(t, "dark", got.Theme)
+	assert.Equal(t, "json", got.Output)
+	assert.Equal(t, "https://api.example.test", got.APIBaseURL)
+
+	_, err = os.ReadFile(predecessorFile)
+	require.NoError(t, err, "the predecessor file must survive Load — it's read-only")
+	_, statErr := os.Stat(filepath.Join(dir, "bitrise", "cli", "config.yml"))
+	assert.True(t, os.IsNotExist(statErr), "Load must not write the new config file as a side effect")
+
+	assert.Contains(t, announced.String(), predecessorFile, "the fallback should be announced once")
+}
+
+func TestLoad_PrefersNewConfigWhenPresent(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "bitrise"), 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "bitrise", "config.yaml"), []byte("theme: dark\n"), 0o600))
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "bitrise", "cli"), 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "bitrise", "cli", "config.yml"), []byte("theme: light\n"), 0o600))
+
+	got, err := Load()
+	require.NoError(t, err)
+	assert.Equal(t, "light", got.Theme, "the new file must win once it exists, regardless of the predecessor file")
+}
+
+func TestActivePath_PredecessorWhileFallbackLive(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "bitrise"), 0o700))
+	predecessorFile := filepath.Join(dir, "bitrise", "config.yaml")
+	require.NoError(t, os.WriteFile(predecessorFile, []byte("theme: dark\n"), 0o600))
+
+	got, err := ActivePath()
+	require.NoError(t, err)
+	assert.Equal(t, predecessorFile, got)
+}
+
+func TestActivePath_NewPathOnceWritten(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "bitrise"), 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "bitrise", "config.yaml"), []byte("theme: dark\n"), 0o600))
+	require.NoError(t, Save(Config{Theme: "light"}))
+
+	got, err := ActivePath()
+	require.NoError(t, err)
+	newPath, err := Path()
+	require.NoError(t, err)
+	assert.Equal(t, newPath, got, "once the new file has been written, ActivePath must name it even though the predecessor file still exists")
+}
+
+func TestActivePath_NewPathWhenNeitherExists(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	got, err := ActivePath()
+	require.NoError(t, err)
+	newPath, err := Path()
+	require.NoError(t, err)
+	assert.Equal(t, newPath, got)
+}
+
 func TestLoadDir_FindsAncestorFile(t *testing.T) {
 	root := t.TempDir()
 	deep := filepath.Join(root, "a", "b", "c")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -124,3 +124,42 @@ func TestSaveYAML_ConcurrentWritesDontCorrupt(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, strings.Repeat("x", 100), got.Value)
 }
+
+// TestWriteAtomic_SweepsStaleTmpSiblings simulates a crash between a
+// previous writeAtomic's CreateTemp and Rename: a *.tmp file matching its
+// naming pattern, old enough to no longer be a plausible in-flight write, is
+// left on disk. The next write must clean it up rather than leaking it
+// forever.
+func TestWriteAtomic_SweepsStaleTmpSiblings(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yml")
+	stale := path + ".deadbeef.tmp"
+	require.NoError(t, os.WriteFile(stale, []byte("leftover"), 0o600))
+	oldTime := time.Now().Add(-2 * staleTmpAge)
+	require.NoError(t, os.Chtimes(stale, oldTime, oldTime))
+
+	require.NoError(t, writeAtomic(path, []byte("value: 1\n")))
+
+	_, err := os.Stat(stale)
+	assert.True(t, os.IsNotExist(err), "stale tmp file should have been swept")
+	got, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, "value: 1\n", string(got))
+}
+
+// TestWriteAtomic_KeepsFreshTmpSiblings guards against the sweep in
+// writeAtomic mistaking a concurrent writer's still-in-flight temp file
+// (same *.tmp glob pattern, just created) for a crash leftover and deleting
+// it out from under that writer.
+func TestWriteAtomic_KeepsFreshTmpSiblings(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yml")
+	fresh := path + ".inflight.tmp"
+	require.NoError(t, os.WriteFile(fresh, []byte("still being written"), 0o600))
+
+	require.NoError(t, writeAtomic(path, []byte("value: 1\n")))
+
+	got, err := os.ReadFile(fresh)
+	require.NoError(t, err, "fresh tmp file should not have been swept")
+	assert.Equal(t, "still being written", string(got))
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 )
 
 func TestPath_HonorsXDG(t *testing.T) {
@@ -204,8 +205,10 @@ func TestSaveYAML_ConcurrentWritesDontCorrupt(t *testing.T) {
 		require.NoError(t, err, "writer %d", i)
 	}
 
-	got, err := LoadYAML[payload](path)
+	data, err := os.ReadFile(path)
 	require.NoError(t, err)
+	var got payload
+	require.NoError(t, yaml.Unmarshal(data, &got))
 	assert.Equal(t, strings.Repeat("x", 100), got.Value)
 }
 

--- a/internal/oauth/callback.go
+++ b/internal/oauth/callback.go
@@ -84,7 +84,15 @@ func (cs *callbackServer) handle(w http.ResponseWriter, r *http.Request) {
 	// could abort an in-flight login with a forged ?error=... — bypassing
 	// the CSRF check entirely on the deny path.
 	if q.Get("state") != cs.state {
-		cs.deliver(w, callbackResult{err: errors.New("state mismatch on OAuth callback — possible CSRF, aborting")})
+		// A provider that omits state on a deny (contrary to RFC 6749
+		// §4.1.2.1) would otherwise be reported as a CSRF attempt with no
+		// hint of the real cause, so name the error param too — without
+		// letting it change what happens, which stays "abort".
+		err := errors.New("state mismatch on OAuth callback — possible CSRF, aborting")
+		if errCode := q.Get("error"); errCode != "" {
+			err = fmt.Errorf("%w (the callback also reported: %s)", err, joinNonEmpty(errCode, q.Get("error_description")))
+		}
+		cs.deliver(w, callbackResult{err: err})
 		return
 	}
 	if errCode := q.Get("error"); errCode != "" {

--- a/internal/oauth/callback.go
+++ b/internal/oauth/callback.go
@@ -78,13 +78,18 @@ func (cs *callbackServer) close() {
 func (cs *callbackServer) handle(w http.ResponseWriter, r *http.Request) {
 	q := r.URL.Query()
 
+	// state is checked first, before even looking at error: deliver() keeps
+	// only the first result on the buffered channel, so if the error branch
+	// returned here first, any local process that finds the loopback port
+	// could abort an in-flight login with a forged ?error=... — bypassing
+	// the CSRF check entirely on the deny path.
+	if q.Get("state") != cs.state {
+		cs.deliver(w, callbackResult{err: errors.New("state mismatch on OAuth callback — possible CSRF, aborting")})
+		return
+	}
 	if errCode := q.Get("error"); errCode != "" {
 		desc := q.Get("error_description")
 		cs.deliver(w, callbackResult{err: fmt.Errorf("authorization denied: %s", joinNonEmpty(errCode, desc))})
-		return
-	}
-	if q.Get("state") != cs.state {
-		cs.deliver(w, callbackResult{err: errors.New("state mismatch on OAuth callback — possible CSRF, aborting")})
 		return
 	}
 	code := q.Get("code")

--- a/internal/oauth/callback_test.go
+++ b/internal/oauth/callback_test.go
@@ -48,6 +48,22 @@ func TestCallbackServer_StateCheckedBeforeError(t *testing.T) {
 	_, err := cs.wait(waitCtx(t))
 	assert.ErrorContains(t, err, "state mismatch")
 	assert.NotContains(t, err.Error(), "authorization denied")
+	// The mismatch still decides the outcome, but the error param is named
+	// so a provider that omits state on a deny isn't reported as pure CSRF.
+	assert.ErrorContains(t, err, "access_denied")
+}
+
+// TestCallbackServer_DenyWithoutState covers the provider that omits state on
+// a deny: the login still aborts as a state mismatch, but the reason the
+// provider gave has to survive into the message.
+func TestCallbackServer_DenyWithoutState(t *testing.T) {
+	cs := startCallbackServer(t, "right")
+	visitCallback(t, cs, "?error=access_denied&error_description=User+said+no")
+
+	_, err := cs.wait(waitCtx(t))
+	assert.ErrorContains(t, err, "state mismatch")
+	assert.ErrorContains(t, err, "access_denied")
+	assert.ErrorContains(t, err, "User said no")
 }
 
 func TestCallbackServer_MissingCode(t *testing.T) {

--- a/internal/oauth/callback_test.go
+++ b/internal/oauth/callback_test.go
@@ -36,6 +36,20 @@ func TestCallbackServer_AuthorizationDenied(t *testing.T) {
 	assert.ErrorContains(t, err, "access_denied")
 }
 
+// TestCallbackServer_StateCheckedBeforeError guards the CSRF fix: state must
+// be validated before the error param is even inspected. deliver() keeps
+// only the first result, so if error were checked first, any local process
+// finding the loopback port could abort an in-flight login with a forged
+// ?error=... whose state doesn't match, without ever tripping the CSRF check.
+func TestCallbackServer_StateCheckedBeforeError(t *testing.T) {
+	cs := startCallbackServer(t, "right")
+	visitCallback(t, cs, "?error=access_denied&state=wrong")
+
+	_, err := cs.wait(waitCtx(t))
+	assert.ErrorContains(t, err, "state mismatch")
+	assert.NotContains(t, err.Error(), "authorization denied")
+}
+
 func TestCallbackServer_MissingCode(t *testing.T) {
 	cs := startCallbackServer(t, "st8")
 	visitCallback(t, cs, "?state=st8")


### PR DESCRIPTION
- Fsync + stale-file cleanup: writeAtomic (used by both auth.yaml and config.yml writes) now fsyncs before
    rename and sweeps leftover *.tmp files from a crashed prior write, so a credential file can no longer be
    silently corrupted or leaked.
 - Locking on login: all three login paths (token, email, OAuth) now hold auth.Lock while saving, closing a
    race with the background OAuth token refresh.
 - OAuth CSRF ordering fix: the local callback server now validates state before looking at an error param, so
    a forged callback can't bypass the CSRF check.
 - SSH login regression fixed: an interactive terminal over SSH now falls back to the token prompt instead of
    picking browser OAuth and immediately hard-failing.
 - Release blocker — predecessor CLI migration: config.Load() and auth.Load() now fall back read-only to the
    standalone bitrise-cli's old config.yaml/auth.yaml (one directory level up, with legacy
    app_slug/default_workspace_slug key aliasing), so existing installs aren't silently logged out and stripped
    of their settings on upgrade. auth.Clear() now removes both the current and predecessor files.
 - Reporting fixes: bitrise config path and bitrise auth status now report whichever file is actually in use
    during the fallback window, instead of a path that may not exist.
 - New env override: BITRISE_API_BASE_URL now works, bringing the main API client in line with the existing
    web/RDE base-URL env overrides.
