### PR TITLE
v3 cleanup 5 - Port the app name→slug resolver from bitrise-cli

### DIFF
--- a/cli/app/view.go
+++ b/cli/app/view.go
@@ -69,7 +69,7 @@ func runView(cmd *cobra.Command, args []string, web bool, openBrowser func(strin
 	if err != nil {
 		return err
 	}
-	a, err := internalapp.NewService(client).ViewByNameOrSlug(cmd.Context(), cmdutil.NewResolver(cmd, client), appSlug)
+	a, err := internalapp.NewService(client).ViewByNameOrSlug(cmd.Context(), cmdutil.NewResolver(client), appSlug)
 	if err != nil {
 		return err
 	}

--- a/cli/app/view.go
+++ b/cli/app/view.go
@@ -69,7 +69,7 @@ func runView(cmd *cobra.Command, args []string, web bool, openBrowser func(strin
 	if err != nil {
 		return err
 	}
-	a, err := internalapp.NewService(client).View(cmd.Context(), appSlug)
+	a, err := internalapp.NewService(client).ViewByNameOrSlug(cmd.Context(), cmdutil.NewResolver(cmd, client), appSlug)
 	if err != nil {
 		return err
 	}

--- a/cli/app/view_test.go
+++ b/cli/app/view_test.go
@@ -3,6 +3,7 @@ package app
 import (
 	"bytes"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -16,11 +17,7 @@ import (
 
 func TestViewCmd_PositionalArg(t *testing.T) {
 	var gotPath string
-	srv := newFakeServer(t, func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/apps" {
-			_, _ = w.Write([]byte(`{"data":[],"paging":{}}`))
-			return
-		}
+	srv := newViewFakeServer(t, func(w http.ResponseWriter, r *http.Request) {
 		gotPath = r.URL.Path
 		_, _ = w.Write([]byte(`{"data":{"slug":"my-app","title":"My App","provider":"github","repo_url":"https://github.com/x/y","owner":{"slug":"acme"}}}`))
 	})
@@ -38,11 +35,7 @@ func TestViewCmd_PositionalArg(t *testing.T) {
 
 func TestViewCmd_FlagFallback(t *testing.T) {
 	var gotPath string
-	srv := newFakeServer(t, func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/apps" {
-			_, _ = w.Write([]byte(`{"data":[],"paging":{}}`))
-			return
-		}
+	srv := newViewFakeServer(t, func(w http.ResponseWriter, r *http.Request) {
 		gotPath = r.URL.Path
 		_, _ = w.Write([]byte(`{"data":{"slug":"my-app","title":"My App","provider":"github","owner":{}}}`))
 	})
@@ -64,11 +57,7 @@ func TestViewCmd_RequiresAppSlug(t *testing.T) {
 }
 
 func TestViewCmd_AppNotFound(t *testing.T) {
-	srv := newFakeServer(t, func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/apps" {
-			_, _ = w.Write([]byte(`{"data":[],"paging":{}}`))
-			return
-		}
+	srv := newViewFakeServer(t, func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNotFound)
 		_, _ = w.Write([]byte(`{"message":"not found"}`))
 	})
@@ -123,4 +112,19 @@ func newTestViewCmd(t *testing.T, apiBaseURL string) (*cobra.Command, *bytes.Buf
 	resolved := config.Resolve(config.Config{}, config.Config{}, config.Config{APIBaseURL: apiBaseURL})
 	cmd.SetContext(config.WithResolved(t.Context(), resolved))
 	return cmd, &out
+}
+
+// newViewFakeServer answers the app name→slug resolver's GET /apps lookup
+// with a passthrough (0 matches) before deferring to handler, so a view test
+// only ever sees the request it is about. The package's newFakeServer can't
+// do this itself: /apps is the endpoint under test in list_test.go.
+func newViewFakeServer(t *testing.T, handler http.HandlerFunc) *httptest.Server {
+	t.Helper()
+	return newFakeServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/apps" {
+			_, _ = w.Write([]byte(`{"data":[],"paging":{}}`))
+			return
+		}
+		handler(w, r)
+	})
 }

--- a/cli/app/view_test.go
+++ b/cli/app/view_test.go
@@ -17,6 +17,10 @@ import (
 func TestViewCmd_PositionalArg(t *testing.T) {
 	var gotPath string
 	srv := newFakeServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/apps" {
+			_, _ = w.Write([]byte(`{"data":[],"paging":{}}`))
+			return
+		}
 		gotPath = r.URL.Path
 		_, _ = w.Write([]byte(`{"data":{"slug":"my-app","title":"My App","provider":"github","repo_url":"https://github.com/x/y","owner":{"slug":"acme"}}}`))
 	})
@@ -35,6 +39,10 @@ func TestViewCmd_PositionalArg(t *testing.T) {
 func TestViewCmd_FlagFallback(t *testing.T) {
 	var gotPath string
 	srv := newFakeServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/apps" {
+			_, _ = w.Write([]byte(`{"data":[],"paging":{}}`))
+			return
+		}
 		gotPath = r.URL.Path
 		_, _ = w.Write([]byte(`{"data":{"slug":"my-app","title":"My App","provider":"github","owner":{}}}`))
 	})
@@ -56,7 +64,11 @@ func TestViewCmd_RequiresAppSlug(t *testing.T) {
 }
 
 func TestViewCmd_AppNotFound(t *testing.T) {
-	srv := newFakeServer(t, func(w http.ResponseWriter, _ *http.Request) {
+	srv := newFakeServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/apps" {
+			_, _ = w.Write([]byte(`{"data":[],"paging":{}}`))
+			return
+		}
 		w.WriteHeader(http.StatusNotFound)
 		_, _ = w.Write([]byte(`{"message":"not found"}`))
 	})

--- a/cli/build/abort.go
+++ b/cli/build/abort.go
@@ -37,12 +37,11 @@ BUILD_ID belongs to an app: pass --app ID, or set BITRISE_APP_ID.`,
 				return fmt.Errorf("failed to configure output format: %w", err)
 			}
 
-			appSlug, err := cmdutil.ResolveAppSlug(cmd)
+			client, err := cmdutil.NewAPIClient(cmd)
 			if err != nil {
 				return err
 			}
-
-			client, err := cmdutil.NewAPIClient(cmd)
+			appSlug, err := cmdutil.ResolveAndLookupAppSlug(cmd, client)
 			if err != nil {
 				return err
 			}

--- a/cli/build/list.go
+++ b/cli/build/list.go
@@ -62,7 +62,11 @@ In JSON mode (--format json), next_cursor holds the cursor value for scripting:
 				return fmt.Errorf("failed to configure output format: %w", err)
 			}
 
-			appSlug, err := cmdutil.ResolveAppSlug(cmd)
+			client, err := cmdutil.NewAPIClient(cmd)
+			if err != nil {
+				return err
+			}
+			rawAppSlug, err := cmdutil.ResolveAppSlug(cmd)
 			if err != nil {
 				return err
 			}
@@ -83,7 +87,7 @@ In JSON mode (--format json), next_cursor holds the cursor value for scripting:
 				beforeTime = &t
 			}
 
-			client, err := cmdutil.NewAPIClient(cmd)
+			appSlug, err := cmdutil.NewResolver(cmd, client).AppSlug(cmd.Context(), rawAppSlug)
 			if err != nil {
 				return err
 			}

--- a/cli/build/list.go
+++ b/cli/build/list.go
@@ -66,7 +66,7 @@ In JSON mode (--format json), next_cursor holds the cursor value for scripting:
 			if err != nil {
 				return err
 			}
-			rawAppSlug, err := cmdutil.ResolveAppSlug(cmd)
+			appSlug, err := cmdutil.ResolveAndLookupAppSlug(cmd, client)
 			if err != nil {
 				return err
 			}
@@ -87,10 +87,6 @@ In JSON mode (--format json), next_cursor holds the cursor value for scripting:
 				beforeTime = &t
 			}
 
-			appSlug, err := cmdutil.NewResolver(client).AppSlug(cmd.Context(), rawAppSlug)
-			if err != nil {
-				return err
-			}
 			svc := internalbuild.NewService(client)
 
 			var isPipelineBuild *bool

--- a/cli/build/list.go
+++ b/cli/build/list.go
@@ -87,7 +87,7 @@ In JSON mode (--format json), next_cursor holds the cursor value for scripting:
 				beforeTime = &t
 			}
 
-			appSlug, err := cmdutil.NewResolver(cmd, client).AppSlug(cmd.Context(), rawAppSlug)
+			appSlug, err := cmdutil.NewResolver(client).AppSlug(cmd.Context(), rawAppSlug)
 			if err != nil {
 				return err
 			}

--- a/cli/build/list_test.go
+++ b/cli/build/list_test.go
@@ -130,7 +130,11 @@ func TestListCmd_RejectsAllWithCursor(t *testing.T) {
 }
 
 func TestListCmd_InvalidAfterValue(t *testing.T) {
-	cmd, _ := newTestListCmd(t, "https://unused.test")
+	srv := newFakeServer(t, func(_ http.ResponseWriter, _ *http.Request) {
+		t.Fatal("must not reach the builds endpoint when --after is invalid")
+	})
+
+	cmd, _ := newTestListCmd(t, srv.URL)
 	require.NoError(t, cmd.Flags().Set("app", "my-app"))
 	require.NoError(t, cmd.Flags().Set("after", "not-a-date"))
 

--- a/cli/build/list_test.go
+++ b/cli/build/list_test.go
@@ -177,9 +177,18 @@ func newTestListCmd(t *testing.T, apiBaseURL string) (*cobra.Command, *bytes.Buf
 	return cmd, &out
 }
 
+// newFakeServer wires handler behind a server that transparently answers the
+// app name→slug resolver's GET /apps?title=... lookup with a passthrough (0
+// matches), so handler only ever sees the real request under test.
 func newFakeServer(t *testing.T, handler http.HandlerFunc) *httptest.Server {
 	t.Helper()
-	srv := httptest.NewServer(handler)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/apps" {
+			_, _ = w.Write([]byte(`{"data":[],"paging":{}}`))
+			return
+		}
+		handler(w, r)
+	}))
 	t.Cleanup(srv.Close)
 	return srv
 }

--- a/cli/build/log.go
+++ b/cli/build/log.go
@@ -39,13 +39,13 @@ Output is always raw text — logs stream as-is, ignoring --format.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmdutil.LogCommandParameters(cmd)
 
-			appSlug, err := cmdutil.ResolveAppSlug(cmd)
-			if err != nil {
-				return err
-			}
 			buildSlug := args[0]
 
 			client, err := cmdutil.NewAPIClient(cmd)
+			if err != nil {
+				return err
+			}
+			appSlug, err := cmdutil.ResolveAndLookupAppSlug(cmd, client)
 			if err != nil {
 				return err
 			}

--- a/cli/build/trigger.go
+++ b/cli/build/trigger.go
@@ -98,7 +98,7 @@ Optional flags:
 				}
 			}
 
-			appSlug, err := cmdutil.NewResolver(cmd, client).AppSlug(cmd.Context(), rawAppSlug)
+			appSlug, err := cmdutil.NewResolver(client).AppSlug(cmd.Context(), rawAppSlug)
 			if err != nil {
 				return err
 			}

--- a/cli/build/trigger.go
+++ b/cli/build/trigger.go
@@ -77,7 +77,7 @@ Optional flags:
 			if err != nil {
 				return err
 			}
-			rawAppSlug, err := cmdutil.ResolveAppSlug(cmd)
+			appSlug, err := cmdutil.ResolveAndLookupAppSlug(cmd, client)
 			if err != nil {
 				return err
 			}
@@ -98,10 +98,6 @@ Optional flags:
 				}
 			}
 
-			appSlug, err := cmdutil.NewResolver(client).AppSlug(cmd.Context(), rawAppSlug)
-			if err != nil {
-				return err
-			}
 			svc := internalbuild.NewService(client)
 
 			b, err := svc.Trigger(cmd.Context(), internalbuild.TriggerRequest{

--- a/cli/build/trigger.go
+++ b/cli/build/trigger.go
@@ -73,7 +73,11 @@ Optional flags:
 				return fmt.Errorf("failed to configure output format: %w", err)
 			}
 
-			appSlug, err := cmdutil.ResolveAppSlug(cmd)
+			client, err := cmdutil.NewAPIClient(cmd)
+			if err != nil {
+				return err
+			}
+			rawAppSlug, err := cmdutil.ResolveAppSlug(cmd)
 			if err != nil {
 				return err
 			}
@@ -94,7 +98,7 @@ Optional flags:
 				}
 			}
 
-			client, err := cmdutil.NewAPIClient(cmd)
+			appSlug, err := cmdutil.NewResolver(cmd, client).AppSlug(cmd.Context(), rawAppSlug)
 			if err != nil {
 				return err
 			}

--- a/cli/build/view.go
+++ b/cli/build/view.go
@@ -66,6 +66,10 @@ func runView(cmd *cobra.Command, args []string, web bool, openBrowser func(strin
 	if err != nil {
 		return err
 	}
+	appSlug, err = cmdutil.NewResolver(cmd, client).AppSlug(cmd.Context(), appSlug)
+	if err != nil {
+		return err
+	}
 	b, err := internalbuild.NewService(client).View(cmd.Context(), appSlug, buildSlug)
 	if err != nil {
 		return err

--- a/cli/build/view.go
+++ b/cli/build/view.go
@@ -66,7 +66,7 @@ func runView(cmd *cobra.Command, args []string, web bool, openBrowser func(strin
 	if err != nil {
 		return err
 	}
-	appSlug, err = cmdutil.NewResolver(cmd, client).AppSlug(cmd.Context(), appSlug)
+	appSlug, err = cmdutil.NewResolver(client).AppSlug(cmd.Context(), appSlug)
 	if err != nil {
 		return err
 	}

--- a/cli/build/watch.go
+++ b/cli/build/watch.go
@@ -40,13 +40,13 @@ written to stdout, so this stays pipeable.`,
 				return fmt.Errorf("failed to configure output format: %w", err)
 			}
 
-			appSlug, err := cmdutil.ResolveAppSlug(cmd)
-			if err != nil {
-				return err
-			}
 			buildSlug := args[0]
 
 			client, err := cmdutil.NewAPIClient(cmd)
+			if err != nil {
+				return err
+			}
+			appSlug, err := cmdutil.ResolveAndLookupAppSlug(cmd, client)
 			if err != nil {
 				return err
 			}

--- a/cli/build/yml.go
+++ b/cli/build/yml.go
@@ -31,12 +31,11 @@ This is a shortcut for "bitrise yml get --app ID --build BUILD_ID".`,
 				return err
 			}
 
-			appSlug, err := cmdutil.ResolveAppSlug(cmd)
+			client, err := cmdutil.NewAPIClient(cmd)
 			if err != nil {
 				return err
 			}
-
-			client, err := cmdutil.NewAPIClient(cmd)
+			appSlug, err := cmdutil.ResolveAndLookupAppSlug(cmd, client)
 			if err != nil {
 				return err
 			}

--- a/cli/cmdutil/app.go
+++ b/cli/cmdutil/app.go
@@ -76,8 +76,9 @@ func AppSlugRequiredErr() error {
 	return errors.New("--app is required")
 }
 
-// NewResolver returns a Resolver wired to client and a fresh in-memory cache.
-func NewResolver(cmd *cobra.Command, client *bitriseapi.Client) *resolve.Resolver {
+// NewResolver returns a Resolver wired to client and a fresh in-memory cache,
+// so repeated lookups within one command invocation hit the API once.
+func NewResolver(client *bitriseapi.Client) *resolve.Resolver {
 	return resolve.New(client, cache.New())
 }
 
@@ -90,5 +91,5 @@ func ResolveAndLookupAppSlug(cmd *cobra.Command, client *bitriseapi.Client) (str
 	if err != nil {
 		return "", err
 	}
-	return NewResolver(cmd, client).AppSlug(cmd.Context(), raw)
+	return NewResolver(client).AppSlug(cmd.Context(), raw)
 }

--- a/cli/cmdutil/app.go
+++ b/cli/cmdutil/app.go
@@ -7,7 +7,10 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
+	"github.com/bitrise-io/bitrise/v2/internal/bitriseapi"
+	"github.com/bitrise-io/bitrise/v2/internal/cache"
 	"github.com/bitrise-io/bitrise/v2/internal/config"
+	"github.com/bitrise-io/bitrise/v2/internal/resolve"
 )
 
 // FlagApp is the app slug a command acts on.
@@ -71,4 +74,21 @@ func LookupAppSlug(cmd *cobra.Command) string {
 // AppSlugRequiredErr returns the standard missing-app-slug error.
 func AppSlugRequiredErr() error {
 	return errors.New("--app is required")
+}
+
+// NewResolver returns a Resolver wired to client and a fresh in-memory cache.
+func NewResolver(cmd *cobra.Command, client *bitriseapi.Client) *resolve.Resolver {
+	return resolve.New(client, cache.New())
+}
+
+// ResolveAndLookupAppSlug reads the app slug from --app / env / config (same
+// precedence as ResolveAppSlug), then resolves a display name to an app slug
+// via a targeted GET /apps?title=<value> query if the value doesn't match any
+// slug directly.
+func ResolveAndLookupAppSlug(cmd *cobra.Command, client *bitriseapi.Client) (string, error) {
+	raw, err := ResolveAppSlug(cmd)
+	if err != nil {
+		return "", err
+	}
+	return NewResolver(cmd, client).AppSlug(cmd.Context(), raw)
 }

--- a/cli/cmdutil/app_test.go
+++ b/cli/cmdutil/app_test.go
@@ -1,12 +1,15 @@
 package cmdutil
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/bitrise-io/bitrise/v2/internal/bitriseapi"
 	"github.com/bitrise-io/bitrise/v2/internal/config"
 )
 
@@ -149,4 +152,95 @@ func TestResolveAppSlug_LegacyEnvTakesPrecedenceOverConfig(t *testing.T) {
 	slug, err := ResolveAppSlug(cmd)
 	require.NoError(t, err)
 	assert.Equal(t, "ci-injected-app-slug", slug)
+}
+
+func TestResolveAndLookupAppSlug_ResolvesNameToSlug(t *testing.T) {
+	client, calls := appsClient(t, `{"data":[{"slug":"app-123","title":"My iOS App"}],"paging":{}}`)
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(t.Context())
+	AddAppFlag(cmd.Flags(), "app slug")
+	require.NoError(t, cmd.Flags().Set(FlagApp, "My iOS App"))
+
+	slug, err := ResolveAndLookupAppSlug(cmd, client)
+	require.NoError(t, err)
+	assert.Equal(t, "app-123", slug)
+	assert.Equal(t, []string{"My iOS App"}, *calls)
+}
+
+// TestResolveAndLookupAppSlug_PassesSlugThrough covers the contract that keeps
+// every existing caller working: a value the API reports no title match for is
+// handed on as a literal slug rather than erroring here.
+func TestResolveAndLookupAppSlug_PassesSlugThrough(t *testing.T) {
+	client, _ := appsClient(t, `{"data":[],"paging":{}}`)
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(t.Context())
+	AddAppFlag(cmd.Flags(), "app slug")
+	require.NoError(t, cmd.Flags().Set(FlagApp, "3f8a91c02d4e"))
+
+	slug, err := ResolveAndLookupAppSlug(cmd, client)
+	require.NoError(t, err)
+	assert.Equal(t, "3f8a91c02d4e", slug)
+}
+
+// TestResolveAndLookupAppSlug_PrecedenceIsUnchanged pins that the resolver runs
+// after --app / env / config precedence, on whatever that produced, rather than
+// replacing it.
+func TestResolveAndLookupAppSlug_PrecedenceIsUnchanged(t *testing.T) {
+	t.Setenv(EnvAppID, "My iOS App")
+	client, calls := appsClient(t, `{"data":[{"slug":"app-123","title":"My iOS App"}],"paging":{}}`)
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(t.Context())
+	AddAppFlag(cmd.Flags(), "app slug")
+
+	slug, err := ResolveAndLookupAppSlug(cmd, client)
+	require.NoError(t, err)
+	assert.Equal(t, "app-123", slug)
+	assert.Equal(t, []string{"My iOS App"}, *calls)
+}
+
+func TestResolveAndLookupAppSlug_AmbiguousNameErrors(t *testing.T) {
+	client, _ := appsClient(t, `{"data":[{"slug":"a1","title":"Dup"},{"slug":"a2","title":"Dup"}],"paging":{}}`)
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(t.Context())
+	AddAppFlag(cmd.Flags(), "app slug")
+	require.NoError(t, cmd.Flags().Set(FlagApp, "Dup"))
+
+	_, err := ResolveAndLookupAppSlug(cmd, client)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ambiguous")
+}
+
+// TestNewResolver_CachesWithinOneInvocation pins the reason NewResolver builds
+// a cache at all: the same name resolved twice through one resolver costs one
+// API call, not two.
+func TestNewResolver_CachesWithinOneInvocation(t *testing.T) {
+	client, calls := appsClient(t, `{"data":[{"slug":"app-123","title":"My iOS App"}],"paging":{}}`)
+
+	r := NewResolver(client)
+	for range 2 {
+		slug, err := r.AppSlug(t.Context(), "My iOS App")
+		require.NoError(t, err)
+		assert.Equal(t, "app-123", slug)
+	}
+	assert.Equal(t, []string{"My iOS App"}, *calls)
+}
+
+// appsClient returns a client whose GET /apps answers with body, plus the
+// title= values it was queried with, so tests can assert on call count.
+func appsClient(t *testing.T, body string) (*bitriseapi.Client, *[]string) {
+	t.Helper()
+	var calls []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls = append(calls, r.URL.Query().Get("title"))
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+
+	client, err := bitriseapi.New(srv.URL, "token")
+	require.NoError(t, err)
+	return client, &calls
 }

--- a/cli/yml/get.go
+++ b/cli/yml/get.go
@@ -34,12 +34,11 @@ instead of the app's current stored configuration.`,
 				return err
 			}
 
-			appSlug, err := cmdutil.ResolveAppSlug(cmd)
+			client, err := cmdutil.NewAPIClient(cmd)
 			if err != nil {
 				return err
 			}
-
-			client, err := cmdutil.NewAPIClient(cmd)
+			appSlug, err := cmdutil.ResolveAndLookupAppSlug(cmd, client)
 			if err != nil {
 				return err
 			}

--- a/cli/yml/get_test.go
+++ b/cli/yml/get_test.go
@@ -19,18 +19,17 @@ func TestGetCmd_RequiresApp(t *testing.T) {
 	t.Setenv(cmdutil.EnvAppID, "")
 	t.Setenv(cmdutil.EnvAppIDLegacy, "")
 
-	cmd, _ := newTestGetCmd(t, "http://unused.test")
+	cmd, _ := newTestGetCmd(t, "https://unused.test")
 	err := cmd.RunE(cmd, nil)
 	require.EqualError(t, err, "--app is required")
 }
 
 func TestGetCmd_App(t *testing.T) {
 	var gotPath string
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	srv := newFakeServer(t, func(w http.ResponseWriter, r *http.Request) {
 		gotPath = r.URL.Path
 		_, _ = w.Write([]byte("format_version: \"13\"\n"))
-	}))
-	t.Cleanup(srv.Close)
+	})
 
 	cmd, out := newTestGetCmd(t, srv.URL)
 	require.NoError(t, cmd.Flags().Set("app", "app-slug"))
