### PR TITLE
v3: cleanup

### DIFF
--- a/_docs/v3-breaking-changes.md
+++ b/_docs/v3-breaking-changes.md
@@ -8,70 +8,83 @@ This document tracks the user-visible breaking changes introduced for the **v3**
 major release. v3 merges the cloud resource-management commands into the existing
 CLI.
 
-Append new breaking changes here as later v3 steps land. List each change with
-what changed, the impact, and how to migrate.
+**Audience: existing Bitrise CLI v2 users.** Every entry describes a change against
+v2 behavior. Commands that are new in v3 are not covered here.
 
-## Legacy (urfave → cobra) cleanup
-
-The v2 line migrated the CLI from `urfave/cli` to `cobra` while preserving the old
-surface behind compatibility shims. v3 removes those shims and adopts cobra's
-native behavior.
+## Command-line behavior
 
 ### Argument parsing
 
-- **Single-dash long flags are no longer accepted.** `urfave` treated `-config`
-  and `--config` as equivalent; cobra/pflag treat a single dash as shorthand flags.
-  So `-workflow` is now rejected (`unknown shorthand flag: 'w' in -workflow`), and —
-  worse — `-config x` is silently parsed as the `-c` shorthand with value `onfig`
-  (not `--config x`). Always use the double-dash form for long flags:
-  `bitrise run -config bitrise.yml` → `bitrise run --config bitrise.yml`. Short flags
+- **Single-dash long flags are no longer accepted.** v2 treated `-config` and
+  `--config` as the same flag. A single dash now introduces short flags only, so
+  `-config x` would otherwise be read as `-c` with the value `onfig`. Rather than
+  misread it, the CLI rejects any single-dash spelling of a long flag:
+  `bitrise run -config bitrise.yml` →
+  `Error: unknown flag: -config (did you mean --config?)`, exit 1. Short flags
   (e.g. `-c`, `-i`) are unaffected.
   *Migrate:* update scripts/CI invocations to use `--<flag>` for long flag names.
 - **Unknown flags are now rejected.** Previously an unrecognized flag that followed
   a positional argument was silently ignored (e.g. `bitrise run wf --bogus` still
   ran the workflow). It now produces an error.
 - **Unknown commands now produce a concise error.** `bitrise notacommand` prints
-  cobra's `unknown command "notacommand" for "bitrise"` error (and exits 1) instead
-  of printing the full help text.
+  `unknown command "notacommand" for "bitrise"` and exits 1, instead of printing
+  the full help text.
+
+### Error output
+
+- **Errors now go to stderr, not stdout.** In v2 every fatal error was printed to
+  stdout, mixed into whatever the command was producing. v3 writes them to stderr
+  as `Error: <message>`. The exit code is unchanged (1).
+  *Migrate:* capture stderr wherever a script reads the failure reason; a
+  stdout-only capture now comes back empty on failure.
+- **Under `run --output-format json`, fatal errors are no longer JSON.** They used to
+  be printed to stdout as a JSON log line like every other message; they are now the
+  same plain `Error: …` line on stderr. This covers errors that abort the command —
+  bad arguments, no workflow specified, setup failures. A workflow that runs and
+  *fails* is unaffected: its log output is still JSON on stdout, and it still exits
+  with the build's exit code.
+  *Migrate:* read stderr for the abort reason, or key off the exit code.
+- **A bare `bitrise` no longer prints an empty `Error:` line** below its help output.
 
 ### Help and version output
 
-- **Root `--help` uses cobra's native layout.** The previous urfave-style
+- **`bitrise --help` has a new layout.** The previous
   `NAME / USAGE / VERSION / GLOBAL OPTIONS / COMMANDS / PLUGINS` layout is gone.
-  Installed plugins are still listed (in a `Plugins:` section appended to the help),
-  but the `[$ENV]` env-binding hints next to global flags are no longer shown.
+  Installed plugins are still listed, in a `Plugins:` section appended to the help,
+  but the `[$ENV]` hints next to global flags are no longer shown.
 
 ### Command listing and completion
 
