### PR TITLE
v3 cleanup 3 - A failed bookkeeping write must not fail a command

### DIFF
--- a/configs/configs.go
+++ b/configs/configs.go
@@ -97,10 +97,6 @@ func IsDebugUseSystemTools() bool {
 // indistinguishable, and Save* below must not create the file for a
 // brand-new user (see saveConfig).
 func LoadLegacyConfig() (ConfigModel, bool, error) {
-	if err := EnsureBitriseConfigDirExists(); err != nil {
-		return ConfigModel{}, false, err
-	}
-
 	configPth := getLegacyConfigFilePath()
 	exist, err := pathutil.IsPathExists(configPth)
 	if err != nil {
@@ -301,7 +297,9 @@ func saveGlobalConfig(mutate func(*internalconfig.Config) error) error {
 
 // saveConfig writes legacy via saveLegacyConfig only when it existed —
 // a brand-new user should never get a legacy file created — and always syncs
-// mutate into the new global config.yml.
+// mutate into the new global config.yml. A config.yml sync failure only
+// warns and never fails the caller, regardless of whether the legacy file
+// existed — it's a bookkeeping mirror, not the load-bearing write.
 //
 // legacy is deliberately the raw on-disk legacy value (each caller loads it
 // via LoadLegacyConfig, not ResolveConfig): both writes below only ever touch
@@ -318,14 +316,9 @@ func saveConfig(existed bool, legacy ConfigModel, mutate func(*internalconfig.Co
 		if err := saveLegacyConfig(legacy); err != nil {
 			return err
 		}
-		if err := saveGlobalConfig(mutate); err != nil {
-			log.Warnf("Failed to sync config.yml, ignoring: %s", err)
-		}
-		return nil
 	}
-
 	if err := saveGlobalConfig(mutate); err != nil {
-		return fmt.Errorf("failed to save config.yml: %w", err)
+		log.Warnf("Failed to sync config.yml, ignoring: %s", err)
 	}
 	return nil
 }

--- a/configs/configs_test.go
+++ b/configs/configs_test.go
@@ -61,12 +61,32 @@ func TestLoadLegacyConfig(t *testing.T) {
 
 	// Once a legacy file exists, LoadLegacyConfig is a pure passthrough
 	// again: it sees whatever SaveSetupSuccessForVersion (and friends) write.
+	require.Equal(t, nil, EnsureBitriseConfigDirExists())
 	require.Equal(t, nil, saveLegacyConfig(ConfigModel{SetupVersion: "0.0.1"}))
 	require.Equal(t, nil, SaveSetupSuccessForVersion("1.2.3"))
 	got, exists, err = LoadLegacyConfig()
 	require.Equal(t, nil, err)
 	require.Equal(t, "1.2.3", got.SetupVersion)
 	require.Equal(t, true, exists)
+}
+
+// TestLoadLegacyConfig_DoesNotCreateBitriseDir asserts a pure read never
+// creates ~/.bitrise as a side effect -- only a write should.
+func TestLoadLegacyConfig_DoesNotCreateBitriseDir(t *testing.T) {
+	fakeHomePth, err := pathutil.NormalizedOSTempDirPath("_FAKE_HOME")
+	require.Equal(t, nil, err)
+	defer func() {
+		require.Equal(t, nil, os.RemoveAll(fakeHomePth))
+	}()
+	t.Setenv("HOME", fakeHomePth)
+	t.Setenv("XDG_CONFIG_HOME", "")
+
+	_, exists, err := LoadLegacyConfig()
+	require.Equal(t, nil, err)
+	require.Equal(t, false, exists)
+
+	_, statErr := os.Stat(GetBitriseHomeDirPath())
+	require.True(t, os.IsNotExist(statErr))
 }
 
 // TestSaveSetupSuccessForVersion_NewUser_OnlySavesToGlobalConfig asserts a
@@ -152,11 +172,11 @@ func TestSaveSetupSuccessForVersion_ExistingUser_GlobalSyncFailureDoesNotFailSav
 	require.Equal(t, "3.0.0", legacy.SetupVersion)
 }
 
-// TestSaveSetupSuccessForVersion_NewUser_GlobalSyncFailureFailsSave is the
-// other half: with no legacy file, config.yml is the *only* place the value
-// gets persisted, so a broken new-location write must surface as an error
-// instead of being silently swallowed and reported as a successful save.
-func TestSaveSetupSuccessForVersion_NewUser_GlobalSyncFailureFailsSave(t *testing.T) {
+// TestSaveSetupSuccessForVersion_NewUser_GlobalSyncFailureDoesNotFailSave is
+// the other half: with no legacy file, config.yml is the only place the
+// value gets persisted, but a broken new-location write is still only a
+// warning -- a bookkeeping write must never fail the caller.
+func TestSaveSetupSuccessForVersion_NewUser_GlobalSyncFailureDoesNotFailSave(t *testing.T) {
 	fakeHomePth, err := pathutil.NormalizedOSTempDirPath("_FAKE_HOME")
 	require.Equal(t, nil, err)
 	defer func() {
@@ -168,7 +188,7 @@ func TestSaveSetupSuccessForVersion_NewUser_GlobalSyncFailureFailsSave(t *testin
 	require.Equal(t, nil, os.WriteFile(blockingFile, []byte("x"), 0o600))
 	t.Setenv("XDG_CONFIG_HOME", blockingFile)
 
-	require.Error(t, SaveSetupSuccessForVersion("3.0.0"))
+	require.Equal(t, nil, SaveSetupSuccessForVersion("3.0.0"))
 
 	_, exists, err := LoadLegacyConfig()
 	require.Equal(t, nil, err)


### PR DESCRIPTION
configs.saveConfig only warned on a config.yml sync failure when a legacy ~/.bitrise/config.json already existed; a brand-new user (e.g. a CI image where ~/.config isn't writable but $HOME is) got that same failure returned as a hard error, which made bitrise/setup.go report a successful setup as failed and made plugins/run.go abort plugin runs on the once-per-24h update check. Make the config.yml sync always warn-only, regardless of existed.

Also stop LoadLegacyConfig from creating ~/.bitrise as a side effect of a read -- InitPaths already ensures it exists before any command reaches this path