@@ -42,11 +41,10 @@ func TestGetCmd_App(t *testing.T) {
 
 func TestGetCmd_Build(t *testing.T) {
 	var gotPath string
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	srv := newFakeServer(t, func(w http.ResponseWriter, r *http.Request) {
 		gotPath = r.URL.Path
 		_, _ = w.Write([]byte("format_version: \"13\"\n"))
-	}))
-	t.Cleanup(srv.Close)
+	})
 
 	cmd, _ := newTestGetCmd(t, srv.URL)
 	require.NoError(t, cmd.Flags().Set("app", "app-slug"))
@@ -57,10 +55,9 @@ func TestGetCmd_Build(t *testing.T) {
 }
 
 func TestGetCmd_AppendsMissingTrailingNewline(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	srv := newFakeServer(t, func(w http.ResponseWriter, _ *http.Request) {
 		_, _ = w.Write([]byte("format_version: \"13\""))
-	}))
-	t.Cleanup(srv.Close)
+	})
 
 	cmd, out := newTestGetCmd(t, srv.URL)
 	require.NoError(t, cmd.Flags().Set("app", "app-slug"))
@@ -70,10 +67,9 @@ func TestGetCmd_AppendsMissingTrailingNewline(t *testing.T) {
 }
 
 func TestGetCmd_JSONOutput(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	srv := newFakeServer(t, func(w http.ResponseWriter, _ *http.Request) {
 		_, _ = w.Write([]byte("format_version: \"13\"\n"))
-	}))
-	t.Cleanup(srv.Close)
+	})
 
 	cmd, _ := newTestGetCmd(t, srv.URL)
 	require.NoError(t, cmd.Flags().Set("app", "app-slug"))
