### PR TITLE
v3 cleanup 4 - small command fixes

### DIFF
--- a/analytics/state_checker.go
+++ b/analytics/state_checker.go
@@ -7,6 +7,11 @@ import (
 const (
 	DisabledEnvKey = "BITRISE_ANALYTICS_DISABLED"
 
+	// unprefixedDisabledEnvKey is the env var the vendored go-utils tracker itself
+	// honours to skip sending events. Checking it here too keeps IsTracking() and
+	// the Send* early-returns consistent with what actually gets sent.
+	unprefixedDisabledEnvKey = "ANALYTICS_DISABLED"
+
 	trueEnv = "true"
 )
 
@@ -23,5 +28,5 @@ func NewStateChecker(repository env.Repository) StateChecker {
 }
 
 func (s stateChecker) Enabled() bool {
-	return s.envRepository.Get(DisabledEnvKey) != trueEnv
+	return s.envRepository.Get(DisabledEnvKey) != trueEnv && s.envRepository.Get(unprefixedDisabledEnvKey) != trueEnv
 }

--- a/analytics/state_checker_test.go
+++ b/analytics/state_checker_test.go
@@ -1,0 +1,55 @@
+package analytics
+
+import (
+	"testing"
+
+	"github.com/bitrise-io/go-utils/v2/env"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_stateChecker_Enabled(t *testing.T) {
+	tests := []struct {
+		name            string
+		disabledEnv     string
+		unprefixedEnv   string
+		expectedEnabled bool
+	}{
+		{
+			name:            "Neither env var set",
+			expectedEnabled: true,
+		},
+		{
+			name:            "BITRISE_ANALYTICS_DISABLED=true disables",
+			disabledEnv:     "true",
+			expectedEnabled: false,
+		},
+		{
+			name:            "ANALYTICS_DISABLED=true disables",
+			unprefixedEnv:   "true",
+			expectedEnabled: false,
+		},
+		{
+			name:            "Both set to true still disables",
+			disabledEnv:     "true",
+			unprefixedEnv:   "true",
+			expectedEnabled: false,
+		},
+		{
+			name:            "Non-true values don't disable",
+			disabledEnv:     "false",
+			unprefixedEnv:   "0",
+			expectedEnabled: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv(DisabledEnvKey, tt.disabledEnv)
+			t.Setenv(unprefixedDisabledEnvKey, tt.unprefixedEnv)
+
+			checker := NewStateChecker(env.NewRepository())
+
+			require.Equal(t, tt.expectedEnabled, checker.Enabled())
+		})
+	}
+}

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -328,6 +328,8 @@ step_bundles:
             #!/usr/bin/env bash
             set -exo pipefail
 
+            export BITRISE_ANALYTICS_DISABLED=true
+
             # Here we save the original test results and deploy directories and later on we recreate them,
             #  because during the tests these directories are removed.
             ORIG_BITRISE_TEST_RESULT_DIR="${BITRISE_TEST_RESULT_DIR}"

--- a/stepruncmd/errorfinder/error_finder.go
+++ b/stepruncmd/errorfinder/error_finder.go
@@ -42,10 +42,13 @@ func (e *ErrorFinder) Write(p []byte) (n int, err error) {
 	if e.writer != nil {
 		return e.writer.Write(p)
 	}
-	return n, nil
+	return len(p), nil
 }
 
 func (e *ErrorFinder) Close() error {
+	e.mux.Lock()
+	defer e.mux.Unlock()
+
 	if e.collecting && e.chunk != "" {
 		e.errorMessages = append(e.errorMessages, redRegexp.ReplaceAllString(e.chunk, ""))
 		e.chunk = ""

--- a/stepruncmd/timeoutcmd/timeoutcmd.go
+++ b/stepruncmd/timeoutcmd/timeoutcmd.go
@@ -71,7 +71,15 @@ func (c *Command) Start() error {
 		return err
 	}
 
-	// Wait for the process to finish
+	// Wait reaps the process only. cmd.Wait would additionally block until the
+	// goroutines exec.Cmd spawns to copy the child's stdout/stderr have drained
+	// their pipes, which sounds better — it is what stops a large final burst
+	// being truncated — but the pipes only reach EOF once every process holding
+	// the write end exits. A step that leaves a daemon behind (ssh-agent, adb,
+	// an emulator) keeps them open, and with no per-step timeout and no
+	// BITRISE_NO_OUTPUT_TIMEOUT configured, which is the default, nothing else
+	// in the select below can fire: the step would hang forever. Truncation is
+	// the lesser failure, so this stays on Process.Wait.
 	done := make(chan error, 1)
 	go func() {
 		switch p, err := c.cmd.Process.Wait(); {


### PR DESCRIPTION
 - The analytics disable flag had two names: analytics/state_checker.go:8 honours only BITRISE_ANALYTICS_DISABLED, while the vendored tracker that actually gates event sending reads the un-prefixed ANALYTICS_DISABLED — so analytics were never fully disabled. Honour both.
 - ErrorFinder.Close mutated its collected-error state without the mutex Write already takes, racing a copy goroutine still delivering output — now locked. Write also returned the never-assigned zero instead of the length written.
 - Documented (no behavior change) why the step-exit reaper waits on Process.Wait instead of cmd.Wait: a step that leaves a daemon behind (ssh-agent, adb, an emulator) would hang forever under cmd.Wait, which is worse than the truncated tail output that motivated trying it.

