### PR TITLE
v3 cleanup 6 - Command errors go to stderr, not stdout

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -24,6 +24,8 @@ import (
 func Run() {
 	rawArgs := os.Args[1:]
 
+	rootCmd := newRootCommand()
+	configureStyleFromArgs(rootCmd, rawArgs)
 	initLogger(rawArgs)
 
 	// This is needed for printInstalledPlugins in the root help output, which is
@@ -49,8 +51,6 @@ func Run() {
 		}
 	}
 
-	rootCmd := newRootCommand()
-
 	if pluginName, pluginArgs, isPlugin := detectPlugin(rootCmd, rawArgs); isPlugin {
 		runPlugin(rootCmd, rawArgs, pluginName, pluginArgs)
 		return
@@ -70,6 +70,29 @@ func Run() {
 	if err := rootCmd.Execute(); err != nil {
 		cmdutil.Failf("%s", err)
 	}
+}
+
+// configureStyleFromArgs applies --no-color and --theme before cobra parses, so
+// errors raised during parsing carry the styling the user asked for. before()
+// applies them again from the fully resolved config; this early pass exists
+// because cobra returns flag and argument errors from ParseFlags and
+// ValidateArgs, both of which run ahead of any PersistentPreRunE — for those
+// errors this is the only styling that ever applies.
+//
+// It reads only the leading global flags, so a value that happens to spell one
+// (bitrise build trigger --commit-message --no-color) and anything past the
+// command token are left alone. The config file's theme is not available this
+// early -- resolving it needs configs.ResolveConfig, which runs in before()
+// and can itself fail -- so only the flag and its env var are consulted.
+func configureStyleFromArgs(root *cobra.Command, arguments []string) {
+	values := cmdutil.GlobalFlagValuesFromArgs(root.PersistentFlags(), arguments, cmdutil.GlobalFlagNames)
+
+	noColor, _ := strconv.ParseBool(values[cmdutil.FlagNoColor])
+	theme, err := style.ParseTheme(config.FirstNonEmptyString(values[cmdutil.FlagTheme], os.Getenv(cmdutil.EnvTheme)))
+	if err != nil {
+		theme = style.ThemeAuto
+	}
+	style.Configure(noColor, theme)
 }
 
 // initLogger sets up the global logger up front, before cobra parses the args,

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"os"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -9,6 +10,7 @@ import (
 
 	"github.com/bitrise-io/bitrise/v2/cli/cmdutil"
 	internalconfig "github.com/bitrise-io/bitrise/v2/internal/config"
+	"github.com/bitrise-io/bitrise/v2/internal/style"
 	"github.com/bitrise-io/bitrise/v2/log"
 	"github.com/bitrise-io/bitrise/v2/output"
 )
@@ -491,6 +493,69 @@ func Test_flagShorthands_doNotCollideAcrossTree(t *testing.T) {
 // Test_rejectSingleDashLongFlags_realCommandTree exercises the guard against
 // the actual registered commands, not a synthetic tree, so it catches a
 // flag/shorthand that changes shape only in cli/root.go or cli/local/run.go.
+func Test_configureStyleFromArgs(t *testing.T) {
+	// Asserted on the values the pre-pass reads rather than on rendered
+	// output: style.New over a *bytes.Buffer is ANSI-free whatever Configure
+	// was given (see internal/style's TestNew_NonTTYWriterIsAnsiFree), so
+	// rendering here would pass no matter what these args parsed to.
+	tests := []struct {
+		name                               string
+		args                               []string
+		wantNoColor, wantTheme, wantOutput string
+	}{
+		{name: "no flags", args: []string{"run", "wf"}},
+		{name: "theme with a space", args: []string{"--theme", "none", "run"}, wantTheme: "none"},
+		{name: "theme attached", args: []string{"--theme=none", "run"}, wantTheme: "none"},
+		{name: "no-color bare", args: []string{"--no-color", "run"}, wantNoColor: "true"},
+		{name: "no-color explicitly false", args: []string{"--no-color=false", "run"}, wantNoColor: "false"},
+		{name: "both, clustered", args: []string{"-qo", "json", "run"}, wantOutput: "json"},
+
+		// An unparseable theme is still read here; configureStyleFromArgs
+		// falls back to auto when style.ParseTheme rejects it.
+		{name: "invalid theme value", args: []string{"--theme", "bogus", "run"}, wantTheme: "bogus"},
+
+		// Everything from the command token on belongs to the command, and a
+		// global's own value is consumed rather than rescanned.
+		{name: "value of another global is not a flag", args: []string{"--output", "--no-color", "run"}, wantOutput: "--no-color"},
+		{name: "trailing theme after the command token", args: []string{"run", "--theme"}},
+		{name: "flag value after the command token", args: []string{"build", "trigger", "--commit-message", "--no-color"}},
+		{name: "after the terminator", args: []string{"run", "--", "--no-color"}},
+		{name: "plugin passthrough args", args: []string{":myplugin", "--no-color"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv(cmdutil.EnvTheme, "")
+			t.Cleanup(func() { style.Configure(false, style.ThemeAuto) })
+
+			values := cmdutil.GlobalFlagValuesFromArgs(newRootCommand().PersistentFlags(), tt.args, cmdutil.GlobalFlagNames)
+			assert.Equal(t, tt.wantNoColor, values[cmdutil.FlagNoColor])
+			assert.Equal(t, tt.wantTheme, values[cmdutil.FlagTheme])
+			assert.Equal(t, tt.wantOutput, values[cmdutil.FlagOutput])
+
+			configureStyleFromArgs(newRootCommand(), tt.args)
+		})
+	}
+}
+
+// Test_configureStyleFromArgs_envFallback pins the layer below the flag: the
+// three Failf calls inside before() fire before it re-applies style from the
+// resolved config, so an env-set theme has to reach the early pass or those
+// errors ignore it.
+func Test_configureStyleFromArgs_envFallback(t *testing.T) {
+	t.Setenv(cmdutil.EnvTheme, "none")
+	t.Cleanup(func() { style.Configure(false, style.ThemeAuto) })
+
+	// No --theme flag, so the env value is what the early pass must use.
+	values := cmdutil.GlobalFlagValuesFromArgs(newRootCommand().PersistentFlags(), []string{"run"}, cmdutil.GlobalFlagNames)
+	assert.Empty(t, values[cmdutil.FlagTheme])
+
+	theme, err := style.ParseTheme(internalconfig.FirstNonEmptyString(values[cmdutil.FlagTheme], os.Getenv(cmdutil.EnvTheme)))
+	require.NoError(t, err)
+	assert.Equal(t, style.ThemeNone, theme)
+
+	configureStyleFromArgs(newRootCommand(), []string{"run"})
+}
+
 func Test_rejectSingleDashLongFlags_realCommandTree(t *testing.T) {
 	tests := []struct {
 		name         string

--- a/cli/cmdutil/args.go
+++ b/cli/cmdutil/args.go
@@ -36,6 +36,27 @@ func CommandTokenIndex(fs *pflag.FlagSet, args []string, globalFlagNames []strin
 // command token) are bitrise globals; anything after belongs to the passthrough.
 func ApplyGlobalFlagsFromArgs(root *cobra.Command, args []string, globalFlagNames []string) {
 	fs := root.PersistentFlags()
+	walkLeadingGlobals(fs, args, globalFlagNames, func(a globalFlagAssignment) {
+		_ = fs.Set(a.name, a.value)
+	})
+}
+
+// GlobalFlagValuesFromArgs returns the values the leading global flags in args
+// assign, keyed by flag name. It reads the same tokens ApplyGlobalFlagsFromArgs
+// would set, without touching the command — for callers that need a global's
+// value before cobra has parsed anything.
+func GlobalFlagValuesFromArgs(fs *pflag.FlagSet, args, globalFlagNames []string) map[string]string {
+	values := map[string]string{}
+	walkLeadingGlobals(fs, args, globalFlagNames, func(a globalFlagAssignment) {
+		values[a.name] = a.value
+	})
+	return values
+}
+
+// walkLeadingGlobals reports every assignment the global flags before the
+// command token make. Both callers above need the same walk and differ only in
+// what they do with each assignment.
+func walkLeadingGlobals(fs *pflag.FlagSet, args, globalFlagNames []string, apply func(globalFlagAssignment)) {
 	boundary := CommandTokenIndex(fs, args, globalFlagNames)
 	for i := 0; i < boundary; {
 		assignments, consumed := matchGlobalFlags(fs, args[i:boundary], globalFlagNames)
@@ -43,7 +64,7 @@ func ApplyGlobalFlagsFromArgs(root *cobra.Command, args []string, globalFlagName
 			break // unreachable within the boundary, but keeps the loop well-defined
 		}
 		for _, a := range assignments {
-			_ = fs.Set(a.name, a.value)
+			apply(a)
 		}
 		i += consumed
 	}

--- a/cli/cmdutil/failf.go
+++ b/cli/cmdutil/failf.go
@@ -13,8 +13,13 @@ import (
 // output (e.g. `stack list -o json | jq`), and re-pointing the global logger
 // would also move `bitrise run`'s step output to stderr with it.
 func Failf(format string, args ...interface{}) {
-	s := style.New(os.Stderr)
-	_, _ = fmt.Fprintf(os.Stderr, "%s %s\n", s.Failure.Render("Error:"), fmt.Sprintf(format, args...))
+	// The root command prints help and returns an empty error purely to exit
+	// non-zero, so an empty message means there is nothing to report — a bare
+	// "Error:" after successful help output reads as a bug.
+	if msg := fmt.Sprintf(format, args...); msg != "" {
+		s := style.New(os.Stderr)
+		_, _ = fmt.Fprintf(os.Stderr, "%s %s\n", s.Failure.Render("Error:"), msg)
+	}
 
 	if globalTracker != nil {
 		globalTracker.Wait()

--- a/cli/cmdutil/failf.go
+++ b/cli/cmdutil/failf.go
@@ -1,14 +1,21 @@
 package cmdutil
 
 import (
+	"fmt"
 	"os"
 
-	"github.com/bitrise-io/bitrise/v2/log"
+	"github.com/bitrise-io/bitrise/v2/internal/style"
 )
 
-// Failf ...
+// Failf prints a formatted error to stderr and exits the process with status
+// 1. It must not go through the global logger (log.Errorf): that logger's
+// writer is stdout, which would leak the error into piped machine-readable
+// output (e.g. `stack list -o json | jq`), and re-pointing the global logger
+// would also move `bitrise run`'s step output to stderr with it.
 func Failf(format string, args ...interface{}) {
-	log.Errorf(format, args...)
+	s := style.New(os.Stderr)
+	_, _ = fmt.Fprintf(os.Stderr, "%s %s\n", s.Failure.Render("Error:"), fmt.Sprintf(format, args...))
+
 	if globalTracker != nil {
 		globalTracker.Wait()
 	}


### PR DESCRIPTION
Failf routed through the global logger, whose writer is stdout, so a failing command emitted an ANSI-colored error onto stdout alongside (or instead of) its data, breaking every --format json consumer piped into another tool. Errors now go to stderr.
 
 Two adjacent fixes: the root command printing help and returning an empty error just to exit non-zero no longer prints a bare Error:  label under it. And --no-color/--theme/NO_COLOR are now read before cobra's own flag and argument parsing can fail — cobra returns those errors ahead of the PersistentPreRunE hook that used to apply styling, so the most common error class (bad flags, unknown subcommands) was ignoring --no-color entirely.