@@ -93,4 +89,20 @@ func newTestGetCmd(t *testing.T, apiBaseURL string) (*cobra.Command, *bytes.Buff
 	resolved := config.Resolve(config.Config{}, config.Config{}, config.Config{APIBaseURL: apiBaseURL})
 	cmd.SetContext(config.WithResolved(t.Context(), resolved))
 	return cmd, &out
+}
+
+// newFakeServer wires handler behind a server that transparently answers the
+// app name→slug resolver's GET /apps?title=... lookup with a passthrough (0
+// matches), so handler only ever sees the real request under test.
+func newFakeServer(t *testing.T, handler http.HandlerFunc) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/apps" {
+			_, _ = w.Write([]byte(`{"data":[],"paging":{}}`))
+			return
+		}
+		handler(w, r)
+	}))
+	t.Cleanup(srv.Close)
+	return srv
 }

--- a/cli/yml/update.go
+++ b/cli/yml/update.go
@@ -56,7 +56,7 @@ later 'bitrise yml get' returns an equivalent, reformatted document.`,
 				return fmt.Errorf("bitrise.yml content is empty")
 			}
 
-			appSlug, err := cmdutil.NewResolver(cmd, client).AppSlug(cmd.Context(), rawAppSlug)
+			appSlug, err := cmdutil.NewResolver(client).AppSlug(cmd.Context(), rawAppSlug)
 			if err != nil {
 				return err
 			}

--- a/cli/yml/update.go
+++ b/cli/yml/update.go
@@ -43,7 +43,7 @@ later 'bitrise yml get' returns an equivalent, reformatted document.`,
 			if err != nil {
 				return err
 			}