-- **Commands and flags are listed alphabetically** in help output (previously in
-  declaration order).
-- **A `completion` command is now available** (cobra's shell-completion generator),
-  e.g. `bitrise completion bash`.
+- **Commands and flags are listed alphabetically** in help output. v2 listed them
+  in a fixed, hand-picked order.
+- **A `completion` command is now available** for generating shell-completion
+  scripts, e.g. `bitrise completion bash`.
 
 ### Environment variable handling
 
-Env-var reading for the bool "mode" flags was unified into one consistent rule:
-**explicit flag > bound env var (parsed with `strconv.ParseBool`) > inventory-based
-default**. A non-bool env value is now an error.
+Reading the boolean "mode" flags from environment variables was unified into one
+rule: **explicit flag > environment variable > inventory-based default**. The
+accepted values are `1`, `t`, `T`, `true`, `TRUE`, `True` and their false
+counterparts (`0`, `f`, `F`, `false`, `FALSE`, `False`); anything else is now an
+error.
 
-- **`run --secret-filtering` is now bound to `$BITRISE_SECRET_FILTERING`** and
-  validated like `trigger --secret-filtering`: the env value is parsed with
-  `ParseBool`, a non-bool value errors, and the flag is reported to analytics when
-  sourced from the env. Previously `run` matched the env literally (`"true"`/`"false"`
-  only), ignored other values, and never reported it as set from the env.
-- **`$BITRISE_SECRET_ENVS_FILTERING` is now parsed with `ParseBool`** (e.g. `1`/`0`
-  are now accepted) and a non-bool value errors, instead of being matched literally.
-- **`$CI` and `$DEBUG` parsing accepts all `ParseBool` spellings** (e.g. `DEBUG=1`
-  now enables debug mode). Non-bool values for these already errored and still do.
-- An empty value for any of these env vars is treated as unset (the CLI falls back
-  to the inventory-based default) rather than as `false`.
+- **`run --secret-filtering` now reads `$BITRISE_SECRET_FILTERING`**, the way
+  `trigger --secret-filtering` always did: any accepted spelling works, a
+  non-boolean value errors, and the flag is reported to analytics when it came from
+  the environment. Previously `run` matched the value literally (`"true"`/`"false"`
+  only), ignored anything else, and never reported it as set from the environment.
+- **`$BITRISE_SECRET_ENVS_FILTERING` accepts every boolean spelling** (e.g. `1`/`0`
+  now work) and errors on a non-boolean value, instead of being matched literally.
+- **`$CI` and `$DEBUG` accept every boolean spelling** (e.g. `DEBUG=1` now enables
+  debug mode). Non-boolean values for these already errored and still do.
+- An empty value for any of these variables is treated as unset — the CLI falls back
+  to the inventory-based default rather than to `false`.
 
 ## Command reorganization
 
 The commands were regrouped by use case under `local`, `yml`, and `step` parent
 commands. The old top-level names continue to work as hidden aliases, so existing
-scripts keep running: `trigger-check` was the only command removed outright, and
-`validate` the only one whose behavior changed.
+scripts keep running; `trigger-check` is the only command removed outright.
 
 ### `trigger-check` removed
 
@@ -107,6 +120,17 @@ scripts keep running: `trigger-check` was the only command removed outright, and
   *Migrate:* no action required for existing scripts. New usage and documentation
   should prefer the grouped paths.
 
+### Plugins named like a new command need the colon prefix
+
+- **A plugin whose name collides with a command is no longer reachable without `:`.**
+  A plugin is only looked up when the first word isn't a known command, so the
+  commands added in v3 now shadow same-named plugins: `bitrise step …` runs the built-in
+  `step` command instead of the bundled `:step` plugin. The same applies to any plugin
+  named `app`, `build`, `auth`, `stack`, `user`, `config`, `api`, `rde`, `yml` or
+  `local`.
+  *Migrate:* use the colon syntax — `bitrise :step …` — which has always worked and is
+  unaffected.
+
 ### `yml validate` updated
 
 - **`validate` now validates online when you're authenticated, instead of locally.**
@@ -118,7 +142,8 @@ scripts keep running: `trigger-check` was the only command removed outright, and
   the old top-level `bitrise validate` is an alias of this command, existing invocations
   change behavior as soon as a token is present — including picking up any difference
   between the server's messages and the local ones. When validation happens online the
-  command says so on stderr and names the escape hatch, and the result gains a `source`
+  command says so on stderr and tells you how to force the local check, and the
+  result gains a `source`
   field under `--format json`; a local result carries no marker and its output on
   stdout is unchanged from v2. Two flags control it, and they cannot be combined:
   the new `--offline` forces the local-only check, and the optional `--app` (or
@@ -126,29 +151,32 @@ scripts keep running: `trigger-check` was the only command removed outright, and
   pools).
   *Migrate:* pass `--offline` anywhere you depend on local validation or on its exact
   output — in particular scripts and tests that assert on validation messages.
+- **An unsupported `format_version` no longer fails validation online.** v2 rejected a
+  `bitrise.yml` whose `format_version` is newer than the CLI supports — `is_valid:
+  false`, a hard error, exit 1. On the online path that check is now only a warning,
+  and `is_valid` follows whatever the API reports, so the same file validates clean
+  and exits 0. Since a build normally has a token, this is the common case in CI.
+  `--offline` still fails it exactly as v2 did.
+  *Migrate:* pass `--offline` wherever validation is meant to gate on the running CLI
+  being new enough for the config.
+- **Inside a Bitrise build, `bitrise validate` now runs app-specific checks.**
+  `$BITRISE_APP_SLUG` is injected into every build and is now read as an app-ID
+  fallback, so an authenticated `bitrise validate` with no app named validates against
+  the app the build runs for. That adds the API's app-specific checks — stacks, machine
+  types, license pools — which previously ran for nobody, so a config that validated
+  cleanly before can now report app-specific errors. `--offline` is unaffected: it
+  skips the online path, and an app ID picked up from the environment stays ignored
+  there.
+  *Migrate:* pass `--offline`, or unset `BITRISE_APP_SLUG` for the invocation, to
+  restore the previous behavior.
+- **`validate --format yml` now works.** v2's help advertised "Accepted: json, yml"
+  but the command rejected anything other than `raw` and `json`, exiting 1 with
+  `Invalid format: yml`. It now renders the result as YAML. With no `--format`, the
+  command follows the new global `--output` / `$BITRISE_OUTPUT` / `output` config key
+  — all unset by default, so nothing changes unless you opt in.
 
 ## Config handling
 
-- **Inside a Bitrise build, cloud commands with no `--app` now target the app the build
-  runs for.** `$BITRISE_APP_SLUG` and `$BITRISE_WORKSPACE_ID` are injected into every
-  build, and both are now read as identity fallbacks: `app_id` resolves as `--app` >
-  `$BITRISE_APP_ID` > `$BITRISE_APP_SLUG` > per-directory file > global file, and
-  `default_workspace_id` the same way via `--workspace` and `$BITRISE_WORKSPACE_ID`.
-  So a build step running `bitrise yml get` or `bitrise yml update` without `--app` no
-  longer fails with `--app is required` — it acts on the host app, and for `yml update`
-  that means overwriting that app's own stored bitrise.yml. `bitrise yml validate` never
-  required `--app`, but it now picks the host app up on its own, so a build step that
-  validates online runs the app-specific checks (stacks, machine types, license pools)
-  that previously ran only when `--app` was passed explicitly — a config that validated
-  cleanly before can now report app-specific errors. `--offline` is unaffected: it skips
-  the online path, and an ambient app ID stays ignored there. Note the env var also
-  outranks an `app_id` pinned in a `.bitrise-cli.yml`. `bitrise stack list` picks up
-  `$BITRISE_WORKSPACE_ID` the same way: without `--workspace`, a build step now returns
-  the host workspace's stacks, including any custom stacks configured for it, where it
-  previously always returned the global list. *Migrate:* pass `--app`/`--workspace`
-  explicitly in any build step that targets a different app or workspace than the one
-  it runs in; unset `BITRISE_APP_SLUG`/`BITRISE_WORKSPACE_ID` for the invocation to
-  restore the previous behavior.
 - **Two new config file locations are now read, layered under the existing one.**
   Besides the pre-existing `~/.bitrise/config.json`, the CLI now also reads a global
   `~/.config/bitrise/cli/config.yml` and a per-directory `.bitrise-cli.yml` (found by
@@ -159,26 +187,25 @@ scripts keep running: `trigger-check` was the only command removed outright, and
   one. *Migrate:* no action required. To have a value controlled by the new
   per-directory or global file instead, remove that value from
   `~/.bitrise/config.json`.
-- **`api_base_url` and `web_base_url` never come from the per-directory file.** These
-  two keys — new in v3, managed with `bitrise config get/set/unset/list` and stored in
-  the global `~/.config/bitrise/cli/config.yml` — are the one exception to the
-  precedence above: they are only ever read from the global file. Both carry
-  credentials (a bearer token, a login password) to whatever host they name, and
-  `.bitrise-cli.yml` is picked up from the working directory and its ancestors with no
-  confirmation, so a repo you merely clone and run `bitrise` inside of must not be able
-  to redirect them. `web_base_url` is additionally overridable via
-  `$BITRISE_WEB_BASE_URL`, which wins over the global file. *Migrate:* set these keys
-  with `bitrise config set` or the env var — either key in a `.bitrise-cli.yml` is
-  ignored.
 - **`setup`/CLI-update-check/plugin-update-check now also write `config.yml`.** If you
   already have `~/.bitrise/config.json`, it keeps being updated exactly as before (still
   authoritative for reads), and `~/.config/bitrise/cli/config.yml` is kept in sync
   alongside it. If you don't have a legacy file, one is no longer created — these
   commands now write only the new `config.yml`. *Migrate:* no action required.
-- **A missing/unwritable `~/.config` directory can now fail `setup` and every
-  plugin invocation.** If `~/.config/bitrise/cli/config.yml` can't be written
-  (e.g. a CI container where `~/.bitrise` is writable but `~/.config` isn't),
-  `bitrise setup` reports failure even though setup itself succeeded, and any
-  `bitrise <plugin>` invocation aborts before running the plugin. *Migrate:*
-  ensure `~/.config` (or `$XDG_CONFIG_HOME`) is writable wherever `setup` or
-  plugins run.
+- **An unwritable `~/.config` directory can now fail `setup` and plugin invocations.**
+  A *missing* directory is fine — it's created, at any depth. An unwritable one only
+  matters if you have no `~/.bitrise/config.json` yet: when that legacy file exists it
+  stays authoritative and a failed `config.yml` write is downgraded to a warning.
+  Without it, `bitrise setup` reports failure even though setup itself succeeded, and
+  a `bitrise <plugin>` invocation aborts before running the plugin — on the runs where
+  that plugin's update check is due. *Migrate:* ensure `~/.config` (or
+  `$XDG_CONFIG_HOME`) is writable wherever `setup` or plugins run.
+
+## Telemetry
+
+- **`ANALYTICS_DISABLED=true` now disables analytics as well.** v2 honored only
+  `BITRISE_ANALYTICS_DISABLED`; both names work now. A side effect is visible on
+  stdout: `bitrise run` stops printing its "Bitrise collects anonymous usage stats…"
+  notice for anyone who had the unprefixed variable set. *Migrate:* no action
+  required; unset `ANALYTICS_DISABLED` if you were relying on Bitrise analytics
+  staying on while another tool's were off.

--- a/cli/app/create.go
+++ b/cli/app/create.go
@@ -117,14 +117,17 @@ func runCreate(cmd *cobra.Command, detector internalapp.GitDetector, flags creat
 		return err
 	}
 
+	client, err := cmdutil.NewAPIClient(cmd)
+	if err != nil {
+		return err
+	}
+
 	// --workspace wins; otherwise fall back to BITRISE_WORKSPACE_ID /
 	// default_workspace_id. Still empty means Service.Create auto-detects,
 	// which only succeeds when the account has exactly one workspace.
-	resolvedWorkspace := flags.workspace
-	workspaceFromDefault := false
-	if resolvedWorkspace == "" {
-		resolvedWorkspace = cmdutil.DefaultWorkspaceSlug(cmd)
-		workspaceFromDefault = resolvedWorkspace != ""
+	resolvedWorkspace, workspaceFromDefault, err := cmdutil.ResolveAndLookupWorkspaceSlug(cmd, client, flags.workspace)
+	if err != nil {
+		return err
 	}
 
 	stderr := cmd.ErrOrStderr()
@@ -154,11 +157,6 @@ func runCreate(cmd *cobra.Command, detector internalapp.GitDetector, flags creat
 			}
 			fmt.Fprintf(stderr, "No bitrise.yml provided — using server preset for project-type=%s\n", presetProjectType)
 		}
-	}
-
-	client, err := cmdutil.NewAPIClient(cmd)
-	if err != nil {
-		return err
 	}
 
 	res, err := internalapp.NewService(client).Create(ctx, internalapp.CreateOptions{

--- a/cli/app/create_test.go
+++ b/cli/app/create_test.go
@@ -193,7 +193,7 @@ func TestCreateCmd_UsesDefaultWorkspaceFromConfig(t *testing.T) {
 	t.Setenv(cmdutil.EnvWorkspaceID, "")
 	api := newStubAPI(t)
 	api.handle("/organizations", func(w http.ResponseWriter, _ *http.Request) {
-		t.Error("auto-detect must not run when default_workspace_id is set")
+		t.Error("default_workspace_id is already a canonical slug and must not be resolved by name")
 		_, _ = io.WriteString(w, `{"data":[]}`)
 	})
 	api.handle("/apps/register", func(w http.ResponseWriter, _ *http.Request) {
@@ -213,6 +213,31 @@ func TestCreateCmd_UsesDefaultWorkspaceFromConfig(t *testing.T) {
 	require.NoError(t, json.Unmarshal(api.bodies["/apps/register"], &reg))
 	assert.Equal(t, "cfg-ws", reg["organization_slug"])
 	assert.Contains(t, errOut.String(), "Using default workspace: cfg-ws")
+}
+
+func TestCreateCmd_WorkspaceNameResolvesToSlug(t *testing.T) {
+	api := newStubAPI(t)
+	api.handle("/organizations", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `{"data":[{"slug":"acme","name":"Acme Corp"}]}`)
+	})
+	api.handle("/apps/register", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `{"slug":"new-app"}`)
+	})
+	api.handle("/apps/new-app/finish", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `{"build_trigger_token":"btt","branch_name":"main"}`)
+	})
+
+	cmd, _, _ := newTestCreateCmd(t, api.baseURL)
+	require.NoError(t, runCreate(cmd, noCallDetector{t: t}, createFlags{
+		repoURL:   "https://github.com/acme/widget.git",
+		branch:    "main",
+		title:     "Widget",
+		workspace: "Acme Corp",
+	}))
+
+	var reg map[string]any
+	require.NoError(t, json.Unmarshal(api.bodies["/apps/register"], &reg))
+	assert.Equal(t, "acme", reg["organization_slug"])
 }
 
 func TestCreateCmd_WorkspaceFlagWinsOverDefault(t *testing.T) {
@@ -334,6 +359,13 @@ type stubAPI struct {
 func newStubAPI(t *testing.T) *stubAPI {
 	t.Helper()
 	s := &stubAPI{registry: map[string]http.HandlerFunc{}, bodies: map[string][]byte{}}
+	// Every workspace value now goes through the workspace name resolver,
+	// which calls GET /organizations. Default to zero matches (the resolved
+	// value passes through as a literal slug); tests exercising org lookup
+	// itself override this via api.handle("/organizations", ...).
+	s.registry["/organizations"] = func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `{"data":[]}`)
+	}
 	srv := newFakeServer(t, func(w http.ResponseWriter, r *http.Request) {
 		body, _ := io.ReadAll(r.Body)
 		s.bodies[r.URL.Path] = body

--- a/cli/app/list.go
+++ b/cli/app/list.go
@@ -17,18 +17,28 @@ import (
 // NewListCommand returns the `app list` subcommand.
 func NewListCommand() *cobra.Command {
 	var (
-		limit       int
-		cursor      string
-		sortBy      string
-		title       string
-		projectType string
-		fetchAll    bool
+		limit         int
+		cursor        string
+		sortBy        string
+		title         string
+		projectType   string
+		fetchAll      bool
+		workspaceSlug string
 	)
 
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List apps the authenticated user can access",
 		Long: `List all apps the authenticated user can access.
+
+Workspace, highest to lowest:
+  --workspace WORKSPACE_ID
+  $BITRISE_WORKSPACE_ID (injected inside a Bitrise build)
+  the default_workspace_id config key ('bitrise config set')
+
+When a workspace resolves, only apps owned by that workspace are returned.
+Otherwise every app the authenticated user can access, across all
+workspaces, is returned.
 
 Filters:
   --title TITLE          filter apps by title
@@ -43,6 +53,7 @@ Pagination:
 In JSON mode (--format json), next_cursor holds the cursor value for scripting:
   bitrise app list --format json | jq -r '.next_cursor'`,
 		Example: `  bitrise app list
+  bitrise app list --workspace acme
   bitrise app list --all
   bitrise app list --format json | jq -r '.next_cursor'
   bitrise app list --project-type ios --limit 100`,
@@ -65,6 +76,14 @@ In JSON mode (--format json), next_cursor holds the cursor value for scripting:
 			}
 			svc := internalapp.NewService(client)
 
+			resolvedWorkspace, workspaceFromDefault, err := cmdutil.ResolveAndLookupWorkspaceSlug(cmd, client, workspaceSlug)
+			if err != nil {
+				return err
+			}
+			if workspaceFromDefault && output.Format == output.FormatRaw {
+				fmt.Fprintf(cmd.ErrOrStderr(), "Using default workspace: %s\n", resolvedWorkspace)
+			}
+
 			makeOpts := func(cur string) internalapp.ListOptions {
 				return internalapp.ListOptions{
 					Limit:       limit,
@@ -72,6 +91,7 @@ In JSON mode (--format json), next_cursor holds the cursor value for scripting:
 					SortBy:      sortBy,
 					Title:       title,
 					ProjectType: projectType,
+					OrgSlug:     resolvedWorkspace,
 				}
 			}
 
@@ -115,6 +135,7 @@ In JSON mode (--format json), next_cursor holds the cursor value for scripting:
 	cmd.Flags().StringVar(&sortBy, "sort-by", "", "ordering accepted by the API (created_at, last_build_at)")
 	cmd.Flags().StringVar(&title, "title", "", "filter apps by title")
 	cmd.Flags().StringVar(&projectType, "project-type", "", "filter by project type (ios, android, ...)")
+	cmd.Flags().StringVar(&workspaceSlug, cmdutil.FlagWorkspace, "", "only list apps owned by this workspace, or set BITRISE_WORKSPACE_ID / default_workspace_id")
 	cmd.Flags().StringP(cmdutil.FormatKey, "f", "", "Output format. Accepted: raw (default), json, yml")
 
 	_ = cmd.RegisterFlagCompletionFunc("sort-by", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
@@ -133,7 +154,7 @@ In JSON mode (--format json), next_cursor holds the cursor value for scripting:
 func nextPageCmd(cmd *cobra.Command) func(nextCursor string) string {
 	return func(nextCursor string) string {
 		parts := []string{"bitrise app list"}
-		for _, name := range []string{"title", "project-type", "sort-by", "limit"} {
+		for _, name := range []string{"title", "project-type", "sort-by", "limit", cmdutil.FlagWorkspace} {
 			if f := cmd.Flags().Lookup(name); f != nil && f.Changed {
 				parts = append(parts, "--"+name, shellescape.Quote(f.Value.String()))
 			}

--- a/cli/app/list_test.go
+++ b/cli/app/list_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/bitrise-io/bitrise/v2/cli/cmdutil"
 	"github.com/bitrise-io/bitrise/v2/internal/auth"
 	"github.com/bitrise-io/bitrise/v2/internal/config"
 )
@@ -135,6 +136,90 @@ func TestListCmd_PropagatesAPIError(t *testing.T) {
 	assert.Contains(t, err.Error(), "forbidden")
 }
 
+func TestListCmd_WorkspaceScopedPath(t *testing.T) {
+	var gotPath string
+	srv := newFakeServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		_, _ = w.Write([]byte(`{"data":[]}`))
+	})
+
+	cmd, _ := newTestListCmd(t, srv.URL)
+	require.NoError(t, cmd.Flags().Set("workspace", "my-workspace"))
+	require.NoError(t, cmd.RunE(cmd, nil))
+
+	assert.Equal(t, "/organizations/my-workspace/apps", gotPath)
+}
+
+func TestListCmd_WorkspaceFromEnv(t *testing.T) {
+	var gotPath string
+	srv := newFakeServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		_, _ = w.Write([]byte(`{"data":[]}`))
+	})
+
+	t.Setenv(cmdutil.EnvWorkspaceID, "env-ws")
+	cmd, _ := newTestListCmd(t, srv.URL)
+	errOut := &bytes.Buffer{}
+	cmd.SetErr(errOut)
+	require.NoError(t, cmd.RunE(cmd, nil))
+
+	assert.Equal(t, "/organizations/env-ws/apps", gotPath)
+	assert.Contains(t, errOut.String(), "Using default workspace: env-ws")
+}
+
+func TestListCmd_WorkspaceFromConfig(t *testing.T) {
+	t.Setenv(cmdutil.EnvWorkspaceID, "")
+	var gotPath string
+	srv := newFakeServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		_, _ = w.Write([]byte(`{"data":[]}`))
+	})
+
+	cmd, _ := newTestListCmdWithConfig(t, srv.URL, config.Config{DefaultWorkspaceID: "cfg-ws"})
+	errOut := &bytes.Buffer{}
+	cmd.SetErr(errOut)
+	require.NoError(t, cmd.RunE(cmd, nil))
+
+	assert.Equal(t, "/organizations/cfg-ws/apps", gotPath)
+	assert.Contains(t, errOut.String(), "Using default workspace: cfg-ws")
+}
+
+func TestListCmd_WorkspaceFlagWinsOverDefault_NoBreadcrumb(t *testing.T) {
+	var gotPath string
+	srv := newFakeServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		_, _ = w.Write([]byte(`{"data":[]}`))
+	})
+
+	t.Setenv(cmdutil.EnvWorkspaceID, "env-ws")
+	cmd, _ := newTestListCmd(t, srv.URL)
+	require.NoError(t, cmd.Flags().Set("workspace", "flag-ws"))
+	errOut := &bytes.Buffer{}
+	cmd.SetErr(errOut)
+	require.NoError(t, cmd.RunE(cmd, nil))
+
+	assert.Equal(t, "/organizations/flag-ws/apps", gotPath)
+	assert.NotContains(t, errOut.String(), "Using default workspace", "an explicit --workspace is not a default")
+}
+
+func TestListCmd_WorkspaceNameResolvesToSlug(t *testing.T) {
+	var gotPath string
+	srv := newFakeServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/organizations" {
+			_, _ = w.Write([]byte(`{"data":[{"slug":"acme","name":"Acme Corp"}]}`))
+			return
+		}
+		gotPath = r.URL.Path
+		_, _ = w.Write([]byte(`{"data":[]}`))
+	})
+
+	cmd, _ := newTestListCmd(t, srv.URL)
+	require.NoError(t, cmd.Flags().Set("workspace", "Acme Corp"))
+	require.NoError(t, cmd.RunE(cmd, nil))
+
+	assert.Equal(t, "/organizations/acme/apps", gotPath)
+}
+
 func TestListCmd_RejectsPositionalArgs(t *testing.T) {
 	cmd := NewListCommand()
 	cmd.SetArgs([]string{"unexpected"})
@@ -157,6 +242,16 @@ func newTestListCmd(t *testing.T, apiBaseURL string) (*cobra.Command, *bytes.Buf
 	resolved := config.Resolve(config.Config{}, config.Config{}, config.Config{APIBaseURL: apiBaseURL})
 	cmd.SetContext(config.WithResolved(t.Context(), resolved))
 	return cmd, &out
+}
+
+// newTestListCmdWithConfig is newTestListCmd for tests that need extra
+// resolved config keys (e.g. default_workspace_id) alongside the API base URL.
+func newTestListCmdWithConfig(t *testing.T, apiBaseURL string, global config.Config) (*cobra.Command, *bytes.Buffer) {
+	t.Helper()
+	cmd, out := newTestListCmd(t, apiBaseURL)
+	global.APIBaseURL = apiBaseURL
+	cmd.SetContext(config.WithResolved(t.Context(), config.Resolve(config.Config{}, config.Config{}, global)))
+	return cmd, out
 }
 
 func newFakeServer(t *testing.T, handler http.HandlerFunc) *httptest.Server {

--- a/cli/app/view.go
+++ b/cli/app/view.go
@@ -56,6 +56,20 @@ func runView(cmd *cobra.Command, args []string, web bool, openBrowser func(strin
 		return err
 	}
 
+	// Only a user-provided value (--app or a positional arg) can be a
+	// display name, so only that case needs a client to resolve it — an
+	// ambient value (env/config) is already a canonical slug.
+	if cmdutil.AppSlugIsUserProvided(cmd, args) {
+		client, err := cmdutil.NewAPIClient(cmd)
+		if err != nil {
+			return err
+		}
+		appSlug, err = cmdutil.NewResolver(client).AppSlug(cmd.Context(), appSlug)
+		if err != nil {
+			return err
+		}
+	}
+
 	if web {
 		url := fmt.Sprintf("%s/app/%s", cmdutil.ResolveWebBaseURL(cmd), appSlug)
 		if err := openBrowser(url); err != nil {
@@ -69,7 +83,7 @@ func runView(cmd *cobra.Command, args []string, web bool, openBrowser func(strin
 	if err != nil {
 		return err
 	}
-	a, err := internalapp.NewService(client).ViewByNameOrSlug(cmd.Context(), cmdutil.NewResolver(client), appSlug)
+	a, err := internalapp.NewService(client).View(cmd.Context(), appSlug)
 	if err != nil {
 		return err
 	}

--- a/cli/app/view_test.go
+++ b/cli/app/view_test.go
@@ -47,6 +47,27 @@ func TestViewCmd_FlagFallback(t *testing.T) {
 	assert.Equal(t, "/apps/my-app", gotPath)
 }
 
+func TestViewCmd_EnvOnly_SkipsNameResolution(t *testing.T) {
+	var gotPath string
+	var titleLookupCalled bool
+	srv := newFakeServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/apps" {
+			titleLookupCalled = true
+			_, _ = w.Write([]byte(`{"data":[],"paging":{}}`))
+			return
+		}
+		gotPath = r.URL.Path
+		_, _ = w.Write([]byte(`{"data":{"slug":"env-app-slug","title":"My App","provider":"github","owner":{}}}`))
+	})
+
+	t.Setenv(cmdutil.EnvAppID, "env-app-slug")
+	cmd, _ := newTestViewCmd(t, srv.URL)
+	require.NoError(t, runView(cmd, nil, false, unusedBrowser(t)))
+
+	assert.Equal(t, "/apps/env-app-slug", gotPath)
+	assert.False(t, titleLookupCalled, "an ambient app slug (env/config) must not be resolved by name")
+}
+
 func TestViewCmd_RequiresAppSlug(t *testing.T) {
 	t.Setenv(cmdutil.EnvAppID, "")
 	t.Setenv(cmdutil.EnvAppIDLegacy, "")
@@ -67,17 +88,38 @@ func TestViewCmd_AppNotFound(t *testing.T) {
 	require.EqualError(t, err, `app "missing-app" not found`)
 }
 
-func TestViewCmd_Web_OpensBrowserAndSkipsAPICall(t *testing.T) {
+func TestViewCmd_Web_EnvOnly_SkipsAPICall(t *testing.T) {
 	cmd, _ := newTestViewCmd(t, "https://unused.test")
 	t.Setenv(cmdutil.EnvWebBaseURL, "https://app.bitrise.io")
+	t.Setenv(cmdutil.EnvAppID, "env-app-slug")
 
 	var gotURL string
-	err := runView(cmd, []string{"my-app"}, true, func(url string) error {
+	err := runView(cmd, nil, true, func(url string) error {
 		gotURL = url
 		return nil
 	})
 	require.NoError(t, err)
-	assert.Equal(t, "https://app.bitrise.io/app/my-app", gotURL)
+	assert.Equal(t, "https://app.bitrise.io/app/env-app-slug", gotURL)
+}
+
+func TestViewCmd_Web_ResolvesUserProvidedName(t *testing.T) {
+	var gotTitle string
+	srv := newFakeServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotTitle = r.URL.Query().Get("title")
+		_, _ = w.Write([]byte(`{"data":[{"slug":"app-123","title":"My App Name","owner":{}}],"paging":{}}`))
+	})
+
+	cmd, _ := newTestViewCmd(t, srv.URL)
+	t.Setenv(cmdutil.EnvWebBaseURL, "https://app.bitrise.io")
+
+	var gotURL string
+	err := runView(cmd, []string{"My App Name"}, true, func(url string) error {
+		gotURL = url
+		return nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "https://app.bitrise.io/app/app-123", gotURL)
+	assert.Equal(t, "My App Name", gotTitle)
 }
 
 func TestViewCmd_RejectsMultipleArgs(t *testing.T) {

--- a/cli/build/view.go
+++ b/cli/build/view.go
@@ -53,6 +53,20 @@ func runView(cmd *cobra.Command, args []string, web bool, openBrowser func(strin
 	}
 	buildSlug := args[0]
 
+	// build view has no positional arg for the app slug (only --app), so
+	// args is nil here. Only a user-provided value can be a display name —
+	// an ambient one (env/config) is already a canonical slug.
+	if cmdutil.AppSlugIsUserProvided(cmd, nil) {
+		client, err := cmdutil.NewAPIClient(cmd)
+		if err != nil {
+			return err
+		}
+		appSlug, err = cmdutil.NewResolver(client).AppSlug(cmd.Context(), appSlug)
+		if err != nil {
+			return err
+		}
+	}
+
 	if web {
 		url := buildWebURL(cmdutil.ResolveWebBaseURL(cmd), appSlug, buildSlug)
 		if err := openBrowser(url); err != nil {
@@ -63,10 +77,6 @@ func runView(cmd *cobra.Command, args []string, web bool, openBrowser func(strin
 	}
 
 	client, err := cmdutil.NewAPIClient(cmd)
-	if err != nil {
-		return err
-	}
-	appSlug, err = cmdutil.NewResolver(client).AppSlug(cmd.Context(), appSlug)
 	if err != nil {
 		return err
 	}

--- a/cli/build/view_test.go
+++ b/cli/build/view_test.go
@@ -3,6 +3,7 @@ package build
 import (
 	"bytes"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -33,6 +34,30 @@ func TestViewCmd_HappyPath(t *testing.T) {
 	assert.Regexp(t, `Workflow:\s+primary`, out)
 }
 
+func TestViewCmd_EnvOnly_SkipsNameResolution(t *testing.T) {
+	var gotPath string
+	var titleLookupCalled bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/apps" {
+			titleLookupCalled = true
+			_, _ = w.Write([]byte(`{"data":[],"paging":{}}`))
+			return
+		}
+		gotPath = r.URL.Path
+		_, _ = w.Write([]byte(`{"data":{"slug":"build-1","build_number":7,"status":1,"branch":"main","triggered_workflow":"primary"}}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	t.Setenv(cmdutil.EnvAppID, "env-app-slug")
+	cmd := newTestViewCmd(t, srv.URL)
+	out, err := runViewCapture(t, cmd, []string{"build-1"}, false, unusedBrowser(t))
+	require.NoError(t, err)
+
+	assert.Equal(t, "/apps/env-app-slug/builds/build-1", gotPath)
+	assert.False(t, titleLookupCalled, "an ambient app slug (env/config) must not be resolved by name")
+	assert.Regexp(t, `Build #7`, out)
+}
+
 func TestViewCmd_RequiresApp(t *testing.T) {
 	t.Setenv(cmdutil.EnvAppID, "")
 	t.Setenv(cmdutil.EnvAppIDLegacy, "")
@@ -54,9 +79,30 @@ func TestViewCmd_BuildNotFound(t *testing.T) {
 	require.EqualError(t, err, `build "missing" not found`)
 }
 
-func TestViewCmd_Web_OpensBrowserAndSkipsAPICall(t *testing.T) {
+func TestViewCmd_Web_EnvOnly_SkipsAPICall(t *testing.T) {
 	cmd := newTestViewCmd(t, "https://unused.test")
-	require.NoError(t, cmd.Flags().Set("app", "my-app"))
+	t.Setenv(cmdutil.EnvWebBaseURL, "https://app.bitrise.io")
+	t.Setenv(cmdutil.EnvAppID, "env-app-slug")
+
+	var gotURL string
+	_, err := runViewCapture(t, cmd, []string{"build-1"}, true, func(url string) error {
+		gotURL = url
+		return nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "https://app.bitrise.io/app/env-app-slug/build/build-1", gotURL)
+}
+
+func TestViewCmd_Web_ResolvesUserProvidedName(t *testing.T) {
+	var gotTitle string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotTitle = r.URL.Query().Get("title")
+		_, _ = w.Write([]byte(`{"data":[{"slug":"app-123","title":"My App Name","owner":{}}],"paging":{}}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	cmd := newTestViewCmd(t, srv.URL)
+	require.NoError(t, cmd.Flags().Set("app", "My App Name"))
 	t.Setenv(cmdutil.EnvWebBaseURL, "https://app.bitrise.io")
 
 	var gotURL string
@@ -65,7 +111,8 @@ func TestViewCmd_Web_OpensBrowserAndSkipsAPICall(t *testing.T) {
 		return nil
 	})
 	require.NoError(t, err)
-	assert.Equal(t, "https://app.bitrise.io/app/my-app/build/build-1", gotURL)
+	assert.Equal(t, "https://app.bitrise.io/app/app-123/build/build-1", gotURL)
+	assert.Equal(t, "My App Name", gotTitle)
 }
 
 func TestViewCmd_RejectsWrongArgCount(t *testing.T) {

--- a/cli/cmdutil/app.go
+++ b/cli/cmdutil/app.go
@@ -35,6 +35,27 @@ func AddAppFlag(fs *pflag.FlagSet, help string) {
 	fs.String(FlagApp, "", help)
 }
 
+// flagAppSlug returns just the --app flag's value, or "" if unset.
+func flagAppSlug(cmd *cobra.Command) string {
+	v, _ := cmd.Flags().GetString(FlagApp)
+	return v
+}
+
+// ambientAppSlug returns the app slug from BITRISE_APP_ID, then
+// BITRISE_APP_SLUG, then the app_id set by `bitrise app create` or `bitrise
+// config set app_id` — all of which are always already a canonical slug
+// (Bitrise-injected or previously resolved by this CLI), never a display
+// name a user typed, so callers never resolve these by name.
+func ambientAppSlug(cmd *cobra.Command) string {
+	if v := os.Getenv(EnvAppID); v != "" {
+		return v
+	}
+	if v := os.Getenv(EnvAppIDLegacy); v != "" {
+		return v
+	}
+	return config.FromContext(cmd.Context()).AppID
+}
+
 // ResolveAppSlug returns the app slug from --app, falling back to
 // BITRISE_APP_ID, then BITRISE_APP_SLUG, then the app_id set by
 // `bitrise app create` or `bitrise config set app_id`.
@@ -59,16 +80,25 @@ func ResolveAppSlugArg(cmd *cobra.Command, args []string) (string, error) {
 // returns an empty string instead of an error when neither source is set —
 // for commands where the app is optional (e.g. `yml validate --app`).
 func LookupAppSlug(cmd *cobra.Command) string {
-	if v, _ := cmd.Flags().GetString(FlagApp); v != "" {
+	if v := flagAppSlug(cmd); v != "" {
 		return v
 	}
-	if v := os.Getenv(EnvAppID); v != "" {
-		return v
+	return ambientAppSlug(cmd)
+}
+
+// AppSlugIsUserProvided reports whether the app slug ResolveAppSlug /
+// ResolveAppSlugArg / LookupAppSlug would return for cmd/args came from
+// something the user typed (--app, or a positional argument in args) rather
+// than an ambient source (BITRISE_APP_ID/BITRISE_APP_SLUG, saved config).
+// Only a user-provided value can be a display name — ambient ones are always
+// already a canonical slug — so callers that resolve a name to a slug
+// themselves (rather than through ResolveAndLookupAppSlug) use this to skip
+// that lookup, and its API call, for ambient values.
+func AppSlugIsUserProvided(cmd *cobra.Command, args []string) bool {
+	if len(args) > 0 && args[0] != "" {
+		return true
 	}
-	if v := os.Getenv(EnvAppIDLegacy); v != "" {
-		return v
-	}
-	return config.FromContext(cmd.Context()).AppID
+	return flagAppSlug(cmd) != ""
 }
 
 // AppSlugRequiredErr returns the standard missing-app-slug error.
@@ -82,14 +112,17 @@ func NewResolver(client *bitriseapi.Client) *resolve.Resolver {
 	return resolve.New(client, cache.New())
 }
 
-// ResolveAndLookupAppSlug reads the app slug from --app / env / config (same
-// precedence as ResolveAppSlug), then resolves a display name to an app slug
-// via a targeted GET /apps?title=<value> query if the value doesn't match any
-// slug directly.
+// ResolveAndLookupAppSlug reads the app slug from --app, falling back to
+// BITRISE_APP_ID, then BITRISE_APP_SLUG, then config app_id. Only a --app
+// value goes through the name lookup (a targeted GET /apps?title=<value>
+// query) — the ambient sources are already a canonical slug, so resolving
+// those would just be a wasted API call.
 func ResolveAndLookupAppSlug(cmd *cobra.Command, client *bitriseapi.Client) (string, error) {
-	raw, err := ResolveAppSlug(cmd)
-	if err != nil {
-		return "", err
+	if v := flagAppSlug(cmd); v != "" {
+		return NewResolver(client).AppSlug(cmd.Context(), v)
 	}
-	return NewResolver(client).AppSlug(cmd.Context(), raw)
+	if v := ambientAppSlug(cmd); v != "" {
+		return v, nil
+	}
+	return "", AppSlugRequiredErr()
 }

--- a/cli/cmdutil/app_test.go
+++ b/cli/cmdutil/app_test.go
@@ -184,12 +184,14 @@ func TestResolveAndLookupAppSlug_PassesSlugThrough(t *testing.T) {
 	assert.Equal(t, "3f8a91c02d4e", slug)
 }
 
-// TestResolveAndLookupAppSlug_PrecedenceIsUnchanged pins that the resolver runs
-// after --app / env / config precedence, on whatever that produced, rather than
-// replacing it.
-func TestResolveAndLookupAppSlug_PrecedenceIsUnchanged(t *testing.T) {
-	t.Setenv(EnvAppID, "My iOS App")
-	client, calls := appsClient(t, `{"data":[{"slug":"app-123","title":"My iOS App"}],"paging":{}}`)
+// TestResolveAndLookupAppSlug_AmbientSourceSkipsResolution pins that only a
+// --app value is resolved by name. BITRISE_APP_ID (like BITRISE_APP_SLUG and
+// the config app_id) is always already a canonical slug — Bitrise injects it
+// verbatim into every build — so resolving it would just be a wasted API
+// call, and the value passes through unchanged instead.
+func TestResolveAndLookupAppSlug_AmbientSourceSkipsResolution(t *testing.T) {
+	t.Setenv(EnvAppID, "env-app-slug")
+	client, calls := appsClient(t, `{"data":[],"paging":{}}`)
 
 	cmd := &cobra.Command{}
 	cmd.SetContext(t.Context())
@@ -197,8 +199,24 @@ func TestResolveAndLookupAppSlug_PrecedenceIsUnchanged(t *testing.T) {
 
 	slug, err := ResolveAndLookupAppSlug(cmd, client)
 	require.NoError(t, err)
-	assert.Equal(t, "app-123", slug)
-	assert.Equal(t, []string{"My iOS App"}, *calls)
+	assert.Equal(t, "env-app-slug", slug)
+	assert.Empty(t, *calls, "an ambient source must not be resolved by name")
+}
+
+func TestAppSlugIsUserProvided(t *testing.T) {
+	t.Setenv(EnvAppIDLegacy, "")
+
+	cmd := &cobra.Command{}
+	AddAppFlag(cmd.Flags(), "app slug")
+	assert.False(t, AppSlugIsUserProvided(cmd, nil), "no flag, no arg, no ambient source")
+
+	t.Setenv(EnvAppID, "env-app-slug")
+	assert.False(t, AppSlugIsUserProvided(cmd, nil), "an ambient env var is not user-provided")
+
+	assert.True(t, AppSlugIsUserProvided(cmd, []string{"arg-app-slug"}), "a positional arg is user-provided")
+
+	require.NoError(t, cmd.Flags().Set(FlagApp, "flag-app-slug"))
+	assert.True(t, AppSlugIsUserProvided(cmd, nil), "the --app flag is user-provided")
 }
 
 func TestResolveAndLookupAppSlug_AmbiguousNameErrors(t *testing.T) {

--- a/cli/cmdutil/flags.go
+++ b/cli/cmdutil/flags.go
@@ -31,7 +31,10 @@ const (
 	PRReadyStateKey     = "pr-ready-state"
 	ConfigKey           = "config"
 	InventoryKey        = "inventory"
-	FormatKey           = "format"
+	// FormatKey selects the output format. It takes the -f shorthand only on
+	// commands that have no --file flag: where both exist (yml update/validate,
+	// rde template create/update), -f binds to --file and --format has none.
+	FormatKey = "format"
 
 	TagKey    = "tag"
 	GitKey    = "git"

--- a/cli/cmdutil/json_output.go
+++ b/cli/cmdutil/json_output.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	"github.com/bitrise-io/bitrise/v2/log"
+	"github.com/bitrise-io/bitrise/v2/output"
 )
 
 // Logger ...
@@ -54,5 +55,27 @@ func NewDefaultJSONLogger() JSONLogger {
 func (l JSONLogger) Print(f Formatable) {
 	if _, err := fmt.Fprint(l.writer, f.JSON()); err != nil {
 		log.Printf("failed to print message: %s, error: %s\n", f.JSON(), err)
+	}
+}
+
+// YAMLLogger ...
+type YAMLLogger struct {
+	writer io.Writer
+}
+
+// NewDefaultYAMLLogger ...
+func NewDefaultYAMLLogger() YAMLLogger {
+	return YAMLLogger{
+		writer: os.Stdout,
+	}
+}
+
+// Print marshals the concrete model behind f rather than asking it for a
+// rendering: Formatable has no YAML method, and only the two loggers above
+// need a hand-written one. Models reaching here need yaml tags matching their
+// json tags, like anything else passed to output.Print.
+func (l YAMLLogger) Print(f Formatable) {
+	if err := output.Print(l.writer, f, output.FormatYML); err != nil {
+		log.Printf("failed to print message: %s, error: %s\n", f.String(), err)
 	}
 }

--- a/cli/cmdutil/workspace.go
+++ b/cli/cmdutil/workspace.go
@@ -70,6 +70,23 @@ func ResolveWorkspaceID(cmd *cobra.Command) (string, error) {
 	return ws.Slug, nil
 }
 
+// ResolveAndLookupWorkspaceSlug resolves a command's --workspace flag value
+// (flagValue), falling back to DefaultWorkspaceSlug (BITRISE_WORKSPACE_ID /
+// default_workspace_id). Only flagValue is resolved by name (a lookup
+// against GET /organizations, since --workspace can be a display name) —
+// the fallback is always already a canonical slug (Bitrise-injected or
+// previously saved by this CLI as a slug), so it's used verbatim without an
+// extra request. usedDefault reports whether the value came from the
+// fallback, for callers that print a "using default workspace" breadcrumb.
+func ResolveAndLookupWorkspaceSlug(cmd *cobra.Command, client *bitriseapi.Client, flagValue string) (slug string, usedDefault bool, err error) {
+	if flagValue != "" {
+		slug, err = NewResolver(client).WorkspaceSlug(cmd.Context(), flagValue)
+		return slug, false, err
+	}
+	slug = DefaultWorkspaceSlug(cmd)
+	return slug, slug != "", nil
+}
+
 // interactiveWorkspacePicker reports whether the workspace picker can run: it
 // reads keys from stdin and draws to stderr, so both must be a terminal, and it
 // only makes sense for raw/human output (json/yml callers want the

--- a/cli/config/cmd.go
+++ b/cli/config/cmd.go
@@ -48,8 +48,7 @@ file then global file) > built-in default (raw). theme resolves the same way,
 via --theme and $%s (default: auto). Both honor the per-directory file, like
 app_id/default_workspace_id above — neither is a credential or a URL. Note
 --output only affects commands that share the raw/json/yml format vocabulary:
-'yml validate', 'local workflow-list' and 'plugin list/info' keep their own
---format flag.
+'local workflows' and 'plugin list/info' keep their own --format flag.
 
 'get'/'set'/'unset'/'list' only read and write the global file — per-dir
 files must be edited by hand.

--- a/cli/local/workflow_list.go
+++ b/cli/local/workflow_list.go
@@ -42,9 +42,9 @@ func NewWorkflowListCommand() *cobra.Command {
 
 // WorkflowListOutputModel ...
 type WorkflowListOutputModel struct {
-	Data     map[string]map[string]string `json:"data,omitempty" yml:"data,omitempty"`
-	Warnings []string                     `json:"warnings,omitempty" yml:"warnings,omitempty"`
-	Error    string                       `json:"error,omitempty" yml:"error,omitempty"`
+	Data     map[string]map[string]string `json:"data,omitempty" yaml:"data,omitempty"`
+	Warnings []string                     `json:"warnings,omitempty" yaml:"warnings,omitempty"`
+	Error    string                       `json:"error,omitempty" yaml:"error,omitempty"`
 }
 
 // NewOutput ...

--- a/cli/stack/list.go
+++ b/cli/stack/list.go
@@ -40,20 +40,20 @@ available stacks.`,
 				return fmt.Errorf("failed to configure output format: %w", err)
 			}
 
-			resolvedWorkspace := workspaceSlug
-			if resolvedWorkspace == "" {
-				resolvedWorkspace = cmdutil.DefaultWorkspaceSlug(cmd)
-				// Flagged so a build step doesn't silently switch from the
-				// global stack list to a workspace-scoped one without the
-				// user noticing.
-				if resolvedWorkspace != "" && output.Format == output.FormatRaw {
-					fmt.Fprintf(cmd.ErrOrStderr(), "Using default workspace: %s\n", resolvedWorkspace)
-				}
-			}
-
 			client, err := cmdutil.NewAPIClient(cmd)
 			if err != nil {
 				return err
+			}
+
+			resolvedWorkspace, workspaceFromDefault, err := cmdutil.ResolveAndLookupWorkspaceSlug(cmd, client, workspaceSlug)
+			if err != nil {
+				return err
+			}
+			// Flagged so a build step doesn't silently switch from the
+			// global stack list to a workspace-scoped one without the
+			// user noticing.
+			if workspaceFromDefault && output.Format == output.FormatRaw {
+				fmt.Fprintf(cmd.ErrOrStderr(), "Using default workspace: %s\n", resolvedWorkspace)
 			}
 
 			result, err := internalstack.NewService(client).List(cmd.Context(), resolvedWorkspace)

--- a/cli/stack/list_test.go
+++ b/cli/stack/list_test.go
@@ -83,6 +83,25 @@ func TestListCmd_WorkspaceFromConfig(t *testing.T) {
 	assert.Contains(t, errOut.String(), "Using default workspace: cfg-ws")
 }
 
+func TestListCmd_WorkspaceNameResolvesToSlug(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/organizations" {
+			_, _ = w.Write([]byte(`{"data":[{"slug":"acme","name":"Acme Corp"}]}`))
+			return
+		}
+		gotPath = r.URL.Path
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	cmd, _ := newTestListCmd(t, srv.URL)
+	require.NoError(t, cmd.Flags().Set("workspace", "Acme Corp"))
+	require.NoError(t, cmd.RunE(cmd, nil))
+
+	assert.Equal(t, "/organizations/acme/available-stacks", gotPath)
+}
+
 func TestListCmd_WorkspaceFlagWinsOverDefault_NoBreadcrumb(t *testing.T) {
 	var gotPath string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/cli/yml/update.go
+++ b/cli/yml/update.go
@@ -65,10 +65,7 @@ later 'bitrise yml get' returns an equivalent, reformatted document.`,
 		},
 	}
 
-	// No -f shorthand: every other cloud command uses -f for --format, so
-	// binding it to --file here would make `yml update -f json` open a file
-	// named "json" while `yml get -f json` selects a format.
-	cmd.Flags().StringVar(&filePath, "file", "", "path to the bitrise.yml file, or - for stdin (reads from stdin if omitted)")
+	cmd.Flags().StringVarP(&filePath, "file", "f", "", "path to the bitrise.yml file, or - for stdin (reads from stdin if omitted)")
 	cmdutil.AddAppFlag(cmd.Flags(), "app ID to update the bitrise.yml for (or set BITRISE_APP_ID; inside a build, defaults to the app the build runs for)")
 
 	return cmd

--- a/cli/yml/update_test.go
+++ b/cli/yml/update_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"io"
 	"net/http"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -47,6 +49,24 @@ func TestUpdateCmd_EmptyContent(t *testing.T) {
 
 	err := cmd.RunE(cmd, nil)
 	require.Error(t, err)
+}
+
+func TestUpdateCmd_FileShorthand(t *testing.T) {
+	var gotBody string
+	srv := newFakeServer(t, func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		gotBody = string(b)
+		_, _ = w.Write([]byte(`{}`))
+	})
+
+	path := filepath.Join(t.TempDir(), "bitrise.yml")
+	require.NoError(t, os.WriteFile(path, []byte("format_version: \"13\"\n"), 0600))
+
+	cmd, _ := newTestUpdateCmd(t, srv.URL, "")
+	cmd.SetArgs([]string{"--app", "app-slug", "-f", path})
+	require.NoError(t, cmd.Execute())
+
+	assert.JSONEq(t, `{"app_config_datastore_yaml":{"format_version":"13"}}`, gotBody)
 }
 
 func newTestUpdateCmd(t *testing.T, apiBaseURL, stdin string) (*cobra.Command, *bytes.Buffer) {

--- a/cli/yml/validate.go
+++ b/cli/yml/validate.go
@@ -286,9 +286,11 @@ func tryOnlineValidate(cmd *cobra.Command, bitriseConfigPath, bitriseConfigBase6
 		return nil, fmt.Sprintf("online validation unavailable: %s", err), false
 	}
 
-	appSlug, err = cmdutil.NewResolver(client).AppSlug(cmd.Context(), appSlug)
-	if err != nil {
-		return nil, fmt.Sprintf("online validation unavailable: %s", err), false
+	if cmdutil.AppSlugIsUserProvided(cmd, nil) {
+		appSlug, err = cmdutil.NewResolver(client).AppSlug(cmd.Context(), appSlug)
+		if err != nil {
+			return nil, fmt.Sprintf("online validation unavailable: %s", err), false
+		}
 	}
 
 	rawYAML, err := getYmlStringForOnlineValidation(bitriseConfigPath, bitriseConfigBase64Data)

--- a/cli/yml/validate.go
+++ b/cli/yml/validate.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 
@@ -23,6 +24,13 @@ import (
 // historical local-only behavior deterministically.
 const offlineKey = "offline"
 
+// fileKey is the cloud CLI's name for the config path, kept as a hidden alias
+// of cmdutil.ConfigKey.
+const fileKey = "file"
+
+// stdinPath is the config path that means "read the config from stdin".
+const stdinPath = "-"
+
 // NewValidateCommand ...
 func NewValidateCommand() *cobra.Command {
 	validateCommand := &cobra.Command{
@@ -32,9 +40,17 @@ func NewValidateCommand() *cobra.Command {
 	}
 
 	cmdutil.AddConfigAndInventoryFlags(validateCommand.Flags())
-	validateCommand.Flags().String(cmdutil.FormatKey, "", "Output format. Accepted: raw (default), json.")
+	validateCommand.Flags().String(cmdutil.FormatKey, "", "Output format. Accepted: raw (default), json, yml.")
 	validateCommand.Flags().Bool(offlineKey, false, "Skip online validation even if authenticated; use only the local schema check.")
 	cmdutil.AddAppFlag(validateCommand.Flags(), "app ID to validate against (enables app-specific checks: stacks, machine types, license pools; inside a build, defaults to the app the build runs for)")
+
+	// --file is the name the cloud CLI used for what is --config here; kept as
+	// a hidden alias so its invocations keep working without documenting two
+	// names for one input.
+	validateCommand.Flags().StringP(fileKey, "f", "", "Alias for --config.")
+	_ = validateCommand.Flags().MarkHidden(fileKey)
+	validateCommand.MarkFlagsMutuallyExclusive(fileKey, cmdutil.ConfigKey)
+	validateCommand.MarkFlagsMutuallyExclusive(fileKey, cmdutil.ConfigBase64Key)
 
 	// --offline skips the online path entirely, so accepting it together with
 	// --app would silently ignore the app-specific checks --app asks for. An
@@ -389,6 +405,9 @@ func validate(cmd *cobra.Command, _ []string) error {
 
 	bitriseConfigBase64Data, _ := cmd.Flags().GetString(cmdutil.ConfigBase64Key)
 	bitriseConfigPath, _ := cmd.Flags().GetString(cmdutil.ConfigKey)
+	if filePath, _ := cmd.Flags().GetString(fileKey); filePath != "" {
+		bitriseConfigPath = filePath
+	}
 
 	inventoryBase64Data, _ := cmd.Flags().GetString(cmdutil.InventoryBase64Key)
 	inventoryPath, _ := cmd.Flags().GetString(cmdutil.InventoryKey)
@@ -398,15 +417,38 @@ func validate(cmd *cobra.Command, _ []string) error {
 
 	format, _ := cmd.Flags().GetString(cmdutil.FormatKey)
 	if format == "" {
-		format = output.FormatRaw
+		format = output.Default()
 	}
 
 	var log cmdutil.Logger = cmdutil.NewDefaultRawLogger()
-	if format == output.FormatJSON {
+	switch format {
+	case output.FormatRaw:
+	case output.FormatJSON:
 		log = cmdutil.NewDefaultJSONLogger()
-	} else if format != output.FormatRaw {
+	case output.FormatYML:
+		log = cmdutil.NewDefaultYAMLLogger()
+	default:
 		log.Print(NewValidationError(fmt.Sprintf("Invalid format: %s", format)))
 		os.Exit(1)
+	}
+
+	// A "-" path feeds stdin through the base64 channel, so both the online and
+	// the local check pick it up. An explicit --config-base64 still wins, the
+	// way it does over a real path everywhere else.
+	if bitriseConfigPath == stdinPath {
+		bitriseConfigPath = ""
+		if bitriseConfigBase64Data == "" {
+			stdinConfig, err := io.ReadAll(cmd.InOrStdin())
+			if err != nil {
+				log.Print(NewValidationError(fmt.Sprintf("Failed to read the config from stdin: %s", err)))
+				os.Exit(1)
+			}
+			if len(stdinConfig) == 0 {
+				log.Print(NewValidationError("No config received on stdin"))
+				os.Exit(1)
+			}
+			bitriseConfigBase64Data = base64.StdEncoding.EncodeToString(stdinConfig)
+		}
 	}
 
 	validation, warnings, err := runValidate(cmd, bitriseConfigPath, bitriseConfigBase64Data, inventoryPath, inventoryBase64Data, offline, appSlug)

--- a/cli/yml/validate_test.go
+++ b/cli/yml/validate_test.go
@@ -3,10 +3,12 @@ package yml
 import (
 	"bytes"
 	"encoding/base64"
+	"encoding/json"
 	"io"
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -16,6 +18,7 @@ import (
 	"github.com/bitrise-io/bitrise/v2/cli/cmdutil"
 	"github.com/bitrise-io/bitrise/v2/internal/auth"
 	"github.com/bitrise-io/bitrise/v2/internal/config"
+	"github.com/bitrise-io/bitrise/v2/output"
 )
 
 const validConfig = `format_version: "17"
@@ -245,6 +248,96 @@ func TestValidateCmd_OfflineAndAppAreMutuallyExclusive(t *testing.T) {
 	assert.Contains(t, err.Error(), "none of the others can be")
 }
 
+func TestValidateCmd_FileIsAnAliasOfConfig(t *testing.T) {
+	for _, flag := range []string{"--" + fileKey, "-f"} {
+		t.Run(flag, func(t *testing.T) {
+			var gotYML string
+			cmd, _ := newTestValidateCommand(t, func(w http.ResponseWriter, r *http.Request) {
+				gotYML = submittedYML(t, r)
+				_, _ = w.Write([]byte(`{"errors":[],"warnings":[]}`))
+			})
+			path := filepath.Join(t.TempDir(), "custom.yml")
+			require.NoError(t, os.WriteFile(path, []byte(validConfig), 0600))
+
+			cmd.SetArgs([]string{flag, path})
+			require.NoError(t, cmd.Execute())
+			assert.Equal(t, validConfig, gotYML)
+		})
+	}
+}
+
+func TestValidateCmd_DashConfigPathReadsStdin(t *testing.T) {
+	for _, flag := range []string{"--" + cmdutil.ConfigKey, "--" + fileKey} {
+		t.Run(flag, func(t *testing.T) {
+			var gotYML string
+			cmd, _ := newTestValidateCommand(t, func(w http.ResponseWriter, r *http.Request) {
+				gotYML = submittedYML(t, r)
+				_, _ = w.Write([]byte(`{"errors":[],"warnings":[]}`))
+			})
+			cmd.SetIn(strings.NewReader(validConfig))
+
+			cmd.SetArgs([]string{flag, stdinPath})
+			require.NoError(t, cmd.Execute())
+			assert.Equal(t, validConfig, gotYML)
+		})
+	}
+}
+
+func TestValidateCmd_ConfigBase64OutranksAStdinPath(t *testing.T) {
+	var gotYML string
+	cmd, _ := newTestValidateCommand(t, func(w http.ResponseWriter, r *http.Request) {
+		gotYML = submittedYML(t, r)
+		_, _ = w.Write([]byte(`{"errors":[],"warnings":[]}`))
+	})
+	cmd.SetIn(strings.NewReader(locallyInvalidConfig))
+
+	cmd.SetArgs([]string{"--" + cmdutil.ConfigKey, stdinPath, "--" + cmdutil.ConfigBase64Key, encode(validConfig)})
+	require.NoError(t, cmd.Execute())
+	assert.Equal(t, validConfig, gotYML)
+}
+
+func TestValidateCmd_FileAndConfigAreMutuallyExclusive(t *testing.T) {
+	for _, other := range []string{cmdutil.ConfigKey, cmdutil.ConfigBase64Key} {
+		t.Run(other, func(t *testing.T) {
+			cmd := NewValidateCommand()
+			cmd.SetArgs([]string{"--" + fileKey, "a", "--" + other, "b"})
+			cmd.SetOut(io.Discard)
+			cmd.SetErr(io.Discard)
+
+			err := cmd.Execute()
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "none of the others can be")
+		})
+	}
+}
+
+func TestValidateCmd_EmptyFormatFallsBackToTheGlobalOutputDefault(t *testing.T) {
+	t.Cleanup(func() { output.SetDefault(output.FormatRaw) })
+	output.SetDefault(output.FormatYML)
+
+	cmd, _ := newTestValidateCommand(t, func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"errors":[],"warnings":[]}`))
+	})
+	require.NoError(t, cmd.Flags().Set(cmdutil.ConfigBase64Key, encode(validConfig)))
+
+	stdout := captureStdout(t, func() { require.NoError(t, cmd.RunE(cmd, nil)) })
+	assert.Contains(t, stdout, "is_valid: true")
+}
+
+func TestValidateCmd_FormatFlagOutranksTheGlobalOutputDefault(t *testing.T) {
+	t.Cleanup(func() { output.SetDefault(output.FormatRaw) })
+	output.SetDefault(output.FormatYML)
+
+	cmd, _ := newTestValidateCommand(t, func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"errors":[],"warnings":[]}`))
+	})
+	require.NoError(t, cmd.Flags().Set(cmdutil.ConfigBase64Key, encode(validConfig)))
+	require.NoError(t, cmd.Flags().Set(cmdutil.FormatKey, output.FormatJSON))
+
+	stdout := captureStdout(t, func() { require.NoError(t, cmd.RunE(cmd, nil)) })
+	assert.Contains(t, stdout, `"is_valid":true`)
+}
+
 func encode(s string) string {
 	return base64.StdEncoding.EncodeToString([]byte(s))
 }
@@ -283,4 +376,33 @@ func newTestValidateCmd(t *testing.T, handler http.HandlerFunc) *cobra.Command {
 	resolved := config.Resolve(config.Config{}, config.Config{}, config.Config{APIBaseURL: apiBaseURL})
 	cmd.SetContext(config.WithResolved(t.Context(), resolved))
 	return cmd
+}
+
+// submittedYML returns the bitrise.yml the command posted for online validation.
+func submittedYML(t *testing.T, r *http.Request) string {
+	t.Helper()
+	var body struct {
+		BitriseYML string `json:"bitrise_yml"`
+	}
+	require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+	return body.BitriseYML
+}
+
+// captureStdout runs fn with os.Stdout redirected to a pipe and returns what
+// it wrote there. validate() renders through cmdutil's loggers, which write to
+// os.Stdout rather than to the command's own writer.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	original := os.Stdout
+	os.Stdout = w
+	defer func() { os.Stdout = original }()
+
+	fn()
+	require.NoError(t, w.Close())
+
+	out, err := io.ReadAll(r)
+	require.NoError(t, err)
+	return string(out)
 }

--- a/internal/app/service.go
+++ b/internal/app/service.go
@@ -22,13 +22,15 @@ type App struct {
 }
 
 // ListOptions paginates and filters app lists. Filter fields map to the
-// query parameters of GET /apps.
+// query parameters of GET /apps (or GET /organizations/{org-slug}/apps when
+// OrgSlug is set).
 type ListOptions struct {
 	Limit       int
 	Cursor      string
 	SortBy      string
 	Title       string
 	ProjectType string
+	OrgSlug     string // non-empty scopes the listing to that workspace
 }
 
 // AppsResult is one page of apps.
@@ -55,6 +57,7 @@ func (s *Service) List(ctx context.Context, opts ListOptions) (AppsResult, error
 		Limit:       opts.Limit,
 		Title:       opts.Title,
 		ProjectType: opts.ProjectType,
+		OrgSlug:     opts.OrgSlug,
 	})
 	if err != nil {
 		return AppsResult{}, err

--- a/internal/app/service.go
+++ b/internal/app/service.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 
 	"github.com/bitrise-io/bitrise/v2/internal/bitriseapi"
-	"github.com/bitrise-io/bitrise/v2/internal/resolve"
 )
 
 // App is the CLI representation of a Bitrise app (project).
@@ -65,21 +64,6 @@ func (s *Service) List(ctx context.Context, opts ListOptions) (AppsResult, error
 		items = append(items, fromAPI(a))
 	}
 	return AppsResult{Items: items, NextCursor: next}, nil
-}
-
-// ViewByNameOrSlug resolves value via r and returns the app. When r found a
-// name match in the current API call (complete=true), that result is used
-// directly — no second request. Otherwise (cache hit or literal-slug
-// passthrough) GET /apps/{slug} is called via View.
-func (s *Service) ViewByNameOrSlug(ctx context.Context, r *resolve.Resolver, value string) (App, error) {
-	app, complete, err := r.ResolveApp(ctx, value)
-	if err != nil {
-		return App{}, err
-	}
-	if complete {
-		return fromAPI(app), nil
-	}
-	return s.View(ctx, app.Slug)
 }
 
 // View returns details of a single app by slug.

--- a/internal/app/service_test.go
+++ b/internal/app/service_test.go
@@ -52,6 +52,32 @@ func TestList_PassesOptionsAsQueryParams(t *testing.T) {
 	assert.Equal(t, "android", gotQuery.Get("project_type"))
 }
 
+func TestList_PassesOrgSlugAsOrgScopedPath(t *testing.T) {
+	var gotPath string
+	srv := newFakeServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		_, _ = w.Write([]byte(`{"data":[]}`))
+	})
+	client := newAPIClient(t, srv.URL)
+
+	_, err := NewService(client).List(context.Background(), ListOptions{OrgSlug: "acme"})
+	require.NoError(t, err)
+	assert.Equal(t, "/organizations/acme/apps", gotPath)
+}
+
+func TestList_EmptyOrgSlugUsesGlobalPath(t *testing.T) {
+	var gotPath string
+	srv := newFakeServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		_, _ = w.Write([]byte(`{"data":[]}`))
+	})
+	client := newAPIClient(t, srv.URL)
+
+	_, err := NewService(client).List(context.Background(), ListOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, "/apps", gotPath)
+}
+
 func TestList_PropagatesAPIError(t *testing.T) {
 	srv := newFakeServer(t, func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusUnauthorized)

--- a/internal/app/service_test.go
+++ b/internal/app/service_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/bitrise-io/bitrise/v2/internal/bitriseapi"
-	"github.com/bitrise-io/bitrise/v2/internal/resolve"
 )
 
 func TestList_MapsAPIShape(t *testing.T) {
@@ -90,41 +89,6 @@ func TestView_AppNotFound(t *testing.T) {
 
 	_, err := NewService(client).View(context.Background(), "missing-app")
 	require.EqualError(t, err, `app "missing-app" not found`)
-}
-
-func TestViewByNameOrSlug_NameMatch_SkipsSecondRequest(t *testing.T) {
-	var requests int
-	srv := newFakeServer(t, func(w http.ResponseWriter, r *http.Request) {
-		requests++
-		assert.Equal(t, "/apps", r.URL.Path)
-		_, _ = w.Write([]byte(`{"data":[{"slug":"my-app","title":"My App","provider":"github","owner":{"slug":"acme"}}],"paging":{}}`))
-	})
-	client := newAPIClient(t, srv.URL)
-	r := resolve.New(client, nil)
-
-	got, err := NewService(client).ViewByNameOrSlug(context.Background(), r, "My App")
-	require.NoError(t, err)
-	assert.Equal(t, 1, requests, "a complete name match must not trigger a second request")
-	assert.Equal(t, App{Slug: "my-app", Title: "My App", Provider: "github", OwnerSlug: "acme"}, got)
-}
-
-func TestViewByNameOrSlug_Passthrough_FallsThroughToView(t *testing.T) {
-	var gotPaths []string
-	srv := newFakeServer(t, func(w http.ResponseWriter, r *http.Request) {
-		gotPaths = append(gotPaths, r.URL.Path)
-		if r.URL.Path == "/apps" {
-			_, _ = w.Write([]byte(`{"data":[],"paging":{}}`))
-			return
-		}
-		_, _ = w.Write([]byte(`{"data":{"slug":"my-app","title":"My App","provider":"github","owner":{"slug":"acme"}}}`))
-	})
-	client := newAPIClient(t, srv.URL)
-	r := resolve.New(client, nil)
-
-	got, err := NewService(client).ViewByNameOrSlug(context.Background(), r, "my-app")
-	require.NoError(t, err)
-	assert.Equal(t, []string{"/apps", "/apps/my-app"}, gotPaths)
-	assert.Equal(t, App{Slug: "my-app", Title: "My App", Provider: "github", OwnerSlug: "acme"}, got)
 }
 
 func newFakeServer(t *testing.T, handler http.HandlerFunc) *httptest.Server {

--- a/internal/bitriseapi/apps.go
+++ b/internal/bitriseapi/apps.go
@@ -30,6 +30,7 @@ type AppsListOptions struct {
 	Limit       int    // server default (50) when 0
 	Title       string
 	ProjectType string
+	OrgSlug     string // non-empty selects GET /organizations/{org-slug}/apps instead of GET /apps; not a query param
 }
 
 func (o AppsListOptions) params() url.Values {
@@ -54,9 +55,20 @@ func (o AppsListOptions) params() url.Values {
 
 // Apps returns one page of apps the authenticated user can access, and the
 // cursor for the next page ("" when there isn't one).
-// Endpoint: GET /apps.
+//
+// When opts.OrgSlug is non-empty, the org-scoped endpoint is used:
+//
+//	GET /organizations/{org-slug}/apps
+//
+// Otherwise the global endpoint is used:
+//
+//	GET /apps
 func (c *Client) Apps(ctx context.Context, opts AppsListOptions) ([]App, string, error) {
-	return getPage[App](ctx, c, "/apps", opts.params())
+	path := "/apps"
+	if opts.OrgSlug != "" {
+		path = "/organizations/" + url.PathEscape(opts.OrgSlug) + "/apps"
+	}
+	return getPage[App](ctx, c, path, opts.params())
 }
 
 // App returns the details of a single app by slug.

--- a/internal/bitriseapi/apps_test.go
+++ b/internal/bitriseapi/apps_test.go
@@ -50,6 +50,45 @@ func TestApps_SendsListOptionsAsQueryParams(t *testing.T) {
 	assert.Equal(t, "android", q.Get("project_type"))
 }
 
+func TestApps_OrgSlugScopesToOrganizationEndpoint(t *testing.T) {
+	var gotPath string
+	srv := newFakeServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		_, _ = w.Write([]byte(`{"data":[]}`))
+	})
+
+	_, _, err := newAPIClient(t, srv.URL, "t").Apps(context.Background(), AppsListOptions{OrgSlug: "acme"})
+	require.NoError(t, err)
+	assert.Equal(t, "/organizations/acme/apps", gotPath)
+}
+
+func TestApps_EmptyOrgSlugUsesGlobalEndpoint(t *testing.T) {
+	var gotPath string
+	srv := newFakeServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		_, _ = w.Write([]byte(`{"data":[]}`))
+	})
+
+	_, _, err := newAPIClient(t, srv.URL, "t").Apps(context.Background(), AppsListOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, "/apps", gotPath)
+}
+
+func TestApps_OrgSlugIsNotSentAsQueryParam(t *testing.T) {
+	var gotQuery string
+	srv := newFakeServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.RawQuery
+		_, _ = w.Write([]byte(`{"data":[]}`))
+	})
+
+	_, _, err := newAPIClient(t, srv.URL, "t").Apps(context.Background(), AppsListOptions{OrgSlug: "acme", Title: "widget"})
+	require.NoError(t, err)
+	q, err := url.ParseQuery(gotQuery)
+	require.NoError(t, err)
+	assert.Equal(t, "widget", q.Get("title"))
+	assert.Empty(t, q.Get("org_slug"), "OrgSlug selects the path, it must not also appear as a query param")
+}
+
 func TestApps_PropagatesAPIError(t *testing.T) {
 	srv := newFakeServer(t, func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusUnauthorized)

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -1,19 +1,22 @@
-// Package cache provides a lightweight in-memory app title→slug cache for
-// CLI lookups. Entries live for the duration of a single command invocation.
+// Package cache provides a lightweight in-memory app title→slug and
+// workspace name→slug cache for CLI lookups. Entries live for the duration
+// of a single command invocation.
 package cache
 
 import "strings"
 
-// Cache is an in-memory app title→slug mapping.
+// Cache is an in-memory app title→slug and workspace name→slug mapping.
 // All lookups and mutations are case-insensitive (keys are stored lowercase).
 type Cache struct {
-	apps map[string]string
+	apps       map[string]string
+	workspaces map[string]string
 }
 
 // New returns an empty, ready-to-use Cache.
 func New() *Cache {
 	return &Cache{
-		apps: make(map[string]string),
+		apps:       make(map[string]string),
+		workspaces: make(map[string]string),
 	}
 }
 
@@ -32,4 +35,21 @@ func (c *Cache) SetApp(title, slug string) {
 		return
 	}
 	c.apps[strings.ToLower(title)] = slug
+}
+
+// LookupWorkspace returns the workspace slug stored for the given name, if any.
+func (c *Cache) LookupWorkspace(name string) (string, bool) {
+	if c == nil {
+		return "", false
+	}
+	slug, ok := c.workspaces[strings.ToLower(name)]
+	return slug, ok
+}
+
+// SetWorkspace stores a name→slug mapping.
+func (c *Cache) SetWorkspace(name, slug string) {
+	if c == nil {
+		return
+	}
+	c.workspaces[strings.ToLower(name)] = slug
 }

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -32,3 +32,30 @@ func TestNilCacheIsNoop(t *testing.T) {
 	_, ok := c.LookupApp("x")
 	assert.False(t, ok, "nil cache LookupApp should return false")
 }
+
+func TestNew_WorkspacesIsEmpty(t *testing.T) {
+	c := New()
+	_, ok := c.LookupWorkspace("anything")
+	assert.False(t, ok, "fresh cache should be empty")
+}
+
+func TestSetAndLookupWorkspace(t *testing.T) {
+	c := New()
+	c.SetWorkspace("My Workspace", "abc12345")
+
+	slug, ok := c.LookupWorkspace("My Workspace")
+	assert.True(t, ok)
+	assert.Equal(t, "abc12345", slug)
+
+	slug, ok = c.LookupWorkspace("my workspace")
+	assert.True(t, ok, "lookup should be case-insensitive")
+	assert.Equal(t, "abc12345", slug)
+}
+
+func TestNilCacheWorkspaceIsNoop(t *testing.T) {
+	var c *Cache
+	c.SetWorkspace("x", "y")
+
+	_, ok := c.LookupWorkspace("x")
+	assert.False(t, ok, "nil cache LookupWorkspace should return false")
+}

--- a/internal/resolve/resolve.go
+++ b/internal/resolve/resolve.go
@@ -1,6 +1,6 @@
-// Package resolve maps a user-supplied app name or slug to the canonical app
-// slug. Results are stored in a name cache so repeated invocations with the
-// same name skip the network call.
+// Package resolve maps a user-supplied app or workspace name/slug to the
+// canonical slug. Results are stored in a name cache so repeated invocations
+// with the same name skip the network call.
 package resolve
 
 import (
@@ -68,5 +68,56 @@ func (r *Resolver) ResolveApp(ctx context.Context, value string) (app bitriseapi
 			slugs = append(slugs, m.Slug)
 		}
 		return bitriseapi.App{}, false, fmt.Errorf("app name %q is ambiguous (matches %d apps: %v) — pass an app ID instead", value, len(matches), slugs)
+	}
+}
+
+// WorkspaceSlug maps value to a workspace slug. See ResolveWorkspace for
+// resolution semantics.
+func (r *Resolver) WorkspaceSlug(ctx context.Context, value string) (string, error) {
+	org, _, err := r.ResolveWorkspace(ctx, value)
+	return org.Slug, err
+}
+
+// ResolveWorkspace is like WorkspaceSlug but returns the full
+// bitriseapi.Organization when value was matched by a name query, so the
+// caller can skip a second lookup. complete=false means value was not
+// resolved by name: org.Slug holds the resolved slug (from cache or
+// passthrough) and the caller must fetch full data.
+//
+// Unlike ResolveApp, GET /organizations has no server-side name filter, so
+// this always fetches the full workspace list and filters client-side.
+func (r *Resolver) ResolveWorkspace(ctx context.Context, value string) (org bitriseapi.Organization, complete bool, err error) {
+	if value == "" {
+		return bitriseapi.Organization{}, false, nil
+	}
+	if r.cache != nil {
+		if slug, ok := r.cache.LookupWorkspace(value); ok {
+			return bitriseapi.Organization{Slug: slug}, false, nil
+		}
+	}
+	orgs, err := r.client.Organizations(ctx)
+	if err != nil {
+		return bitriseapi.Organization{}, false, fmt.Errorf("look up workspace %q: %w", value, err)
+	}
+	var matches []bitriseapi.Organization
+	for _, o := range orgs {
+		if strings.EqualFold(o.Name, value) {
+			matches = append(matches, o)
+		}
+	}
+	switch len(matches) {
+	case 0:
+		return bitriseapi.Organization{Slug: value}, false, nil
+	case 1:
+		if r.cache != nil {
+			r.cache.SetWorkspace(matches[0].Name, matches[0].Slug)
+		}
+		return matches[0], true, nil
+	default:
+		slugs := make([]string, 0, len(matches))
+		for _, m := range matches {
+			slugs = append(slugs, m.Slug)
+		}
+		return bitriseapi.Organization{}, false, fmt.Errorf("workspace name %q is ambiguous (matches %d workspaces: %v) — pass a workspace ID instead", value, len(matches), slugs)
 	}
 }

--- a/internal/resolve/resolve_test.go
+++ b/internal/resolve/resolve_test.go
@@ -164,3 +164,134 @@ func TestResolveApp_AmbiguousError(t *testing.T) {
 	_, _, err := r.ResolveApp(context.Background(), "My App")
 	require.Error(t, err)
 }
+
+func organizationsBody(body string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/organizations" {
+			_, _ = w.Write([]byte(body))
+			return
+		}
+		http.NotFound(w, r)
+	}
+}
+
+func TestWorkspaceSlug_LiteralSlugPassthrough(t *testing.T) {
+	var called bool
+	srv := newFakeServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		called = true
+		_, _ = w.Write([]byte(`{"data":[]}`))
+	})
+	r := New(newAPIClient(t, srv.URL), nil)
+
+	slug, err := r.WorkspaceSlug(context.Background(), "abc12345")
+	require.NoError(t, err)
+	assert.Equal(t, "abc12345", slug)
+	assert.True(t, called, "expected API to be called even for slug-like input")
+}
+
+func TestWorkspaceSlug_NameResolution(t *testing.T) {
+	srv := newFakeServer(t, organizationsBody(`{"data":[{"slug":"abc12345","name":"My Workspace"}]}`))
+	r := New(newAPIClient(t, srv.URL), nil)
+
+	slug, err := r.WorkspaceSlug(context.Background(), "My Workspace")
+	require.NoError(t, err)
+	assert.Equal(t, "abc12345", slug)
+}
+
+func TestWorkspaceSlug_CaseInsensitive(t *testing.T) {
+	srv := newFakeServer(t, organizationsBody(`{"data":[{"slug":"abc12345","name":"My Workspace"}]}`))
+	r := New(newAPIClient(t, srv.URL), nil)
+
+	slug, err := r.WorkspaceSlug(context.Background(), "my workspace")
+	require.NoError(t, err)
+	assert.Equal(t, "abc12345", slug)
+}
+
+func TestWorkspaceSlug_AmbiguousError(t *testing.T) {
+	srv := newFakeServer(t, organizationsBody(`{"data":[
+		{"slug":"slug-1","name":"My Workspace"},
+		{"slug":"slug-2","name":"My Workspace"}
+	]}`))
+	r := New(newAPIClient(t, srv.URL), nil)
+
+	_, err := r.WorkspaceSlug(context.Background(), "My Workspace")
+	require.Error(t, err)
+}
+
+func TestWorkspaceSlug_CacheHit(t *testing.T) {
+	var apiCalled bool
+	srv := newFakeServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		apiCalled = true
+		_, _ = w.Write([]byte(`{"data":[]}`))
+	})
+	c := cache.New()
+	c.SetWorkspace("My Workspace", "cached-slug")
+	r := New(newAPIClient(t, srv.URL), c)
+
+	slug, err := r.WorkspaceSlug(context.Background(), "My Workspace")
+	require.NoError(t, err)
+	assert.Equal(t, "cached-slug", slug)
+	assert.False(t, apiCalled, "API should not be called on cache hit")
+}
+
+func TestWorkspaceSlug_PopulatesCache(t *testing.T) {
+	srv := newFakeServer(t, organizationsBody(`{"data":[{"slug":"abc12345","name":"My Workspace"}]}`))
+	c := cache.New()
+	r := New(newAPIClient(t, srv.URL), c)
+
+	_, err := r.WorkspaceSlug(context.Background(), "My Workspace")
+	require.NoError(t, err)
+
+	slug, ok := c.LookupWorkspace("My Workspace")
+	assert.True(t, ok)
+	assert.Equal(t, "abc12345", slug)
+}
+
+func TestResolveWorkspace_NameMatch_ReturnsFull(t *testing.T) {
+	srv := newFakeServer(t, organizationsBody(`{"data":[{"slug":"abc12345","name":"My Workspace"}]}`))
+	r := New(newAPIClient(t, srv.URL), nil)
+
+	org, complete, err := r.ResolveWorkspace(context.Background(), "My Workspace")
+	require.NoError(t, err)
+	assert.True(t, complete, "expected complete=true on name match")
+	assert.Equal(t, "abc12345", org.Slug)
+	assert.Equal(t, "My Workspace", org.Name)
+}
+
+func TestResolveWorkspace_NoMatch_Passthrough(t *testing.T) {
+	srv := newFakeServer(t, organizationsBody(`{"data":[]}`))
+	r := New(newAPIClient(t, srv.URL), nil)
+
+	org, complete, err := r.ResolveWorkspace(context.Background(), "abc12345")
+	require.NoError(t, err)
+	assert.False(t, complete, "expected complete=false on passthrough")
+	assert.Equal(t, "abc12345", org.Slug)
+}
+
+func TestResolveWorkspace_CacheHit_NotFetched(t *testing.T) {
+	var apiCalled bool
+	srv := newFakeServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		apiCalled = true
+		_, _ = w.Write([]byte(`{"data":[]}`))
+	})
+	c := cache.New()
+	c.SetWorkspace("My Workspace", "cached-slug")
+	r := New(newAPIClient(t, srv.URL), c)
+
+	org, complete, err := r.ResolveWorkspace(context.Background(), "My Workspace")
+	require.NoError(t, err)
+	assert.False(t, complete, "expected complete=false on cache hit (full data not cached)")
+	assert.Equal(t, "cached-slug", org.Slug)
+	assert.False(t, apiCalled, "API should not be called on cache hit")
+}
+
+func TestResolveWorkspace_AmbiguousError(t *testing.T) {
+	srv := newFakeServer(t, organizationsBody(`{"data":[
+		{"slug":"slug-1","name":"My Workspace"},
+		{"slug":"slug-2","name":"My Workspace"}
+	]}`))
+	r := New(newAPIClient(t, srv.URL), nil)
+
+	_, _, err := r.ResolveWorkspace(context.Background(), "My Workspace")
+	require.Error(t, err)
+}

--- a/output/output.go
+++ b/output/output.go
@@ -34,6 +34,13 @@ func SetDefault(format string) {
 	defaultFormat = format
 }
 
+// Default returns the format set by SetDefault. Commands that render through
+// their own logger instead of ConfigureOutputFormat need it to honour the
+// root-persistent --output flag.
+func Default() string {
+	return defaultFormat
+}
+
 // ParseFormat validates a format string without mutating any global state,
 // accepting "human" as an alias for FormatRaw.
 func ParseFormat(s string) (string, error) {


### PR DESCRIPTION
Fixed some inconsistencies (flag and output handling mainly) found during review against v2 and bitrise-cli.

Also updated the breaking changes doc, removed obsolete and technical content.