### PR TITLE
v3 cleanup 7 - Fix rde session exec dialling the wrong SSH port

### DIFF
--- a/internal/rde/exec_ssh.go
+++ b/internal/rde/exec_ssh.go
@@ -806,8 +806,13 @@ func sshTargetForSession(sess Session) (sshTarget, error) {
 }
 
 // parseSSHAddress extracts user, host, and port from a backend-provided
-// ssh_address, which may be a full ssh command (`ssh [options] user@host`), a
-// bare `user@host[:port]`, or an `ssh://user@host[:port]` URI.
+// ssh_address, which may be a full ssh command (`ssh [options] user@host
+// [options]`), a bare `user@host[:port]`, or an `ssh://user@host[:port]` URI.
+//
+// Options are accepted on both sides of the destination: the RDE backend emits
+// `ssh ubuntu@host -p 26238`, with the port after it. Scanning only up to the
+// destination dropped that `-p` and silently dialled 22, which made every
+// session unreachable.
 //
 // The address is tokenized rather than pattern-matched across the whole string,
 // because regex scanning silently produced wrong targets: an unanchored
@@ -827,16 +832,22 @@ func parseSSHAddress(addr string) (sshTarget, error) {
 	optPort := 0
 	for i := 0; i < len(fields); i++ {
 		f := fields[i]
-		if f == "ssh" {
+		if f == "ssh" && target == "" {
 			continue
 		}
-		if !strings.HasPrefix(f, "-") {
-			// In OpenSSH syntax the destination is the FIRST operand and
-			// everything after it is the remote command, so scanning stops
-			// here — otherwise `ssh u@host -- echo user@evil` would retarget
-			// the dial at whatever the command mentions.
-			target = f
+		if f == "--" {
 			break
+		}
+		if !strings.HasPrefix(f, "-") {
+			if target != "" {
+				// The destination is the FIRST operand; a second one starts
+				// the remote command, so scanning stops here — otherwise
+				// `ssh u@host echo user@evil` would retarget the dial at
+				// whatever the command mentions.
+				break
+			}
+			target = f
+			continue
 		}
 
 		// Walk the option cluster so `-p 22`, `-p22` and `-tp 22` all resolve;

--- a/internal/rde/exec_ssh_address_test.go
+++ b/internal/rde/exec_ssh_address_test.go
@@ -43,11 +43,22 @@ func TestParseSSHAddress(t *testing.T) {
 		{name: "option argument is not the destination", addr: "ssh -o ProxyJump=jump@bastion ubuntu@h.example", wantUser: "ubuntu", wantHost: "h.example", wantPort: 22},
 		{name: "attached option argument is not the destination", addr: "ssh -oProxyJump=jump@bastion ubuntu@h.example", wantUser: "ubuntu", wantHost: "h.example", wantPort: 22},
 
-		// The destination is the first operand; the rest is the remote command,
-		// so an "@" appearing in it must not retarget the dial.
+		// The destination is the first operand; a second operand starts the
+		// remote command, so an "@" appearing in it must not retarget the dial.
 		{name: "remote command after the destination is ignored", addr: "ssh vagrant@host.example -- echo user@evil", wantUser: "vagrant", wantHost: "host.example", wantPort: 22},
 		{name: "trailing operand is not the destination", addr: "ssh -p 2222 vagrant@h extra@operand", wantUser: "vagrant", wantHost: "h", wantPort: 2222},
-		{name: "option-looking token after the destination is remote command, not an option", addr: "ssh u@h -p", wantUser: "u", wantHost: "h", wantPort: 22},
+
+		// The RDE backend emits the port after the destination; parsing only up
+		// to the destination dropped it and dialled 22, making every session
+		// unreachable.
+		{name: "backend format, -p after the destination", addr: "ssh ubuntu@vm-host.example -p 26238", wantUser: "ubuntu", wantHost: "vm-host.example", wantPort: 26238},
+		{name: "attached -p after the destination", addr: "ssh u@h -p2222", wantUser: "u", wantHost: "h", wantPort: 2222},
+
+		// ...but only up to the remote command, so a command's own flags are
+		// never mistaken for ssh options.
+		{name: "flags belonging to the remote command are not ssh options", addr: "ssh u@h somecmd -p 80", wantUser: "u", wantHost: "h", wantPort: 22},
+		{name: "flags after -- are not ssh options", addr: "ssh u@h -- -p 80", wantUser: "u", wantHost: "h", wantPort: 22},
+		{name: "-p after the destination missing its argument", addr: "ssh u@h -p", wantError: true},
 
 		// Clustered short flags: the first letter taking an argument consumes
 		// the remainder of the token, or the next one.

--- a/internal/rde/exec_ssh_address_test.go
+++ b/internal/rde/exec_ssh_address_test.go
@@ -60,6 +60,17 @@ func TestParseSSHAddress(t *testing.T) {
 		{name: "flags after -- are not ssh options", addr: "ssh u@h -- -p 80", wantUser: "u", wantHost: "h", wantPort: 22},
 		{name: "-p after the destination missing its argument", addr: "ssh u@h -p", wantError: true},
 
+		// Scanning past the destination means the literal "ssh" is only a
+		// no-op token before one is found; after it, it starts the remote
+		// command, so a -p belonging to that command must not set the port.
+		{name: "remote command named ssh does not reopen option scanning", addr: "ssh u@h ssh -p 9999", wantUser: "u", wantHost: "h", wantPort: 22},
+
+		// Post-destination equivalents of the pre-destination error cases, now
+		// that options are accepted on both sides.
+		{name: "conflicting ports with -p after the destination", addr: "ssh u@h:2223 -p 2222", wantError: true},
+		{name: "out of range port after the destination", addr: "ssh u@h -p 99999", wantError: true},
+		{name: "clustered flags after the destination", addr: "ssh u@h -tp 2222", wantUser: "u", wantHost: "h", wantPort: 2222},
+
 		// Clustered short flags: the first letter taking an argument consumes
 		// the remainder of the token, or the next one.
 		{name: "clustered flags with separate port", addr: "ssh -tp 2222 u@h", wantUser: "u", wantHost: "h", wantPort: 2222},


### PR DESCRIPTION
 rde session exec couldn't connect to any RDE session — every dial went to port 22. parseSSHAddress stopped scanning for ssh options once it hit the destination, but the backend's ssh_address puts the port after it (ssh ubuntu@host -p 26238), so -p was never read.
  This broke Execute, ExecuteInteractive, and the Claude host bridge against production.
 
 Scanning now continues past the destination, stopping at -- or a second operand, so a remote command's own flags still can't be mistaken for ssh options. The predecessor CLI's unanchored regex handled this correctly; the tokenizer that replaced it fixed two real regex weaknesses (a -p matching inside another option's argument, IPv6 hosts truncating at the first colon) but was never tested against the backend's actual format. Added boundary tests for both sides of the destination, including a remote command literally named ssh.