-			rawAppSlug, err := cmdutil.ResolveAppSlug(cmd)
+			appSlug, err := cmdutil.ResolveAndLookupAppSlug(cmd, client)
 			if err != nil {
 				return err
 			}
@@ -54,11 +54,6 @@ later 'bitrise yml get' returns an equivalent, reformatted document.`,
 			}
 			if len(rawYAML) == 0 {
 				return fmt.Errorf("bitrise.yml content is empty")
-			}
-
-			appSlug, err := cmdutil.NewResolver(client).AppSlug(cmd.Context(), rawAppSlug)
-			if err != nil {
-				return err
 			}
 
 			if err := internalyml.NewService(client).Update(cmd.Context(), appSlug, string(rawYAML)); err != nil {

--- a/cli/yml/update.go
+++ b/cli/yml/update.go
@@ -39,7 +39,11 @@ later 'bitrise yml get' returns an equivalent, reformatted document.`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			cmdutil.LogCommandParameters(cmd)
 
-			appSlug, err := cmdutil.ResolveAppSlug(cmd)
+			client, err := cmdutil.NewAPIClient(cmd)
+			if err != nil {
+				return err
+			}
+			rawAppSlug, err := cmdutil.ResolveAppSlug(cmd)
 			if err != nil {
 				return err
 			}
