### PR TITLE
v3 cleanup 2 - Restore two guards dropped during the v3 migration

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -64,6 +64,8 @@ func Run() {
 		return
 	}
 
+	rejectSingleDashLongFlags(rootCmd, rawArgs)
+
 	rootCmd.SetArgs(rawArgs)
 	if err := rootCmd.Execute(); err != nil {
 		cmdutil.Failf("%s", err)

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -488,6 +488,68 @@ func Test_flagShorthands_doNotCollideAcrossTree(t *testing.T) {
 	})
 }
 
+// Test_rejectSingleDashLongFlags_realCommandTree exercises the guard against
+// the actual registered commands, not a synthetic tree, so it catches a
+// flag/shorthand that changes shape only in cli/root.go or cli/local/run.go.
+func Test_rejectSingleDashLongFlags_realCommandTree(t *testing.T) {
+	tests := []struct {
+		name         string
+		args         []string
+		wantFound    bool
+		wantFlagName string
+	}{
+		{
+			name:         "single-dash --config on run silently misparses without the guard",
+			args:         []string{"run", "-config", "bitrise.yml"},
+			wantFound:    true,
+			wantFlagName: "config",
+		},
+		{
+			name:         "single-dash --inventory on run silently misparses without the guard",
+			args:         []string{"run", "-inventory", "secrets.yml"},
+			wantFound:    true,
+			wantFlagName: "inventory",
+		},
+		{
+			name:         "single-dash --workflow already errors via pflag, guard gives a clearer message",
+			args:         []string{"run", "-workflow", "primary"},
+			wantFound:    true,
+			wantFlagName: "workflow",
+		},
+		{name: "double-dash --config is untouched", args: []string{"run", "--config", "bitrise.yml"}},
+		{name: "-c shorthand with a space is untouched", args: []string{"run", "-c", "bitrise.yml"}},
+		{name: "-i shorthand with a space is untouched", args: []string{"run", "-i", "secrets.yml"}},
+		{name: "-qo shorthand cluster is untouched", args: []string{"stack", "list", "-qo", "json"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := newRootCommand()
+			target, _, err := root.Find(tt.args)
+			require.NoError(t, err)
+
+			_, flagName, found := cmdutil.DetectSingleDashLongFlag(target, tt.args)
+			assert.Equal(t, tt.wantFound, found)
+			if tt.wantFound {
+				assert.Equal(t, tt.wantFlagName, flagName)
+			}
+		})
+	}
+}
+
+// Test_rejectSingleDashLongFlags_NoMatch_DoesNotExit relies on the fact that a
+// false positive here would call cmdutil.Failf and kill the test process —
+// completing at all is the assertion for the non-matching cases.
+func Test_rejectSingleDashLongFlags_NoMatch_DoesNotExit(t *testing.T) {
+	for _, args := range [][]string{
+		{"run", "--config", "bitrise.yml"},
+		{"run", "-c", "bitrise.yml"},
+		{"run", "-i", "secrets.yml"},
+		{"stack", "list", "-qo", "json"},
+	} {
+		rejectSingleDashLongFlags(newRootCommand(), args)
+	}
+}
+
 func visitCommands(cmd *cobra.Command, fn func(*cobra.Command)) {
 	fn(cmd)
 	for _, sub := range cmd.Commands() {

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -520,6 +520,82 @@ func Test_rejectSingleDashLongFlags_realCommandTree(t *testing.T) {
 		{name: "-c shorthand with a space is untouched", args: []string{"run", "-c", "bitrise.yml"}},
 		{name: "-i shorthand with a space is untouched", args: []string{"run", "-i", "secrets.yml"}},
 		{name: "-qo shorthand cluster is untouched", args: []string{"stack", "list", "-qo", "json"}},
+
+		// pflag takes the next argument verbatim as a flag's value, dash and
+		// all, so a value that happens to spell a sibling flag's name is a
+		// legitimate invocation. build trigger has both --commit-message and
+		// --tag, which makes this reachable rather than theoretical.
+		{name: "dash-leading value of --commit-message is not a flag", args: []string{"build", "trigger", "--commit-message", "-tag"}},
+		{name: "dash-leading value of the -c shorthand is not a flag", args: []string{"run", "-c", "-config"}},
+		{name: "negative number as a flag value is untouched", args: []string{"build", "trigger", "--priority", "-1"}},
+		{name: "value after a shorthand cluster is not a flag", args: []string{"stack", "list", "-qo", "-format"}},
+
+		// ...but a genuine single-dash long flag still has to be caught when
+		// it follows a flag that took its own value.
+		{
+			name:         "single-dash long flag after a satisfied flag is still caught",
+			args:         []string{"build", "trigger", "--commit-message", "msg", "-tag", "v1"},
+			wantFound:    true,
+			wantFlagName: "tag",
+		},
+
+		// A value-taking shorthand that opens a cluster swallows the rest of
+		// the token, so the following argument is a fresh one, not its value.
+		{
+			name:         "cluster led by a value shorthand does not consume the next token",
+			args:         []string{"run", "-oq", "-config", "bitrise.yml"},
+			wantFound:    true,
+			wantFlagName: "config",
+		},
+
+		// pflag only treats "--" as a terminator when it reads it as a fresh
+		// token; as a flag's value it is literal, so scanning continues.
+		{
+			name:         "terminator as a flag value does not end the scan",
+			args:         []string{"build", "trigger", "--commit-message", "--", "-tag", "v1"},
+			wantFound:    true,
+			wantFlagName: "tag",
+		},
+
+		// -ci parses as --config=i under pflag, which is exactly the silent
+		// misparse this guard exists to catch: nobody means a config file
+		// named "i", they mean --ci.
+		{
+			name:         "two-character global spelled with one dash is caught",
+			args:         []string{"run", "-ci"},
+			wantFound:    true,
+			wantFlagName: "ci",
+		},
+
+		// pflag walks a cluster character by character and a bool consumes
+		// nothing, so a long flag typed with one dash behind an incidental
+		// bool still reaches the value-taking shorthand and misparses
+		// silently. -h is registered on every command, so this is reachable
+		// everywhere.
+		{
+			name:         "long flag behind a bool shorthand is caught",
+			args:         []string{"run", "-qconfig", "x"},
+			wantFound:    true,
+			wantFlagName: "config",
+		},
+		{
+			name:         "long flag behind the help shorthand is caught",
+			args:         []string{"run", "-hconfig", "x"},
+			wantFound:    true,
+			wantFlagName: "config",
+		},
+		{
+			name:         "long flag behind two bool shorthands is caught",
+			args:         []string{"run", "-qqconfig", "x"},
+			wantFound:    true,
+			wantFlagName: "config",
+		},
+		{
+			name:         "long flag behind a bool, with an attached value, is caught",
+			args:         []string{"run", "-qconfig=x"},
+			wantFound:    true,
+			wantFlagName: "config",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/cli/cmdutil/args.go
+++ b/cli/cmdutil/args.go
@@ -127,3 +127,42 @@ func assignOne(f *pflag.Flag, value string, hasValue bool, args []string) ([]glo
 func IsFlag(name, arg string) bool {
 	return arg == "--"+name || strings.HasPrefix(arg, "--"+name+"=")
 }
+
+// DetectSingleDashLongFlag reports the first argument in args that spells a
+// long flag name of cmd with a single dash instead of "--" (e.g. "-config").
+// Left to pflag, this either silently misparses as a shorthand cluster with
+// an attached value (when the leading character happens to be a registered
+// shorthand, e.g. "-config" becomes "-c" with value "onfig") or is rejected
+// with a cryptic "unknown shorthand flag" error — so callers should reject it
+// outright rather than let cobra parse it. cmd should be the resolved target
+// command (e.g. via (*cobra.Command).Find), since a flag name is only
+// meaningful relative to the command it is reachable on.
+func DetectSingleDashLongFlag(cmd *cobra.Command, args []string) (arg, flagName string, found bool) {
+	names := longFlagNames(cmd)
+	for _, a := range args {
+		if a == "--" {
+			break
+		}
+		if !strings.HasPrefix(a, "-") || strings.HasPrefix(a, "--") || a == "-" {
+			continue
+		}
+		name, _, _ := strings.Cut(strings.TrimPrefix(a, "-"), "=")
+		if names[name] {
+			return a, name, true
+		}
+	}
+	return "", "", false
+}
+
+// longFlagNames returns every long flag name reachable on cmd: its own flags
+// plus every ancestor's persistent flags, mirroring what pflag actually sees
+// once cobra merges them at parse time.
+func longFlagNames(cmd *cobra.Command) map[string]bool {
+	cmd.InitDefaultHelpFlag()
+	cmd.InitDefaultVersionFlag()
+
+	names := map[string]bool{}
+	cmd.Flags().VisitAll(func(f *pflag.Flag) { names[f.Name] = true })
+	cmd.InheritedFlags().VisitAll(func(f *pflag.Flag) { names[f.Name] = true })
+	return names
+}

--- a/cli/cmdutil/args.go
+++ b/cli/cmdutil/args.go
@@ -78,31 +78,24 @@ func matchGlobalFlags(fs *pflag.FlagSet, args, globalFlagNames []string) ([]glob
 	// Shorthand form. Every character has to name a global flag, since a
 	// cluster is all-or-nothing: "-qx" is not two bitrise globals, so the
 	// whole token belongs to the command.
-	rest := strings.TrimPrefix(arg, "-")
-	var out []globalFlagAssignment
-	for i := 0; i < len(rest); i++ {
-		f := fs.ShorthandLookup(string(rest[i]))
+	out, wantsNextArg, ok := walkShorthands(arg[1:], func(c string) *pflag.Flag {
+		f := fs.ShorthandLookup(c)
 		if f == nil || !slices.Contains(globalFlagNames, f.Name) {
-			return nil, 0
+			return nil
 		}
-		tail := rest[i+1:]
-		if f.NoOptDefVal == "" {
-			// A value flag ends the cluster: it swallows the rest of the token
-			// ("-o=json", "-ojson") or, when the token ends here, the next
-			// argument.
-			value, hasValue := strings.CutPrefix(tail, "=")
-			if !hasValue {
-				value, hasValue = tail, tail != ""
-			}
-			assigned, consumed := assignOne(f, value, hasValue, args)
-			return append(out, assigned...), consumed
-		}
-		if value, hasValue := strings.CutPrefix(tail, "="); hasValue {
-			return append(out, globalFlagAssignment{f.Name, value}), 1
-		}
-		out = append(out, globalFlagAssignment{f.Name, f.NoOptDefVal})
+		return f
+	})
+	switch {
+	case !ok:
+		return nil, 0
+	case wantsNextArg && len(args) > 1:
+		out[len(out)-1].value = args[1]
+		return out, 2
+	default:
+		// A required value with nothing left to take it is pflag's error to
+		// report; the empty assignment keeps the boundary scan moving.
+		return out, 1
 	}
-	return out, 1
 }
 
 // assignOne resolves a single flag's value: an attached one when hasValue, the
@@ -137,32 +130,116 @@ func IsFlag(name, arg string) bool {
 // outright rather than let cobra parse it. cmd should be the resolved target
 // command (e.g. via (*cobra.Command).Find), since a flag name is only
 // meaningful relative to the command it is reachable on.
+//
+// Tokens that pflag would consume as a preceding flag's value are skipped:
+// pflag takes the next argument verbatim even when it starts with a dash, so
+// `--commit-message -tag` legitimately sets the message to "-tag" and must
+// not be mistaken for a misspelled --tag.
 func DetectSingleDashLongFlag(cmd *cobra.Command, args []string) (arg, flagName string, found bool) {
-	names := longFlagNames(cmd)
+	byName, byShorthand := reachableFlags(cmd)
+
+	skipValue := false
 	for _, a := range args {
+		if skipValue {
+			// Checked before the terminator: pflag only treats "--" as one
+			// when it reads it as a fresh token, so as a flag's value it is
+			// taken literally and scanning has to continue past it.
+			skipValue = false
+			continue
+		}
 		if a == "--" {
 			break
 		}
-		if !strings.HasPrefix(a, "-") || strings.HasPrefix(a, "--") || a == "-" {
-			continue
-		}
-		name, _, _ := strings.Cut(strings.TrimPrefix(a, "-"), "=")
-		if names[name] {
-			return a, name, true
+		switch {
+		case strings.HasPrefix(a, "--"):
+			name, _, attached := strings.Cut(a[2:], "=")
+			skipValue = !attached && takesValue(byName[name])
+		case a != "-" && strings.HasPrefix(a, "-"):
+			name, _, _ := strings.Cut(a[1:], "=")
+			if flagName, ok := singleDashLongFlag(name, byName, byShorthand); ok {
+				return a, flagName, true
+			}
+			_, wantsNextArg, ok := walkShorthands(a[1:], func(c string) *pflag.Flag { return byShorthand[c] })
+			skipValue = ok && wantsNextArg
 		}
 	}
 	return "", "", false
 }
 
-// longFlagNames returns every long flag name reachable on cmd: its own flags
-// plus every ancestor's persistent flags, mirroring what pflag actually sees
-// once cobra merges them at parse time.
-func longFlagNames(cmd *cobra.Command) map[string]bool {
+// singleDashLongFlag reports the long flag name token spells, after peeling any
+// leading bool shorthands. pflag walks a cluster one character at a time and a
+// bool consumes nothing, so "-qconfig" carries on to --config's shorthand and
+// silently becomes --config=onfig — the same misparse as the bare "-config"
+// this guard exists to catch, just behind an incidental bool. -h is registered
+// on every command, which makes that prefix reachable everywhere.
+func singleDashLongFlag(token string, byName, byShorthand map[string]*pflag.Flag) (string, bool) {
+	for i := 0; i < len(token); i++ {
+		if byName[token[i:]] != nil {
+			return token[i:], true
+		}
+		// Anything but a bool shorthand ends the peel: an unregistered
+		// character makes pflag reject the token, and a value-taking one
+		// swallows the rest as its value.
+		if f := byShorthand[token[i:i+1]]; f == nil || takesValue(f) {
+			break
+		}
+	}
+	return "", false
+}
+
+// reachableFlags indexes every flag reachable on cmd — its own plus every
+// ancestor's persistent flags — by long name and by shorthand, mirroring what
+// pflag actually sees once cobra merges them at parse time.
+func reachableFlags(cmd *cobra.Command) (byName, byShorthand map[string]*pflag.Flag) {
 	cmd.InitDefaultHelpFlag()
 	cmd.InitDefaultVersionFlag()
 
-	names := map[string]bool{}
-	cmd.Flags().VisitAll(func(f *pflag.Flag) { names[f.Name] = true })
-	cmd.InheritedFlags().VisitAll(func(f *pflag.Flag) { names[f.Name] = true })
-	return names
+	byName, byShorthand = map[string]*pflag.Flag{}, map[string]*pflag.Flag{}
+	index := func(f *pflag.Flag) {
+		byName[f.Name] = f
+		if f.Shorthand != "" {
+			byShorthand[f.Shorthand] = f
+		}
+	}
+	cmd.Flags().VisitAll(index)
+	cmd.InheritedFlags().VisitAll(index)
+	return byName, byShorthand
+}
+
+// walkShorthands decomposes the characters after a single dash exactly as
+// pflag's parseSingleShortArg does, so every caller here shares one model of
+// that grammar rather than each keeping its own. In order: "-f=arg" wins but
+// only when something follows the "=", then a flag with a NoOptDefVal takes
+// that and parsing continues on the next character, then "-farg" swallows the
+// remainder of the token, and finally a bare "-f" needs the next argument.
+//
+// ok is false as soon as a character names no flag, which is pflag's own hard
+// error — callers decide what that means for them. wantsNextArg reports the
+// last case, where the value is the following argument.
+func walkShorthands(cluster string, lookup func(string) *pflag.Flag) (out []globalFlagAssignment, wantsNextArg, ok bool) {
+	for cluster != "" {
+		f := lookup(cluster[:1])
+		if f == nil {
+			return nil, false, false
+		}
+		switch {
+		case len(cluster) > 2 && cluster[1] == '=':
+			return append(out, globalFlagAssignment{f.Name, cluster[2:]}), false, true
+		case f.NoOptDefVal != "":
+			out = append(out, globalFlagAssignment{f.Name, f.NoOptDefVal})
+			cluster = cluster[1:]
+		case len(cluster) > 1:
+			return append(out, globalFlagAssignment{f.Name, cluster[1:]}), false, true
+		default:
+			return append(out, globalFlagAssignment{f.Name, ""}), true, true
+		}
+	}
+	return out, false, true
+}
+
+// takesValue reports whether f needs a separate argument for its value. A
+// flag with a NoOptDefVal (every bool, and anything declared with one) can be
+// written bare, so it never consumes the next argument.
+func takesValue(f *pflag.Flag) bool {
+	return f != nil && f.NoOptDefVal == ""
 }

--- a/cli/cmdutil/args_test.go
+++ b/cli/cmdutil/args_test.go
@@ -1,0 +1,101 @@
+package cmdutil
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDetectSingleDashLongFlag(t *testing.T) {
+	newCmd := func() *cobra.Command {
+		root := &cobra.Command{Use: "root"}
+		root.PersistentFlags().BoolP(FlagQuiet, "q", false, "quiet")
+		root.PersistentFlags().StringP(FlagOutput, "o", "", "output")
+		root.PersistentFlags().Bool(DebugModeKey, false, "debug")
+
+		child := &cobra.Command{Use: "run"}
+		child.Flags().StringP(ConfigKey, "c", "", "config")
+		child.Flags().StringP(InventoryKey, "i", "", "inventory")
+		child.Flags().String(WorkflowKey, "", "workflow")
+		root.AddCommand(child)
+
+		return child
+	}
+
+	for _, tc := range []struct {
+		name         string
+		args         []string
+		wantArg      string
+		wantFlagName string
+		wantFound    bool
+	}{
+		{
+			name:         "single-dash long flag name misparsed by pflag as a shorthand cluster",
+			args:         []string{"run", "-config", "bitrise.yml"},
+			wantArg:      "-config",
+			wantFlagName: "config",
+			wantFound:    true,
+		},
+		{
+			name:         "single-dash long flag name with attached value",
+			args:         []string{"run", "-inventory=secrets.yml"},
+			wantArg:      "-inventory=secrets.yml",
+			wantFlagName: "inventory",
+			wantFound:    true,
+		},
+		{
+			name:         "single-dash long flag with no colliding shorthand",
+			args:         []string{"run", "-workflow", "primary"},
+			wantArg:      "-workflow",
+			wantFlagName: "workflow",
+			wantFound:    true,
+		},
+		{
+			name:         "single-dash long flag inherited from a persistent parent flag",
+			args:         []string{"run", "-debug"},
+			wantArg:      "-debug",
+			wantFlagName: "debug",
+			wantFound:    true,
+		},
+		{
+			name:      "double-dash long flag is untouched",
+			args:      []string{"run", "--config", "bitrise.yml"},
+			wantFound: false,
+		},
+		{
+			name:      "legitimate value shorthand with space syntax is untouched",
+			args:      []string{"run", "-c", "bitrise.yml"},
+			wantFound: false,
+		},
+		{
+			name:      "legitimate value shorthand with attached value is untouched",
+			args:      []string{"run", "-i", "secrets.yml"},
+			wantFound: false,
+		},
+		{
+			name:      "legitimate bool shorthand cluster is untouched",
+			args:      []string{"run", "-qo", "json"},
+			wantFound: false,
+		},
+		{
+			name:      "bare dash is untouched",
+			args:      []string{"run", "-"},
+			wantFound: false,
+		},
+		{
+			name:      "positional args after -- are not scanned",
+			args:      []string{"run", "--", "-config"},
+			wantFound: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			arg, flagName, found := DetectSingleDashLongFlag(newCmd(), tc.args)
+			assert.Equal(t, tc.wantFound, found)
+			if tc.wantFound {
+				assert.Equal(t, tc.wantArg, arg)
+				assert.Equal(t, tc.wantFlagName, flagName)
+			}
+		})
+	}
+}

--- a/cli/cmdutil/args_test.go
+++ b/cli/cmdutil/args_test.go
@@ -1,10 +1,14 @@
 package cmdutil
 
 import (
+	"io"
+	"slices"
 	"testing"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDetectSingleDashLongFlag(t *testing.T) {
@@ -98,4 +102,65 @@ func TestDetectSingleDashLongFlag(t *testing.T) {
 			}
 		})
 	}
+}
+
+// Test_walkShorthands_matchesPflag runs the shared grammar model and a real
+// pflag.FlagSet over the same token and asserts they agree on every count.
+// Three separate bugs in this file reached review because each hand-rolled
+// model was only checked by hand; this checks it against the parser it models.
+func Test_walkShorthands_matchesPflag(t *testing.T) {
+	const sentinel = "SENTINEL"
+
+	tokens := []string{
+		"-q", "-qq", "-qh", "-h",
+		"-o", "-ojson", "-o=json", "-o=", "-oq", "-oqjson",
+		"-q=", "-q=true", "-qo", "-qojson", "-qo=json",
+		"-c", "-cfile", "-c=file",
+		"-config", "-qconfig", "-hconfig", "-qqconfig", "-qconfig=x",
+		"-x", "-qx", "-=",
+	}
+
+	for _, token := range tokens {
+		t.Run(token, func(t *testing.T) {
+			fs := newPflagFixture()
+			predicted, wantsNextArg, ok := walkShorthands(token[1:], func(c string) *pflag.Flag {
+				return fs.ShorthandLookup(c)
+			})
+
+			actual := newPflagFixture()
+			parseErr := actual.Parse([]string{token, sentinel})
+
+			if !ok {
+				assert.Error(t, parseErr, "model rejected the token, pflag accepted it")
+				return
+			}
+			require.NoError(t, parseErr, "model accepted the token, pflag rejected it")
+
+			consumed := !slices.Contains(actual.Args(), sentinel)
+			assert.Equal(t, consumed, wantsNextArg, "disagreement on whether the next argument is the value")
+
+			for i, a := range predicted {
+				value := a.value
+				// Only the flag that ends the cluster can take the next
+				// argument; the bools before it are already satisfied.
+				if wantsNextArg && i == len(predicted)-1 {
+					value = sentinel
+				}
+				assert.Equal(t, actual.Lookup(a.name).Value.String(), value, "disagreement on %s's value", a.name)
+			}
+		})
+	}
+}
+
+// newPflagFixture mirrors the shorthands that actually collide in the real
+// tree: a bool, help, and two value flags whose shorthands lead long names
+// (-c/--config, -o/--output).
+func newPflagFixture() *pflag.FlagSet {
+	fs := pflag.NewFlagSet("fixture", pflag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	fs.BoolP(FlagQuiet, "q", false, "quiet")
+	fs.BoolP("help", "h", false, "help")
+	fs.StringP(FlagOutput, "o", "", "output")
+	fs.StringP("config", "c", "", "config")
+	return fs
 }

--- a/cli/cmdutil/config.go
+++ b/cli/cmdutil/config.go
@@ -126,21 +126,33 @@ func CreateBitriseConfigFromCLIParams(bitriseConfigBase64Data, bitriseConfigPath
 		}
 	}
 
-	supportedVersion, err := ver.NewVersion(models.FormatVersion)
-	if err != nil {
-		return models.BitriseDataModel{}, warnings, fmt.Errorf("failed to parse bitrise CLI supported format version (%s): %s", models.FormatVersion, err)
-	}
-
-	configVersion, err := ver.NewVersion(bitriseConfig.FormatVersion)
-	if err != nil {
-		return models.BitriseDataModel{}, warnings, fmt.Errorf("failed to parse bitrise.yml format version (%s): %s", bitriseConfig.FormatVersion, err)
-	}
-
-	if configVersion.GreaterThan(supportedVersion) {
-		return models.BitriseDataModel{}, warnings, fmt.Errorf("the bitrise.yml has a higher format version (%s) than the bitrise CLI supported format version (%s), please upgrade your bitrise CLI to use this bitrise.yml", bitriseConfig.FormatVersion, models.FormatVersion)
+	if err := CheckFormatVersionSupported(bitriseConfig.FormatVersion); err != nil {
+		return models.BitriseDataModel{}, warnings, err
 	}
 
 	return *bitriseConfig, warnings, nil
+}
+
+// CheckFormatVersionSupported errors when configFormatVersion is newer than
+// the format version this CLI supports (models.FormatVersion). A bitrise.yml
+// requesting a newer format may use syntax this CLI version doesn't
+// understand yet, so this is checked separately from schema validity.
+func CheckFormatVersionSupported(configFormatVersion string) error {
+	supportedVersion, err := ver.NewVersion(models.FormatVersion)
+	if err != nil {
+		return fmt.Errorf("failed to parse bitrise CLI supported format version (%s): %s", models.FormatVersion, err)
+	}
+
+	configVersion, err := ver.NewVersion(configFormatVersion)
+	if err != nil {
+		return fmt.Errorf("failed to parse bitrise.yml format version (%s): %s", configFormatVersion, err)
+	}
+
+	if configVersion.GreaterThan(supportedVersion) {
+		return fmt.Errorf("the bitrise.yml has a higher format version (%s) than the bitrise CLI supported format version (%s), please upgrade your bitrise CLI to use this bitrise.yml", configFormatVersion, models.FormatVersion)
+	}
+
+	return nil
 }
 
 // GetInventoryFromBase64Data ...

--- a/cli/cmdutil/config_test.go
+++ b/cli/cmdutil/config_test.go
@@ -1,0 +1,28 @@
+package cmdutil
+
+import (
+	"testing"
+
+	"github.com/bitrise-io/bitrise/v2/models"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCheckFormatVersionSupported(t *testing.T) {
+	t.Run("supported version passes", func(t *testing.T) {
+		assert.NoError(t, CheckFormatVersionSupported(models.FormatVersion))
+	})
+
+	t.Run("older version passes", func(t *testing.T) {
+		assert.NoError(t, CheckFormatVersionSupported("1"))
+	})
+
+	t.Run("newer version errors", func(t *testing.T) {
+		err := CheckFormatVersionSupported("99")
+		assert.ErrorContains(t, err, "higher format version")
+	})
+
+	t.Run("unparsable version errors", func(t *testing.T) {
+		err := CheckFormatVersionSupported("not-a-version")
+		assert.ErrorContains(t, err, "failed to parse bitrise.yml format version")
+	})
+}

--- a/cli/single_dash_guard.go
+++ b/cli/single_dash_guard.go
@@ -1,0 +1,25 @@
+package cli
+
+import (
+	"github.com/bitrise-io/bitrise/v2/cli/cmdutil"
+	"github.com/spf13/cobra"
+)
+
+// rejectSingleDashLongFlags errors out before cobra parses args if any
+// argument spells a registered long flag name with a single dash instead of
+// "--" (e.g. "-config" instead of "--config"). This has to run before
+// Execute(): by the time any hook on the resolved command sees the args,
+// pflag has already parsed them, and the misparse it produces (or the
+// cryptic "unknown shorthand flag" error, when the leading character isn't a
+// registered shorthand) is indistinguishable after the fact from a
+// legitimate shorthand invocation.
+func rejectSingleDashLongFlags(root *cobra.Command, rawArgs []string) {
+	target, _, err := root.Find(rawArgs)
+	if err != nil {
+		return // let cobra's own error handling take over
+	}
+
+	if arg, flagName, found := cmdutil.DetectSingleDashLongFlag(target, rawArgs); found {
+		cmdutil.Failf("unknown flag: %s (did you mean --%s?)", arg, flagName)
+	}
+}

--- a/cli/yml/validate.go
+++ b/cli/yml/validate.go
@@ -16,6 +16,7 @@ import (
 	"github.com/bitrise-io/go-utils/colorstring"
 	"github.com/bitrise-io/go-utils/fileutil"
 	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v2"
 )
 
 // offlineKey skips online validation even when authenticated, forcing the
@@ -299,7 +300,29 @@ func tryOnlineValidate(cmd *cobra.Command, bitriseConfigPath, bitriseConfigBase6
 	if len(result.Errors) > 0 {
 		item.Error = strings.Join(result.Errors, "; ")
 	}
+	if warning := formatVersionWarning(rawYAML); warning != "" {
+		item.Warnings = append(item.Warnings, warning)
+	}
 	return item, "", true
+}
+
+// formatVersionWarning checks rawYAML's format_version against this CLI's
+// supported version, for the online-validate path: the API only checks
+// schema validity, so the online result stays authoritative for IsValid and
+// this only adds a warning, never an error. A missing or unparsable
+// format_version is skipped silently rather than surfaced as a warning,
+// since that isn't what this check is about.
+func formatVersionWarning(rawYAML string) string {
+	var v struct {
+		FormatVersion string `yaml:"format_version"`
+	}
+	if err := yaml.Unmarshal([]byte(rawYAML), &v); err != nil || v.FormatVersion == "" {
+		return ""
+	}
+	if err := cmdutil.CheckFormatVersionSupported(v.FormatVersion); err != nil {
+		return err.Error()
+	}
+	return ""
 }
 
 // validateConfig prefers the online validate-bitrise-yml endpoint when a

--- a/cli/yml/validate_test.go
+++ b/cli/yml/validate_test.go
@@ -29,6 +29,13 @@ default_step_lib_source: "https://github.com/bitrise-io/bitrise-steplib.git"
 const locallyInvalidConfig = `workflows: {}
 `
 
+// newerFormatVersionConfig requests a format version above what this CLI
+// supports (models.FormatVersion), to exercise the online-path format-version
+// warning without touching schema validity.
+const newerFormatVersionConfig = `format_version: "99"
+default_step_lib_source: "https://github.com/bitrise-io/bitrise-steplib.git"
+`
+
 func TestValidateConfig_NoToken_UsesLocal(t *testing.T) {
 	var onlineCalled bool
 	srv := newValidateFakeServer(t, func(w http.ResponseWriter, _ *http.Request) {
@@ -122,6 +129,25 @@ func TestValidateConfig_OnlineSucceeds_SkipsLocalEntirely(t *testing.T) {
 	assert.Empty(t, warning, "no top-level warning expected when the online call itself succeeds")
 	assert.Equal(t, sourceOnline, item.Source)
 	assert.Equal(t, "app_slug=app-slug", gotQuery)
+}
+
+func TestValidateConfig_OnlineSucceeds_NewerFormatVersion_AddsWarning(t *testing.T) {
+	cmd := newTestValidateCmd(t, func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"errors":[],"warnings":[]}`))
+	})
+
+	// The online endpoint reports it schema-valid regardless of format
+	// version; IsValid must stay true and the mismatch must only add a
+	// warning, never flip to an error, since the online result stays
+	// authoritative for schema validity.
+	item, warning, err := validateConfig(cmd, "", encode(newerFormatVersionConfig), false, "")
+	require.NoError(t, err)
+	assert.True(t, item.IsValid)
+	assert.Empty(t, item.Error)
+	require.Len(t, item.Warnings, 1)
+	assert.Contains(t, item.Warnings[0], "higher format version")
+	assert.Empty(t, warning, "the format-version mismatch is a Warnings entry, not a top-level warning")
+	assert.Equal(t, sourceOnline, item.Source)
 }
 
 func TestValidateConfig_Online422_UsesOnlyOnlineResult(t *testing.T) {


### PR DESCRIPTION
Single-dash long flags used to work under the old urfave/cli parser; under cobra/pflag "-config" silently misparses as the "-c" shorthand with value "onfig" (no error), and "-inventory" is the same trap. Reject any single-dash token that spells a registered long flag name, before cobra gets to parse it.

Separately, yml validate's online-by-default path skipped the local format-version check entirely on success, so a newer-format bitrise.yml was reported valid with no warning. Extract the check and run it on the online path too, as a warning rather than a hard error, since the online result stays authoritative for schema validity.