@@ -52,7 +56,7 @@ later 'bitrise yml get' returns an equivalent, reformatted document.`,
 				return fmt.Errorf("bitrise.yml content is empty")
 			}
 
-			client, err := cmdutil.NewAPIClient(cmd)
+			appSlug, err := cmdutil.NewResolver(cmd, client).AppSlug(cmd.Context(), rawAppSlug)
 			if err != nil {
 				return err
 			}

--- a/cli/yml/update_test.go
+++ b/cli/yml/update_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"io"
 	"net/http"
-	"net/http/httptest"
 	"strings"
 	"testing"
 
@@ -21,19 +20,18 @@ func TestUpdateCmd_RequiresApp(t *testing.T) {
 	t.Setenv(cmdutil.EnvAppID, "")
 	t.Setenv(cmdutil.EnvAppIDLegacy, "")
 
-	cmd, _ := newTestUpdateCmd(t, "http://unused.test", "")
+	cmd, _ := newTestUpdateCmd(t, "https://unused.test", "")
 	err := cmd.RunE(cmd, nil)
 	require.EqualError(t, err, "--app is required")
 }
 
 func TestUpdateCmd_FromStdin(t *testing.T) {
 	var gotBody string
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	srv := newFakeServer(t, func(w http.ResponseWriter, r *http.Request) {
 		b, _ := io.ReadAll(r.Body)
 		gotBody = string(b)
 		_, _ = w.Write([]byte(`{}`))
-	}))
-	t.Cleanup(srv.Close)
+	})
 
 	cmd, stderr := newTestUpdateCmd(t, srv.URL, "format_version: \"13\"\n")
 	require.NoError(t, cmd.Flags().Set("app", "app-slug"))
@@ -44,7 +42,7 @@ func TestUpdateCmd_FromStdin(t *testing.T) {
 }
 
 func TestUpdateCmd_EmptyContent(t *testing.T) {
-	cmd, _ := newTestUpdateCmd(t, "http://unused.test", "")
+	cmd, _ := newTestUpdateCmd(t, "https://unused.test", "")
 	require.NoError(t, cmd.Flags().Set("app", "app-slug"))
 
 	err := cmd.RunE(cmd, nil)

--- a/cli/yml/validate.go
+++ b/cli/yml/validate.go
@@ -286,6 +286,14 @@ func tryOnlineValidate(cmd *cobra.Command, bitriseConfigPath, bitriseConfigBase6
 		return nil, fmt.Sprintf("online validation unavailable: %s", err), false
 	}
 
+	if appSlug != "" {
+		resolved, rerr := cmdutil.NewResolver(cmd, client).AppSlug(cmd.Context(), appSlug)
+		if rerr != nil {
+			return nil, fmt.Sprintf("online validation unavailable: %s", rerr), false
+		}
+		appSlug = resolved
+	}
+
 	rawYAML, err := getYmlStringForOnlineValidation(bitriseConfigPath, bitriseConfigBase64Data)
 	if err != nil {
 		return nil, fmt.Sprintf("online validation unavailable: %s", err), false

--- a/cli/yml/validate.go
+++ b/cli/yml/validate.go
@@ -287,7 +287,7 @@ func tryOnlineValidate(cmd *cobra.Command, bitriseConfigPath, bitriseConfigBase6
 	}
 
 	if appSlug != "" {
-		resolved, rerr := cmdutil.NewResolver(cmd, client).AppSlug(cmd.Context(), appSlug)
+		resolved, rerr := cmdutil.NewResolver(client).AppSlug(cmd.Context(), appSlug)
 		if rerr != nil {
 			return nil, fmt.Sprintf("online validation unavailable: %s", rerr), false
 		}

--- a/cli/yml/validate.go
+++ b/cli/yml/validate.go
@@ -286,12 +286,9 @@ func tryOnlineValidate(cmd *cobra.Command, bitriseConfigPath, bitriseConfigBase6
 		return nil, fmt.Sprintf("online validation unavailable: %s", err), false
 	}
 
-	if appSlug != "" {
-		resolved, rerr := cmdutil.NewResolver(client).AppSlug(cmd.Context(), appSlug)
-		if rerr != nil {
-			return nil, fmt.Sprintf("online validation unavailable: %s", rerr), false
-		}
-		appSlug = resolved
+	appSlug, err = cmdutil.NewResolver(client).AppSlug(cmd.Context(), appSlug)
+	if err != nil {
+		return nil, fmt.Sprintf("online validation unavailable: %s", err), false
 	}
 
 	rawYAML, err := getYmlStringForOnlineValidation(bitriseConfigPath, bitriseConfigBase64Data)

--- a/cli/yml/validate_test.go
+++ b/cli/yml/validate_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/base64"
 	"io"
 	"net/http"
-	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
@@ -38,7 +37,7 @@ default_step_lib_source: "https://github.com/bitrise-io/bitrise-steplib.git"
 
 func TestValidateConfig_NoToken_UsesLocal(t *testing.T) {
 	var onlineCalled bool
-	srv := newValidateFakeServer(t, func(w http.ResponseWriter, _ *http.Request) {
+	srv := newFakeServer(t, func(w http.ResponseWriter, _ *http.Request) {
 		onlineCalled = true
 		_, _ = w.Write([]byte(`{"errors":[],"warnings":[]}`))
 	})
@@ -63,7 +62,7 @@ func TestValidateConfig_CorruptAuthFile_FallsBackWithWarning(t *testing.T) {
 	// surface as a warning rather than being silently treated the same as
 	// the expected, unconfigured-token default.
 	var onlineCalled bool
-	srv := newValidateFakeServer(t, func(w http.ResponseWriter, _ *http.Request) {
+	srv := newFakeServer(t, func(w http.ResponseWriter, _ *http.Request) {
 		onlineCalled = true
 		_, _ = w.Write([]byte(`{"errors":[],"warnings":[]}`))
 	})
@@ -250,23 +249,6 @@ func encode(s string) string {
 	return base64.StdEncoding.EncodeToString([]byte(s))
 }
 
-// newValidateFakeServer wires handler behind a server that transparently
-// answers the app name→slug resolver's GET /apps?title=... lookup with a
-// passthrough (0 matches), so handler only ever sees the real request under
-// test.
-func newValidateFakeServer(t *testing.T, handler http.HandlerFunc) *httptest.Server {
-	t.Helper()
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/apps" {
-			_, _ = w.Write([]byte(`{"data":[],"paging":{}}`))
-			return
-		}
-		handler(w, r)
-	}))
-	t.Cleanup(srv.Close)
-	return srv
-}
-
 // newTestValidateCommand is newTestValidateCmd for the real command, so tests
 // can drive RunE through its actual flag set. It returns the command's stderr
 // buffer, which carries the online-validation note.
@@ -276,7 +258,7 @@ func newTestValidateCommand(t *testing.T, handler http.HandlerFunc) (*cobra.Comm
 	t.Setenv("BITRISE_TOKEN", "") // an exported token would outrank the fixture in cmdutil.ResolveToken
 	require.NoError(t, auth.Save(auth.Auth{Token: "test-token"}))
 
-	apiBaseURL := newValidateFakeServer(t, handler).URL
+	apiBaseURL := newFakeServer(t, handler).URL
 
 	cmd := NewValidateCommand()
 	var stderr bytes.Buffer
@@ -295,7 +277,7 @@ func newTestValidateCmd(t *testing.T, handler http.HandlerFunc) *cobra.Command {
 	t.Setenv("BITRISE_TOKEN", "") // an exported token would outrank the fixture in cmdutil.ResolveToken
 	require.NoError(t, auth.Save(auth.Auth{Token: "test-token"}))
 
-	apiBaseURL := newValidateFakeServer(t, handler).URL
+	apiBaseURL := newFakeServer(t, handler).URL
 
 	cmd := &cobra.Command{}
 	resolved := config.Resolve(config.Config{}, config.Config{}, config.Config{APIBaseURL: apiBaseURL})

--- a/cli/yml/validate_test.go
+++ b/cli/yml/validate_test.go
@@ -250,9 +250,19 @@ func encode(s string) string {
 	return base64.StdEncoding.EncodeToString([]byte(s))
 }
 
+// newValidateFakeServer wires handler behind a server that transparently
+// answers the app name→slug resolver's GET /apps?title=... lookup with a
+// passthrough (0 matches), so handler only ever sees the real request under
+// test.
 func newValidateFakeServer(t *testing.T, handler http.HandlerFunc) *httptest.Server {
 	t.Helper()
-	srv := httptest.NewServer(handler)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/apps" {
+			_, _ = w.Write([]byte(`{"data":[],"paging":{}}`))
+			return
+		}
+		handler(w, r)
+	}))
 	t.Cleanup(srv.Close)
 	return srv
 }

--- a/internal/app/service.go
+++ b/internal/app/service.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 
 	"github.com/bitrise-io/bitrise/v2/internal/bitriseapi"
+	"github.com/bitrise-io/bitrise/v2/internal/resolve"
 )
 
 // App is the CLI representation of a Bitrise app (project).
@@ -64,6 +65,21 @@ func (s *Service) List(ctx context.Context, opts ListOptions) (AppsResult, error
 		items = append(items, fromAPI(a))
 	}
 	return AppsResult{Items: items, NextCursor: next}, nil
+}
+
+// ViewByNameOrSlug resolves value via r and returns the app. When r found a
+// name match in the current API call (complete=true), that result is used
+// directly — no second request. Otherwise (cache hit or literal-slug
+// passthrough) GET /apps/{slug} is called via View.
+func (s *Service) ViewByNameOrSlug(ctx context.Context, r *resolve.Resolver, value string) (App, error) {
+	app, complete, err := r.ResolveApp(ctx, value)
+	if err != nil {
+		return App{}, err
+	}
+	if complete {
+		return fromAPI(app), nil
+	}
+	return s.View(ctx, app.Slug)
 }
 
 // View returns details of a single app by slug.

--- a/internal/app/service_test.go
+++ b/internal/app/service_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/bitrise-io/bitrise/v2/internal/bitriseapi"
+	"github.com/bitrise-io/bitrise/v2/internal/resolve"
 )
 
 func TestList_MapsAPIShape(t *testing.T) {
@@ -89,6 +90,41 @@ func TestView_AppNotFound(t *testing.T) {
 
 	_, err := NewService(client).View(context.Background(), "missing-app")
 	require.EqualError(t, err, `app "missing-app" not found`)
+}
+
+func TestViewByNameOrSlug_NameMatch_SkipsSecondRequest(t *testing.T) {
+	var requests int
+	srv := newFakeServer(t, func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		assert.Equal(t, "/apps", r.URL.Path)
+		_, _ = w.Write([]byte(`{"data":[{"slug":"my-app","title":"My App","provider":"github","owner":{"slug":"acme"}}],"paging":{}}`))
+	})
+	client := newAPIClient(t, srv.URL)
+	r := resolve.New(client, nil)
+
+	got, err := NewService(client).ViewByNameOrSlug(context.Background(), r, "My App")
+	require.NoError(t, err)
+	assert.Equal(t, 1, requests, "a complete name match must not trigger a second request")
+	assert.Equal(t, App{Slug: "my-app", Title: "My App", Provider: "github", OwnerSlug: "acme"}, got)
+}
+
+func TestViewByNameOrSlug_Passthrough_FallsThroughToView(t *testing.T) {
+	var gotPaths []string
+	srv := newFakeServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotPaths = append(gotPaths, r.URL.Path)
+		if r.URL.Path == "/apps" {
+			_, _ = w.Write([]byte(`{"data":[],"paging":{}}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"data":{"slug":"my-app","title":"My App","provider":"github","owner":{"slug":"acme"}}}`))
+	})
+	client := newAPIClient(t, srv.URL)
+	r := resolve.New(client, nil)
+
+	got, err := NewService(client).ViewByNameOrSlug(context.Background(), r, "my-app")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"/apps", "/apps/my-app"}, gotPaths)
+	assert.Equal(t, App{Slug: "my-app", Title: "My App", Provider: "github", OwnerSlug: "acme"}, got)
 }
 
 func newFakeServer(t *testing.T, handler http.HandlerFunc) *httptest.Server {

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -1,0 +1,35 @@
+// Package cache provides a lightweight in-memory app title→slug cache for
+// CLI lookups. Entries live for the duration of a single command invocation.
+package cache
+
+import "strings"
+
+// Cache is an in-memory app title→slug mapping.
+// All lookups and mutations are case-insensitive (keys are stored lowercase).
+type Cache struct {
+	apps map[string]string
+}
+
+// New returns an empty, ready-to-use Cache.
+func New() *Cache {
+	return &Cache{
+		apps: make(map[string]string),
+	}
+}
+
+// LookupApp returns the app slug stored for the given title, if any.
+func (c *Cache) LookupApp(title string) (string, bool) {
+	if c == nil {
+		return "", false
+	}
+	slug, ok := c.apps[strings.ToLower(title)]
+	return slug, ok
+}
+
+// SetApp stores a title→slug mapping.
+func (c *Cache) SetApp(title, slug string) {
+	if c == nil {
+		return
+	}
+	c.apps[strings.ToLower(title)] = slug
+}

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -1,0 +1,34 @@
+package cache
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNew_IsEmpty(t *testing.T) {
+	c := New()
+	_, ok := c.LookupApp("anything")
+	assert.False(t, ok, "fresh cache should be empty")
+}
+
+func TestSetAndLookupApp(t *testing.T) {
+	c := New()
+	c.SetApp("My App", "abc12345")
+
+	slug, ok := c.LookupApp("My App")
+	assert.True(t, ok)
+	assert.Equal(t, "abc12345", slug)
+
+	slug, ok = c.LookupApp("my app")
+	assert.True(t, ok, "lookup should be case-insensitive")
+	assert.Equal(t, "abc12345", slug)
+}
+
+func TestNilCacheIsNoop(t *testing.T) {
+	var c *Cache
+	c.SetApp("x", "y")
+
+	_, ok := c.LookupApp("x")
+	assert.False(t, ok, "nil cache LookupApp should return false")
+}

--- a/internal/resolve/resolve.go
+++ b/internal/resolve/resolve.go
@@ -1,0 +1,72 @@
+// Package resolve maps a user-supplied app name or slug to the canonical app
+// slug. Results are stored in a name cache so repeated invocations with the
+// same name skip the network call.
+package resolve
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/bitrise-io/bitrise/v2/internal/bitriseapi"
+	"github.com/bitrise-io/bitrise/v2/internal/cache"
+)
+
+// Resolver maps a display name to an app slug.
+type Resolver struct {
+	client *bitriseapi.Client
+	cache  *cache.Cache
+}
+
+// New returns a Resolver backed by the given API client and cache.
+// cache may be nil — resolution still works, just without in-memory caching.
+func New(client *bitriseapi.Client, c *cache.Cache) *Resolver {
+	return &Resolver{client: client, cache: c}
+}
+
+// AppSlug maps value to an app slug. See ResolveApp for resolution semantics.
+func (r *Resolver) AppSlug(ctx context.Context, value string) (string, error) {
+	app, _, err := r.ResolveApp(ctx, value)
+	return app.Slug, err
+}
+
+// ResolveApp is like AppSlug but returns the full bitriseapi.App when value
+// was matched by a name query, so the caller can skip a second GET
+// /apps/{slug}. complete=false means value was not resolved by name:
+// app.Slug holds the resolved slug (from cache or passthrough) and the
+// caller must fetch full data.
+func (r *Resolver) ResolveApp(ctx context.Context, value string) (app bitriseapi.App, complete bool, err error) {
+	if value == "" {
+		return bitriseapi.App{}, false, nil
+	}
+	if r.cache != nil {
+		if slug, ok := r.cache.LookupApp(value); ok {
+			return bitriseapi.App{Slug: slug}, false, nil
+		}
+	}
+	apps, _, err := r.client.Apps(ctx, bitriseapi.AppsListOptions{Title: value})
+	if err != nil {
+		return bitriseapi.App{}, false, fmt.Errorf("look up app %q: %w", value, err)
+	}
+	var matches []bitriseapi.App
+	for _, a := range apps {
+		if strings.EqualFold(a.Title, value) {
+			matches = append(matches, a)
+		}
+	}
+	switch len(matches) {
+	case 0:
+		return bitriseapi.App{Slug: value}, false, nil
+	case 1:
+		if r.cache != nil {
+			r.cache.SetApp(matches[0].Title, matches[0].Slug)
+		}
+		return matches[0], true, nil
+	default:
+		slugs := make([]string, 0, len(matches))
+		for _, m := range matches {
+			slugs = append(slugs, m.Slug)
+		}
+		return bitriseapi.App{}, false, fmt.Errorf("app name %q is ambiguous (matches %d apps: %v) — pass an app ID instead", value, len(matches), slugs)
+	}
+}

--- a/internal/resolve/resolve_test.go
+++ b/internal/resolve/resolve_test.go
@@ -1,0 +1,166 @@
+package resolve
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/bitrise-io/bitrise/v2/internal/bitriseapi"
+	"github.com/bitrise-io/bitrise/v2/internal/cache"
+)
+
+func newFakeServer(t *testing.T, handler http.HandlerFunc) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func newAPIClient(t *testing.T, baseURL string) *bitriseapi.Client {
+	t.Helper()
+	c, err := bitriseapi.New(baseURL, "test-token")
+	require.NoError(t, err)
+	return c
+}
+
+func appsBody(body string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/apps" {
+			_, _ = w.Write([]byte(body))
+			return
+		}
+		http.NotFound(w, r)
+	}
+}
+
+func TestAppSlug_LiteralSlugPassthrough(t *testing.T) {
+	var called bool
+	srv := newFakeServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		called = true
+		_, _ = w.Write([]byte(`{"data":[],"paging":{}}`))
+	})
+	r := New(newAPIClient(t, srv.URL), nil)
+
+	slug, err := r.AppSlug(context.Background(), "abc12345")
+	require.NoError(t, err)
+	assert.Equal(t, "abc12345", slug)
+	assert.True(t, called, "expected API to be called even for slug-like input")
+}
+
+func TestAppSlug_NameResolution(t *testing.T) {
+	var gotTitle string
+	srv := newFakeServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotTitle, _ = url.QueryUnescape(r.URL.Query().Get("title"))
+		_, _ = w.Write([]byte(`{"data":[{"slug":"abc12345","title":"My App","owner":{}}],"paging":{}}`))
+	})
+	r := New(newAPIClient(t, srv.URL), nil)
+
+	slug, err := r.AppSlug(context.Background(), "My App")
+	require.NoError(t, err)
+	assert.Equal(t, "abc12345", slug)
+	assert.Equal(t, "My App", gotTitle)
+}
+
+func TestAppSlug_CaseInsensitive(t *testing.T) {
+	srv := newFakeServer(t, appsBody(`{"data":[{"slug":"abc12345","title":"My App","owner":{}}],"paging":{}}`))
+	r := New(newAPIClient(t, srv.URL), nil)
+
+	slug, err := r.AppSlug(context.Background(), "my app")
+	require.NoError(t, err)
+	assert.Equal(t, "abc12345", slug)
+}
+
+func TestAppSlug_AmbiguousError(t *testing.T) {
+	srv := newFakeServer(t, appsBody(`{"data":[
+		{"slug":"slug-1","title":"My App","owner":{}},
+		{"slug":"slug-2","title":"My App","owner":{}}
+	],"paging":{}}`))
+	r := New(newAPIClient(t, srv.URL), nil)
+
+	_, err := r.AppSlug(context.Background(), "My App")
+	require.Error(t, err)
+}
+
+func TestAppSlug_CacheHit(t *testing.T) {
+	var apiCalled bool
+	srv := newFakeServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		apiCalled = true
+		_, _ = w.Write([]byte(`{"data":[],"paging":{}}`))
+	})
+	c := cache.New()
+	c.SetApp("My App", "cached-slug")
+	r := New(newAPIClient(t, srv.URL), c)
+
+	slug, err := r.AppSlug(context.Background(), "My App")
+	require.NoError(t, err)
+	assert.Equal(t, "cached-slug", slug)
+	assert.False(t, apiCalled, "API should not be called on cache hit")
+}
+
+func TestAppSlug_PopulatesCache(t *testing.T) {
+	srv := newFakeServer(t, appsBody(`{"data":[{"slug":"abc12345","title":"My App","owner":{}}],"paging":{}}`))
+	c := cache.New()
+	r := New(newAPIClient(t, srv.URL), c)
+
+	_, err := r.AppSlug(context.Background(), "My App")
+	require.NoError(t, err)
+
+	slug, ok := c.LookupApp("My App")
+	assert.True(t, ok)
+	assert.Equal(t, "abc12345", slug)
+}
+
+func TestResolveApp_NameMatch_ReturnsFull(t *testing.T) {
+	srv := newFakeServer(t, appsBody(`{"data":[{"slug":"abc12345","title":"My App","provider":"github","repo_url":"https://github.com/x/y","owner":{"slug":"acme"}}],"paging":{}}`))
+	r := New(newAPIClient(t, srv.URL), nil)
+
+	app, complete, err := r.ResolveApp(context.Background(), "My App")
+	require.NoError(t, err)
+	assert.True(t, complete, "expected complete=true on name match")
+	assert.Equal(t, "abc12345", app.Slug)
+	assert.Equal(t, "My App", app.Title)
+	assert.Equal(t, "github", app.Provider)
+}
+
+func TestResolveApp_NoMatch_Passthrough(t *testing.T) {
+	srv := newFakeServer(t, appsBody(`{"data":[],"paging":{}}`))
+	r := New(newAPIClient(t, srv.URL), nil)
+
+	app, complete, err := r.ResolveApp(context.Background(), "abc12345")
+	require.NoError(t, err)
+	assert.False(t, complete, "expected complete=false on passthrough")
+	assert.Equal(t, "abc12345", app.Slug)
+}
+
+func TestResolveApp_CacheHit_NotFetched(t *testing.T) {
+	var apiCalled bool
+	srv := newFakeServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		apiCalled = true
+		_, _ = w.Write([]byte(`{"data":[],"paging":{}}`))
+	})
+	c := cache.New()
+	c.SetApp("My App", "cached-slug")
+	r := New(newAPIClient(t, srv.URL), c)
+
+	app, complete, err := r.ResolveApp(context.Background(), "My App")
+	require.NoError(t, err)
+	assert.False(t, complete, "expected complete=false on cache hit (full data not cached)")
+	assert.Equal(t, "cached-slug", app.Slug)
+	assert.False(t, apiCalled, "API should not be called on cache hit")
+}
+
+func TestResolveApp_AmbiguousError(t *testing.T) {
+	srv := newFakeServer(t, appsBody(`{"data":[
+		{"slug":"slug-1","title":"My App","owner":{}},
+		{"slug":"slug-2","title":"My App","owner":{}}
+	],"paging":{}}`))
+	r := New(newAPIClient(t, srv.URL), nil)
+
+	_, _, err := r.ResolveApp(context.Background(), "My App")
+	require.Error(t, err)
+}


### PR DESCRIPTION
Today a user must paste a raw 12-hex app slug wherever they used to type the app name shown in the dashboard, since the merged bitrise-cli reference project's transparent name resolution never made it across. That's a compat regression, not a new feature: internal/resolve and internal/cache are ported (app-only; the workspace half stays with internal/workspace, which already owns that), and cli/cmdutil.ResolveAndLookupAppSlug wires them into the ten --app call sites across build/yml/app.

--web on `build view`/`app view` keeps resolving nothing and hitting no API, matching its existing no-auth-required contract. yml validate's optional --app resolves too, inside tryOnlineValidate where a client already exists.